### PR TITLE
Group/Organization whitelisting

### DIFF
--- a/oauthenticator/bitbucket.py
+++ b/oauthenticator/bitbucket.py
@@ -116,16 +116,18 @@ class BitbucketOAuthenticator(OAuthenticator):
         # We verify the team membership by calling teams endpoint.
         next_page = url_concat("https://api.bitbucket.org/2.0/teams",
                                {'role': 'member'})
-        user_teams = set()
         while next_page:
             req = HTTPRequest(next_page, method="GET", headers=headers)
             resp = yield http_client.fetch(req)
             resp_json = json.loads(resp.body.decode('utf8', 'replace'))
             next_page = resp_json.get('next', None)
 
-            user_teams |= \
+            user_teams = \
                 set([entry["username"] for entry in resp_json["values"]])
-        return len(self.bitbucket_team_whitelist & user_teams) > 0
+            # check if any of the organizations seen thus far are in whitelist
+            if len(self.bitbucket_team_whitelist & user_teams) > 0:
+                return True
+        return False
 
 
 class LocalBitbucketOAuthenticator(LocalAuthenticator,

--- a/oauthenticator/bitbucket.py
+++ b/oauthenticator/bitbucket.py
@@ -46,6 +46,13 @@ class BitbucketOAuthenticator(OAuthenticator):
         help="Automatically whitelist members of selected teams",
     )
 
+    bitbucket_team_whitelist = team_whitelist
+
+
+    headers = {"Accept": "application/json",
+               "User-Agent": "JupyterHub",
+               "Authorization": "Bearer {}"
+               }
 
     @gen.coroutine
     def authenticate(self, handler, data=None):
@@ -95,7 +102,7 @@ class BitbucketOAuthenticator(OAuthenticator):
 
         # Check if user is a member of any whitelisted teams.
         # This check is performed here, as the check requires `access_token`.
-        if self.team_whitelist:
+        if self.bitbucket_team_whitelist:
             user_in_team = yield self._check_team_whitelist(username, access_token)
             return username if user_in_team else None
         else:  # no team whitelisting
@@ -118,7 +125,7 @@ class BitbucketOAuthenticator(OAuthenticator):
 
             user_teams |= \
                 set([entry["username"] for entry in resp_json["values"]])
-        return len(self.team_whitelist & user_teams) > 0
+        return len(self.bitbucket_team_whitelist & user_teams) > 0
 
 
 class LocalBitbucketOAuthenticator(LocalAuthenticator,

--- a/oauthenticator/github.py
+++ b/oauthenticator/github.py
@@ -25,9 +25,9 @@ from .oauth2 import OAuthLoginHandler, OAuthenticator
 # Support github.com and github enterprise installations
 GITHUB_HOST = os.environ.get('GITHUB_HOST') or 'github.com'
 if GITHUB_HOST == 'github.com':
-    GITHUB_API = 'api.github.com/user'
+    GITHUB_API = 'api.github.com'
 else:
-    GITHUB_API = '%s/api/v3/user' % GITHUB_HOST
+    GITHUB_API = '%s/api/v3' % GITHUB_HOST
 
 
 def _api_headers(access_token):
@@ -118,7 +118,7 @@ class GitHubOAuthenticator(OAuthenticator):
         access_token = resp_json['access_token']
         
         # Determine who the logged in user is
-        req = HTTPRequest("https://%s" % GITHUB_API,
+        req = HTTPRequest("https://%s/user" % GITHUB_API,
                           method="GET",
                           headers=_api_headers(access_token)
                           )

--- a/oauthenticator/github.py
+++ b/oauthenticator/github.py
@@ -12,6 +12,7 @@ import re
 from tornado.auth import OAuth2Mixin
 from tornado import gen, web
 
+import requests
 from tornado.httputil import url_concat
 from tornado.httpclient import HTTPRequest, AsyncHTTPClient
 
@@ -42,11 +43,9 @@ def _get_next_page(response):
     link_header = response.headers.get('Link')
     if not link_header:
         return
-    # parse the Link header; is this regex general enough?
-    link_regex = r',? *< *(.*?) *> *; *rel="(.*?)"'
-    for link_url, link_type in re.findall(link_regex, link_header):
-        if link_type == 'next':
-            return link_url
+    for link in requests.utils.parse_header_links(link_header):
+        if link.get('rel') == 'next':
+            return link['url']
     # if no "next" page, this is the last one
     return None
 

--- a/oauthenticator/github.py
+++ b/oauthenticator/github.py
@@ -143,15 +143,16 @@ class GitHubOAuthenticator(OAuthenticator):
         headers = _api_headers(access_token)
         # Get all the user's organizations
         next_page = "https://%s/orgs" % GITHUB_API
-        user_orgs = set()
         while next_page:
             req = HTTPRequest(next_page, method="GET", headers=headers)
             resp = yield http_client.fetch(req)
             resp_json = json.loads(resp.body.decode('utf8', 'replace'))
             next_page = _get_next_page(resp)
-            user_orgs |= set(entry["login"] for entry in resp_json)
-        # check if any of the organizations are in the whitelist
-        return len(self.github_organization_whitelist & user_orgs) > 0
+            user_orgs = set(entry["login"] for entry in resp_json)
+            # check if any of the organizations seen thus far are in whitelist
+            if len(self.github_organization_whitelist & user_orgs) > 0:
+                return True
+        return False
 
 
 

--- a/oauthenticator/gitlab.py
+++ b/oauthenticator/gitlab.py
@@ -143,7 +143,7 @@ class GitLabOAuthenticator(OAuthenticator):
             # we check if we are a member of each group in the whitelist
             for group in self.gitlab_group_whitelist:
                 group_id = _get_group_id(group, headers)
-                 url = "%s/groups/%d/members/%d" % (GITLAB_API, group_id, user_id)
+                url = "%s/groups/%d/members/%d" % (GITLAB_API, group_id, user_id)
                 req = HTTPRequest(url, method="GET", headers=headers)
                 resp = yield http_client.fetch(req)
                 if resp.code == 200:

--- a/oauthenticator/gitlab.py
+++ b/oauthenticator/gitlab.py
@@ -144,7 +144,7 @@ class GitLabOAuthenticator(OAuthenticator):
             for group in map(url_escape, self.gitlab_group_whitelist):
                 url = "%s/groups/%s/members/%d" % (GITLAB_API, group, user_id)
                 req = HTTPRequest(url, method="GET", headers=headers)
-                resp = yield http_client.fetch(req)
+                resp = yield http_client.fetch(req, raise_error=False)
                 if resp.code == 200:
                     return True  # user _is_ in group
         else:

--- a/oauthenticator/gitlab.py
+++ b/oauthenticator/gitlab.py
@@ -14,6 +14,7 @@ from tornado.auth import OAuth2Mixin
 from tornado import gen, web
 
 import requests
+from tornado.escape import url_escape
 from tornado.httputil import url_concat
 from tornado.httpclient import HTTPRequest, AsyncHTTPClient
 
@@ -140,9 +141,8 @@ class GitLabOAuthenticator(OAuthenticator):
         if is_admin:
             # For admins, /groups returns *all* groups. As a workaround
             # we check if we are a member of each group in the whitelist
-            for group in self.gitlab_group_whitelist:
-                group_id = _get_group_id(group, headers)
-                url = "%s/groups/%d/members/%d" % (GITLAB_API, group_id, user_id)
+            for group in map(url_escape, self.gitlab_group_whitelist):
+                url = "%s/groups/%s/members/%d" % (GITLAB_API, group, user_id)
                 req = HTTPRequest(url, method="GET", headers=headers)
                 resp = yield http_client.fetch(req)
                 if resp.code == 200:

--- a/oauthenticator/gitlab.py
+++ b/oauthenticator/gitlab.py
@@ -153,15 +153,16 @@ class GitLabOAuthenticator(OAuthenticator):
             # and check if any of these are in the whitelisted groups
             next_page = url_concat("%s/groups" % GITLAB_API,
                                    dict(all_available=True))
-            user_groups = set()
             while next_page:
                 req = HTTPRequest(next_page, method="GET", headers=headers)
                 resp = yield http_client.fetch(req)
                 resp_json = json.loads(resp.body.decode('utf8', 'replace'))
                 next_page = _get_next_page(resp)
-                user_groups |= set(entry["path"] for entry in resp_json)
-            # check if any of the organizations are in the whitelist
-            return len(self.gitlab_group_whitelist & user_orgs) > 0
+                user_groups = set(entry["path"] for entry in resp_json)
+                # check if any of the organizations seen thus far are in whitelist
+                if len(self.gitlab_group_whitelist & user_groups) > 0:
+                    return True
+            return False
 
 
 

--- a/oauthenticator/gitlab.py
+++ b/oauthenticator/gitlab.py
@@ -13,6 +13,7 @@ import sys
 from tornado.auth import OAuth2Mixin
 from tornado import gen, web
 
+import requests
 from tornado.httputil import url_concat
 from tornado.httpclient import HTTPRequest, AsyncHTTPClient
 
@@ -40,11 +41,9 @@ def _get_next_page(response):
     link_header = response.headers.get('Link')
     if not link_header:
         return
-    # parse the Link header; is this regex general enough?
-    link_regex = r',? *< *(.*?) *> *; *rel="(.*?)"'
-    for link_url, link_type in re.findall(link_regex, link_header):
-        if link_type == 'next':
-            return link_url
+    for link in requests.utils.parse_header_links(link_header):
+        if link.get('rel') == 'next':
+            return link['url']
     # if no "next" page, this is the last one
     return None
 

--- a/oauthenticator/tests/test_bitbucket.py
+++ b/oauthenticator/tests/test_bitbucket.py
@@ -41,7 +41,7 @@ def test_no_code(bitbucket_client):
 def test_team_whitelist(bitbucket_client):
     client = bitbucket_client
     authenticator = BitbucketOAuthenticator()
-    authenticator.team_whitelist = ['blue']
+    authenticator.bitbucket_team_whitelist = ['blue']
 
     teams = {
         'red': ['grif', 'simmons', 'donut', 'sarge', 'lopez'],
@@ -80,7 +80,3 @@ def test_team_whitelist(bitbucket_client):
     handler = client.handler_for_user(user_model('donut'))
     name = yield authenticator.authenticate(handler)
     assert name == 'donut'
-
-
-
-    

--- a/oauthenticator/tests/test_github.py
+++ b/oauthenticator/tests/test_github.py
@@ -1,4 +1,12 @@
+import re
+import functools
+import json
+from io import BytesIO
+
 from pytest import fixture, mark
+from urllib.parse import urlparse, parse_qs
+from tornado.httpclient import HTTPRequest, HTTPResponse
+from tornado.httputil import HTTPHeaders
 
 from ..github import GitHubOAuthenticator
 
@@ -33,3 +41,84 @@ def test_github(github_client):
 @mark.gen_test
 def test_no_code(github_client):
     yield no_code_test(GitHubOAuthenticator())
+
+
+def make_link_header(urlinfo, page):
+    return {'Link': '<{}://{}{}?page={}>;rel="next"'
+                    .format(urlinfo.scheme, urlinfo.netloc, urlinfo.path, page)}
+
+
+@mark.gen_test
+def test_org_whitelist(github_client):
+    client = github_client
+    authenticator = GitHubOAuthenticator()
+
+    ## Mock Github API
+
+    teams = {
+        'red': ['grif', 'simmons', 'donut', 'sarge', 'lopez'],
+        'blue': ['tucker', 'caboose', 'burns', 'sheila', 'texas'],
+    }
+
+    member_regex = re.compile(r'/orgs/(.*)/members')
+
+    def team_members(paginate, request):
+        urlinfo = urlparse(request.url)
+        team = member_regex.match(urlinfo.path).group(1)
+
+        if team not in teams:
+            return HTTPResponse(400, request)
+
+        if not paginate:
+            return [user_model(m) for m in teams[team]]
+        else:
+            page = parse_qs(urlinfo.query).get('page', ['1'])
+            page = int(page[0])
+            return team_members_paginated(
+                team, page, urlinfo, functools.partial(HTTPResponse, request))
+
+    def team_members_paginated(team, page, urlinfo, response):
+        if page < len(teams[team]):
+            headers = make_link_header(urlinfo, page + 1)
+        elif page == len(teams[team]):
+            headers = {}
+        else:
+            return response(400)
+
+        headers.update({'Content-Type': 'application/json'})
+
+        ret = [user_model(teams[team][page - 1])]
+
+        return response(200,
+                        headers=HTTPHeaders(headers),
+                        buffer=BytesIO(json.dumps(ret).encode('utf-8')))
+
+    ## Perform tests
+
+    for paginate in (False, True):
+        client.hosts['api.github.com'].append(
+            (member_regex, functools.partial(team_members, paginate)),
+        )
+
+        authenticator.github_organization_whitelist = ['blue']
+
+        handler = client.handler_for_user(user_model('caboose'))
+        name = yield authenticator.authenticate(handler)
+        assert name == 'caboose'
+
+        handler = client.handler_for_user(user_model('donut'))
+        name = yield authenticator.authenticate(handler)
+        assert name is None
+
+        # reverse it, just to be safe
+        authenticator.github_organization_whitelist = ['red']
+
+        handler = client.handler_for_user(user_model('caboose'))
+        name = yield authenticator.authenticate(handler)
+        assert name is None
+
+        handler = client.handler_for_user(user_model('donut'))
+        name = yield authenticator.authenticate(handler)
+        assert name == 'donut'
+
+        client.hosts['api.github.com'].pop()

--- a/oauthenticator/tests/test_gitlab.py
+++ b/oauthenticator/tests/test_gitlab.py
@@ -1,3 +1,12 @@
+import re
+import json
+from io import BytesIO
+import functools
+import collections
+from urllib.parse import urlparse, parse_qs
+
+from tornado.httpclient import HTTPResponse
+from tornado.httputil import HTTPHeaders
 from pytest import fixture, mark
 
 from ..gitlab import GitLabOAuthenticator
@@ -5,10 +14,12 @@ from ..gitlab import GitLabOAuthenticator
 from .mocks import setup_oauth_mock, no_code_test
 
 
-def user_model(username):
+def user_model(username, id=1, is_admin=False):
     """Return a user model"""
     return {
         'username': username,
+        'id': id,
+        'is_admin': is_admin
     }
 
 @fixture
@@ -32,3 +43,109 @@ def test_gitlab(gitlab_client):
 @mark.gen_test
 def test_no_code(gitlab_client):
     yield no_code_test(GitLabOAuthenticator())
+
+
+def make_link_header(urlinfo, page):
+    return {'Link': '<{}://{}{}?page={}>;rel="next"'
+                    .format(urlinfo.scheme, urlinfo.netloc, urlinfo.path, page)}
+
+@mark.gen_test
+def test_group_whitelist(gitlab_client):
+    client = gitlab_client
+    authenticator = GitLabOAuthenticator()
+
+    ## set up fake Gitlab API
+
+    user_groups = collections.OrderedDict({
+        'grif': ['red', 'yellow'],
+        'simmons': ['red', 'yellow'],
+        'caboose': ['blue', 'yellow'],
+        'burns': ['blue', 'yellow'],
+    })
+
+    def user_model(username, is_admin=False):
+        return {
+            'username': username,
+            'id': list(user_groups.keys()).index(username) + 1,
+            'is_admin': is_admin
+        }
+
+
+    member_regex = re.compile(r'/api/v3/groups/(.*)/members/(.*)')
+    def is_member(request):
+        urlinfo = urlparse(request.url)
+        group, uid = member_regex.match(urlinfo.path).group(1, 2)
+        uname = list(user_groups.keys())[int(uid) - 1]
+        if group in user_groups[uname]:
+            return HTTPResponse(request, 200)
+        else:
+            return HTTPResponse(request, 404)
+
+    def groups(paginate, request):
+        urlinfo = urlparse(request.url)
+        _, token = request._headers.get('Authorization').split()
+        user = client.access_tokens[token]['username']
+        if not paginate:
+            return [{'path': group} for group in user_groups[user]]
+        else:
+            page = parse_qs(urlinfo.query).get('page', ['1'])
+            page = int(page[0])
+            return groups_paginated(user, page, urlinfo,
+                                    functools.partial(HTTPResponse, request))
+
+    def groups_paginated(user, page, urlinfo, response):
+        if page < len(user_groups[user]):
+            headers = make_link_header(urlinfo, page + 1)
+        elif page == len(user_groups[user]):
+            headers = {}
+        else:
+            return response(400)
+
+        headers.update({'Content-Type': 'application/json'})
+
+        ret = [{'path': user_groups[user][page - 1]}]
+
+        return response(200, headers=HTTPHeaders(headers),
+                        buffer=BytesIO(json.dumps(ret).encode('utf-8')))
+
+    client.hosts['gitlab.com'].append(
+        (member_regex, is_member)
+    )
+
+    ## actual tests
+
+    for paginate in (False, True):
+        client.hosts['gitlab.com'].append(
+            ('/api/v3/groups', functools.partial(groups, paginate))
+        )
+
+        authenticator.gitlab_group_whitelist = ['blue']
+
+        handler = client.handler_for_user(user_model('caboose'))
+        name = yield authenticator.authenticate(handler)
+        assert name == 'caboose'
+
+        handler = client.handler_for_user(user_model('burns', is_admin=True))
+        name = yield authenticator.authenticate(handler)
+        assert name == 'burns'
+
+        handler = client.handler_for_user(user_model('grif'))
+        name = yield authenticator.authenticate(handler)
+        assert name is None
+
+        handler = client.handler_for_user(user_model('simmons', is_admin=True))
+        name = yield authenticator.authenticate(handler)
+        assert name is None
+
+        # reverse it, just to be safe
+        authenticator.gitlab_group_whitelist = ['red']
+
+        handler = client.handler_for_user(user_model('caboose'))
+        name = yield authenticator.authenticate(handler)
+        assert name is None
+
+        handler = client.handler_for_user(user_model('grif'))
+        name = yield authenticator.authenticate(handler)
+        assert name == 'grif'
+
+        client.hosts['gitlab.com'].pop()


### PR DESCRIPTION
This adds Gitlab group whitelisting and Github organization whitelisting to the corresponding authenticators. Fixes #57.

As this contains nontrivial changes, I am marking this as work in progress (WIP) until @minrk has set up a mocking framework to test this.

If I should submit this as 2 (or 3) separate pull requests, feel free to close this and I will split everything up.

