### PR TITLE
Add support for OpenShift OAuth

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,3 +103,51 @@ For a Google Apps domain you can set:
     c.GoogleOAuthenticator.login_service = 'My College'
 ```
 
+## OpenShift Setup
+
+In case you have an OpenShift deployment with OAuth properly configured (see the
+following sections for a quick reference), you should set the client ID and
+secret by the environment variables `OAUTH_CLIENT_ID`, `OAUTH_CLIENT_SECRET` and
+`OAUTH_CALLBACK_URL`. The OpenShift API URL can be specified by setting the
+variable `OPENSHIFT_URL`.
+
+The `OAUTH_CALLBACK_URL` should match `http[s]://[your-app-route]/hub/oauth_callback`
+
+
+### Global OAuth (admin)
+
+As a cluster admin, you can create a global [OAuth client](https://docs.openshift.org/latest/architecture/additional_concepts/authentication.html#oauth-clients)
+in your OpenShift cluster creating a new OAuthClient object using the API:
+```
+$ oc create -f - <<EOF
+apiVersion: v1
+kind: OAuthClient
+metadata:
+  name: <OAUTH_CLIENT_ID>
+redirectURIs:
+- <OUAUTH_CALLBACK_URL>
+secret: <OAUTH_SECRET>
+EOF
+```
+
+### Service Accounts as OAuth Clients
+
+As a project member, you can use the [Service Accounts as OAuth Clients](https://docs.openshift.org/latest/architecture/additional_concepts/authentication.html#service-accounts-as-oauth-clients)
+scenario. This gives you the possibility of defining clients associated with
+service accounts. You just need to create the service account with the
+proper annotations:
+```
+$ oc create -f - <<EOF
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: <name>
+  annotations:
+    serviceaccounts.openshift.io/oauth-redirecturi.1: '<OUAUTH_CALLBACK_URL>'
+EOF
+```
+
+In this scenario your `OAUTH_CLIENT_ID` will be `system:serviceaccount:<serviceaccount_namespace>:<serviceaccount_name>`,
+the OAUTH_CLIENT_SECRET is the API token of the service account (`oc sa get-token <serviceaccount_name>`)
+and the OAUTH_CALLBACK_URL is the value of the annotation `serviceaccounts.openshift.io/oauth-redirecturi.1`.
+More details can be found in the upstream documentation.

--- a/oauthenticator/openshift.py
+++ b/oauthenticator/openshift.py
@@ -1,0 +1,94 @@
+"""
+Custom Authenticator to use OpenShift OAuth with JupyterHub.
+
+Derived from the GitHub OAuth authenticator.
+"""
+
+
+import json
+import os
+
+from tornado.auth import OAuth2Mixin
+from tornado import gen, web
+
+from tornado.httputil import url_concat
+from tornado.httpclient import HTTPRequest, AsyncHTTPClient
+
+from jupyterhub.auth import LocalAuthenticator
+
+from .oauth2 import OAuthLoginHandler, OAuthenticator
+
+OPENSHIFT_URL = os.environ.get('OPENSHIFT_URL') or 'https://localhost:8443'
+
+class OpenShiftMixin(OAuth2Mixin):
+    _OAUTH_AUTHORIZE_URL = "%s/oauth/authorize" % OPENSHIFT_URL
+    _OAUTH_ACCESS_TOKEN_URL = "%s/oauth/token" % OPENSHIFT_URL
+
+
+class OpenShiftLoginHandler(OAuthLoginHandler, OpenShiftMixin):
+    # This allows `Service Accounts as OAuth Clients` scenario
+    # https://docs.openshift.org/latest/architecture/additional_concepts/authentication.html#service-accounts-as-oauth-clients
+    scope=['user:info']
+
+
+class OpenShiftOAuthenticator(OAuthenticator):
+
+    login_service = "OpenShift"
+
+    login_handler = OpenShiftLoginHandler
+
+    @gen.coroutine
+    def authenticate(self, handler, data=None):
+        code = handler.get_argument("code", False)
+        if not code:
+            raise web.HTTPError(400, "oauth callback made without a token")
+
+        # TODO: Configure the curl_httpclient for tornado
+        http_client = AsyncHTTPClient()
+
+        # Exchange the OAuth code for a OpenShift Access Token
+        #
+        # See: https://docs.openshift.org/latest/architecture/additional_concepts/authentication.html#api-authentication
+
+        params = dict(
+            client_id=self.client_id,
+            client_secret=self.client_secret,
+            grant_type="authorization_code",
+            code=code
+        )
+
+        url = url_concat("%s/oauth/token" % OPENSHIFT_URL, params)
+
+        req = HTTPRequest(url,
+                          method="POST",
+                          validate_cert=False,
+                          headers={"Accept": "application/json"},
+                          body='' # Body is required for a POST...
+                          )
+
+        resp = yield http_client.fetch(req)
+
+        resp_json = json.loads(resp.body.decode('utf8', 'replace'))
+
+        access_token = resp_json['access_token']
+
+        # Determine who the logged in user is
+        headers={"Accept": "application/json",
+                 "User-Agent": "JupyterHub",
+                 "Authorization": "Bearer {}".format(access_token)
+        }
+
+        req = HTTPRequest("%s/oapi/v1/users/~" % OPENSHIFT_URL,
+                          method="GET",
+                          validate_cert=False,
+                          headers=headers)
+
+        resp = yield http_client.fetch(req)
+        resp_json = json.loads(resp.body.decode('utf8', 'replace'))
+
+        return resp_json["metadata"]["name"]
+
+class LocalOpenShiftOAuthenticator(LocalAuthenticator, OpenShiftOAuthenticator):
+
+    """A version that mixes in local system user creation"""
+    pass


### PR DESCRIPTION
I'm in the process of deploying JupyterHub in an OpenShift environment using `oauthenticator` and `kubespawner`.

This patch adds support for OpenShift OAuth logic.

It's a working implementation following the _classic_ GitHub module structure.