### PR TITLE
Fix GitLab CamelCase

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,9 +56,9 @@ should add the following to your `jupyterhub_config.py`:
 
 You can use your own Github Enterprise instance by setting the `GITHUB_HOST` environment
 flag.
-## Gitlab Setup
+## GitLab Setup
 
-First, you'll need to create a [Gitlab OAuth
+First, you'll need to create a [GitLab OAuth
 application](http://docs.gitlab.com/ce/integration/oauth_provider.html). Make sure the
 callback URL is:
 
@@ -69,23 +69,23 @@ Where `[your-host]` is where your server will be running. Such as
 
 Then, add the following to your `jupyterhub_config.py` file:
 
-    c.JupyterHub.authenticator_class = 'oauthenticator.gitlab.GitlabOAuthenticator'
+    c.JupyterHub.authenticator_class = 'oauthenticator.gitlab.GitLabOAuthenticator'
 
-(you can also use `LocalGitlabOAuthenticator` to handle both local and Gitlab
+(you can also use `LocalGitLabOAuthenticator` to handle both local and GitLab
 auth).
 
 You will additionally need to specify the OAuth callback URL, the client ID, and
 the client secret (you should have gotten these when you created your OAuth app
-on Gitlab). For example, if these values are in the environment variables
+on GitLab). For example, if these values are in the environment variables
 `$OAUTH_CALLBACK_URL`, `$GITLAB_CLIENT_ID` and `$GITLAB_CLIENT_SECRET`, you
 should add the following to your `jupyterhub_config.py`:
 ```
-    c.GitlabOAuthenticator.oauth_callback_url = os.environ['OAUTH_CALLBACK_URL']
-    c.GitlabOAuthenticator.client_id = os.environ['GITLAB_CLIENT_ID']
-    c.GitlabOAuthenticator.client_secret = os.environ['GITLAB_CLIENT_SECRET']
+    c.GitLabOAuthenticator.oauth_callback_url = os.environ['OAUTH_CALLBACK_URL']
+    c.GitLabOAuthenticator.client_id = os.environ['GITLAB_CLIENT_ID']
+    c.GitLabOAuthenticator.client_secret = os.environ['GITLAB_CLIENT_SECRET']
 ```
 
-You can use your own Gitlab CE/EE instance by setting the `GITLAB_HOST` environment
+You can use your own GitLab CE/EE instance by setting the `GITLAB_HOST` environment
 flag.
 ## Google Setup
 

--- a/oauthenticator/gitlab.py
+++ b/oauthenticator/gitlab.py
@@ -1,7 +1,7 @@
 """
-Custom Authenticator to use Gitlab OAuth with JupyterHub
+Custom Authenticator to use GitLab OAuth with JupyterHub
 
-Modified for Gitlab by Laszlo Dobos (@dobos)
+Modified for GitLab by Laszlo Dobos (@dobos)
 based on the GitHub plugin by Kyle Kelley (@rgbkrk) 
 """
 
@@ -24,22 +24,22 @@ from .oauth2 import OAuthLoginHandler, OAuthenticator
 GITLAB_HOST = os.environ.get('GITLAB_HOST') or 'https://gitlab.com'
 GITLAB_API = '%s/api/v3/user' % GITLAB_HOST
 
-class GitlabMixin(OAuth2Mixin):
+class GitLabMixin(OAuth2Mixin):
     _OAUTH_AUTHORIZE_URL = "%s/oauth/authorize" % GITLAB_HOST
     _OAUTH_ACCESS_TOKEN_URL = "%s/oauth/access_token" % GITLAB_HOST
 
 
-class GitlabLoginHandler(OAuthLoginHandler, GitlabMixin):
+class GitLabLoginHandler(OAuthLoginHandler, GitLabMixin):
     pass
 
 
-class GitlabOAuthenticator(OAuthenticator):
+class GitLabOAuthenticator(OAuthenticator):
     
-    login_service = "Gitlab"
+    login_service = "GitLab"
         
     client_id_env = 'GITLAB_CLIENT_ID'
     client_secret_env = 'GITLAB_CLIENT_SECRET'
-    login_handler = GitlabLoginHandler
+    login_handler = GitLabLoginHandler
     
     @gen.coroutine
     def authenticate(self, handler, data=None):
@@ -49,11 +49,11 @@ class GitlabOAuthenticator(OAuthenticator):
         # TODO: Configure the curl_httpclient for tornado
         http_client = AsyncHTTPClient()
         
-        # Exchange the OAuth code for a Gitlab Access Token
+        # Exchange the OAuth code for a GitLab Access Token
         #
         # See: https://github.com/gitlabhq/gitlabhq/blob/master/doc/api/oauth2.md
         
-        # Gitlab specifies a POST request yet requires URL parameters
+        # GitLab specifies a POST request yet requires URL parameters
         params = dict(
             client_id=self.client_id,
             client_secret=self.client_secret,
@@ -92,7 +92,7 @@ class GitlabOAuthenticator(OAuthenticator):
         return resp_json["username"]
 
 
-class LocalGitlabOAuthenticator(LocalAuthenticator, GitlabOAuthenticator):
+class LocalGitLabOAuthenticator(LocalAuthenticator, GitLabOAuthenticator):
 
     """A version that mixes in local system user creation"""
     pass


### PR DESCRIPTION
it's two words, not one.

cc @dobos and @vilhelmen who might be using this from master.