### PR TITLE
Fix for second header argument in BitbucketOAuthentication.check_whitelist

### DIFF
--- a/oauthenticator/bitbucket.py
+++ b/oauthenticator/bitbucket.py
@@ -41,7 +41,7 @@ class BitbucketOAuthenticator(OAuthenticator):
 
     headers = {"Accept": "application/json",
                "User-Agent": "JupyterHub",
-               "Authorization": "Bearer {}".format(access_token)
+               "Authorization": "Bearer {}"
                }
 
     @gen.coroutine
@@ -78,6 +78,8 @@ class BitbucketOAuthenticator(OAuthenticator):
         resp_json = json.loads(resp.body.decode('utf8', 'replace'))
 
         access_token = resp_json['access_token']
+
+        self.headers["Authorization"] = self.headers["Authorization"].format(access_token)
 
         # Determine who the logged in user is
         req = HTTPRequest("https://api.bitbucket.org/2.0/user",

--- a/oauthenticator/bitbucket.py
+++ b/oauthenticator/bitbucket.py
@@ -39,6 +39,11 @@ class BitbucketOAuthenticator(OAuthenticator):
         help="Automatically whitelist members of selected teams",
     )
 
+    headers = {"Accept": "application/json",
+               "User-Agent": "JupyterHub",
+               "Authorization": "Bearer {}".format(access_token)
+               }
+
     @gen.coroutine
     def authenticate(self, handler, data=None):
         code = handler.get_argument("code", False)
@@ -75,20 +80,17 @@ class BitbucketOAuthenticator(OAuthenticator):
         access_token = resp_json['access_token']
 
         # Determine who the logged in user is
-        headers = {"Accept": "application/json",
-                   "User-Agent": "JupyterHub",
-                   "Authorization": "Bearer {}".format(access_token)
-                   }
         req = HTTPRequest("https://api.bitbucket.org/2.0/user",
                           method="GET",
-                          headers=headers
+                          headers=self.headers
                           )
         resp = yield http_client.fetch(req)
         resp_json = json.loads(resp.body.decode('utf8', 'replace'))
 
         return resp_json["username"]
 
-    def check_whitelist(self, username, headers):
+    def check_whitelist(self, username, headers=None):
+        headers = headers if headers else self.headers
         if self.team_whitelist:
             return self._check_group_whitelist(username, headers)
         else:
@@ -99,11 +101,12 @@ class BitbucketOAuthenticator(OAuthenticator):
         return (not self.whitelist) or (user in self.whitelist)
 
     @gen.coroutine
-    def _check_group_whitelist(self, username, headers):
+    def _check_group_whitelist(self, username, headers=None):
         http_client = AsyncHTTPClient()
 
         # We verify the team membership by calling teams endpoint.
         # Re-use the headers, change the request.
+        headers = headers if headers else self.headers
         next_page = url_concat("https://api.bitbucket.org/2.0/teams",
                                {'role': 'member'})
         user_teams = set()


### PR DESCRIPTION
This pull request addresses issue #49.

The fix:
1. moves the definition of headers from the authenticate method to the class level
2. sets the access token in the headers["Authorization"] field appropriately when obtained in authenticate
3. makes the headers argument in check_whitelist and _check_group_whitelist as a named argument with default of None
4. sets the headers variable in these methods to self.headers except when a headers argument is passed to them

