### PR TITLE
fix typo get_authenticated_username -> get_authenticated_user

### DIFF
--- a/oauthenticator/google.py
+++ b/oauthenticator/google.py
@@ -53,7 +53,7 @@ class GoogleOAuthHandler(OAuthCallbackHandler, GoogleOAuth2Mixin):
 
         # "Cannot redirect after headers have been written" ?
         #OAuthCallbackHandler.get(self)
-        username = yield self.authenticator.get_authenticated_username(self, None)
+        username = yield self.authenticator.get_authenticated_user(self, None)
         self.log.info('google: username: "%s"', username)
         if username:
             user = self.user_from_username(username)


### PR DESCRIPTION
Greetings!

Closes #33.

It is a simple patch to fix an apparent typo: `get_authenticated_username` -> `get_authenticated_user`.

I can report that this fixes the issue in my own local testing.

What's a good way to add a regression test for this?  Can we exercise this code without having to integrate against Google services?
