### PR TITLE
wip: testing framework

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,0 +1,2 @@
+[report]
+omit = *test*

--- a/.flake8
+++ b/.flake8
@@ -1,4 +1,4 @@
 [flake8]
 select = F
-ignore = E,W,C
+ignore = E,W,C,F841
 exclude = __init__.py

--- a/.flake8
+++ b/.flake8
@@ -1,4 +1,4 @@
 [flake8]
 select = F
-ignore = E,W,C,F841
+ignore = E,W,C,F401,F841
 exclude = __init__.py

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,6 @@
 language: python
 sudo: false
+cache: pip
 python:
   - "nightly"
   - "3.6"

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,20 @@
 language: python
 sudo: false
 python:
-  - "3.4"
+  - "nightly"
+  - "3.6"
   - "3.5"
+  - "3.4"
 install:
-  - pip install -r requirements.txt flake8 .
+  - pip install -r test-requirements.txt .
 script:
-  - python -c 'import oauthenticator'
-  - flake8 oauthenticator
+  - |
+    if [[ "$TEST_LINT" = 1 ]]; then
+      flake8 oauthenticator
+    else
+      py.test --cov oauthenticator oauthenticator
+    fi
+matrix:
+  include:
+    python: "3.5"
+    env: TEST_LINT=1

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ python:
   - "3.4"
 install:
   - pip install --upgrade pip
-  - pip install -r test-requirements.txt .
+  - pip install --upgrade --pre -r test-requirements.txt .
   - pip freeze
 script:
   - |

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,9 @@ python:
   - "3.5"
   - "3.4"
 install:
+  - pip install --upgrade pip
   - pip install -r test-requirements.txt .
+  - pip freeze
 script:
   - |
     if [[ "$TEST_LINT" = 1 ]]; then

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,6 +14,9 @@ script:
     else
       py.test --cov oauthenticator oauthenticator
     fi
+after_success:
+  - codecov
+
 matrix:
   include:
     python: "3.5"

--- a/oauthenticator/auth0.py
+++ b/oauthenticator/auth0.py
@@ -70,7 +70,7 @@ class Auth0OAuthenticator(OAuthenticator):
             'client_id': self.client_id,
             'client_secret': self.client_secret,
             'code':code,
-            'redirect_uri': self.oauth_callback_url
+            'redirect_uri': self.get_callback_url(handler)
         }
         url = "https://%s.auth0.com/oauth/token" % AUTH0_SUBDOMAIN
 

--- a/oauthenticator/bitbucket.py
+++ b/oauthenticator/bitbucket.py
@@ -60,7 +60,7 @@ class BitbucketOAuthenticator(OAuthenticator):
             client_secret=self.client_secret,
             grant_type="authorization_code",
             code=code,
-            redirect_uri=self.oauth_callback_url
+            redirect_uri=self.get_callback_url(handler),
         )
 
         url = url_concat(

--- a/oauthenticator/cilogon.py
+++ b/oauthenticator/cilogon.py
@@ -142,7 +142,7 @@ class CILogonOAuthenticator(OAuthenticator):
     def get_oauth_token(self):
         """Get the temporary OAuth token"""
         uri = url_concat(ujoin(self.oauth_url, "initiate"), {
-            'oauth_callback': self.oauth_callback_url,
+            'oauth_callback': self.get_callback_url(handler),
             'certreq': self.certreq,
         })
         uri, _, _ = self.oauth_client.sign(uri)

--- a/oauthenticator/cilogon.py
+++ b/oauthenticator/cilogon.py
@@ -59,7 +59,7 @@ class CILogonHandler(BaseHandler):
 
     @gen.coroutine
     def get(self):
-        token = yield self.authenticator.get_oauth_token()
+        token = yield self.authenticator.get_oauth_token(self)
         self.redirect(url_concat(self.authenticator.authorization_url,
             {'oauth_token': token, 'cilogon_skin': self.authenticator.cilogon_skin}))
 
@@ -139,7 +139,7 @@ class CILogonOAuthenticator(OAuthenticator):
     client = Instance(AsyncHTTPClient, args=())
 
     @gen.coroutine
-    def get_oauth_token(self):
+    def get_oauth_token(self, handler):
         """Get the temporary OAuth token"""
         uri = url_concat(ujoin(self.oauth_url, "initiate"), {
             'oauth_callback': self.get_callback_url(handler),

--- a/oauthenticator/generic.py
+++ b/oauthenticator/generic.py
@@ -17,7 +17,7 @@ from jupyterhub.auth import LocalAuthenticator
 
 from traitlets import Unicode, Dict
 
-from .oauth2 import OAuthLoginHandler, OAuthenticator, guess_callback_uri
+from .oauth2 import OAuthLoginHandler, OAuthenticator
 
 
 class GenericEnvMixin(OAuth2Mixin):
@@ -70,13 +70,8 @@ class GenericOAuthenticator(OAuthenticator):
         # TODO: Configure the curl_httpclient for tornado
         http_client = AsyncHTTPClient()
 
-        guess_uri = guess_callback_uri(
-            handler.request.protocol,
-            handler.request.host,
-            handler.hub.server.base_url
-        )
         params = dict(
-            redirect_uri=self.oauth_callback_url or guess_uri,
+            redirect_uri=self.get_callback_url(handler),
             code=code,
             grant_type='authorization_code'
         )

--- a/oauthenticator/gitlab.py
+++ b/oauthenticator/gitlab.py
@@ -59,7 +59,7 @@ class GitLabOAuthenticator(OAuthenticator):
             client_secret=self.client_secret,
             code=code,
             grant_type="authorization_code",
-            redirect_uri=self.oauth_callback_url
+            redirect_uri=self.get_callback_url(handler),
         )
 
 

--- a/oauthenticator/gitlab.py
+++ b/oauthenticator/gitlab.py
@@ -68,8 +68,6 @@ class GitLabOAuthenticator(OAuthenticator):
         url = url_concat("%s/oauth/token" % GITLAB_HOST,
                          params)
 
-        print(url, file=sys.stderr)
-
         req = HTTPRequest(url,
                           method="POST",
                           headers={"Accept": "application/json"},

--- a/oauthenticator/google.py
+++ b/oauthenticator/google.py
@@ -31,28 +31,10 @@ class GoogleLoginHandler(OAuthLoginHandler, GoogleOAuth2Mixin):
             scope=['openid', 'email'],
             response_type='code')
 
-class GoogleOAuthHandler(OAuthCallbackHandler, GoogleOAuth2Mixin):
-    @gen.coroutine
-    def get(self):
-        self.settings['google_oauth'] = {
-            'key': self.authenticator.client_id,
-            'secret': self.authenticator.client_secret,
-            'scope': ['openid', 'email']
-        }
-        self.log.debug('google: settings: "%s"', str(self.settings['google_oauth']))
-        # FIXME: we should verify self.settings['google_oauth']['hd']
 
-        # "Cannot redirect after headers have been written" ?
-        #OAuthCallbackHandler.get(self)
-        username = yield self.authenticator.get_authenticated_user(self, None)
-        self.log.info('google: username: "%s"', username)
-        if username:
-            user = self.user_from_username(username)
-            self.set_login_cookie(user)
-            self.redirect(url_path_join(self.hub.server.base_url, 'home'))
-        else:
-            # todo: custom error
-            raise HTTPError(403)
+class GoogleOAuthHandler(OAuthCallbackHandler, GoogleOAuth2Mixin):
+    pass
+
 
 class GoogleOAuthenticator(OAuthenticator, GoogleOAuth2Mixin):
 
@@ -75,6 +57,11 @@ class GoogleOAuthenticator(OAuthenticator, GoogleOAuth2Mixin):
         code = handler.get_argument('code', False)
         if not code:
             raise HTTPError(400, "oauth callback made without a token")
+        handler.settings['google_oauth'] = {
+            'key': self.client_id,
+            'secret': self.client_secret,
+            'scope': ['openid', 'email']
+        }
         user = yield handler.get_authenticated_user(
             redirect_uri=self.get_callback_url(handler),
             code=code)

--- a/oauthenticator/tests/conftest.py
+++ b/oauthenticator/tests/conftest.py
@@ -1,0 +1,16 @@
+"""Py.Test fixtures"""
+
+from tornado.httpclient import AsyncHTTPClient
+from pytest import fixture
+
+from .mocks import MockAsyncHTTPClient
+
+@fixture
+def client(io_loop, request):
+    """Return mocked AsyncHTTPClient"""
+    before = AsyncHTTPClient.configured_class()
+    AsyncHTTPClient.configure(MockAsyncHTTPClient)
+    request.addfinalizer(lambda : AsyncHTTPClient.configure(before))
+    c = AsyncHTTPClient()
+    assert isinstance(c, MockAsyncHTTPClient)
+    return c

--- a/oauthenticator/tests/mocks.py
+++ b/oauthenticator/tests/mocks.py
@@ -1,0 +1,172 @@
+"""Mocking utilities for testing"""
+
+from io import BytesIO
+import json
+import re
+from unittest.mock import Mock
+from urllib.parse import urlparse, parse_qs
+import uuid
+
+from tornado.httpclient import HTTPResponse
+from tornado.log import app_log
+from tornado.simple_httpclient import SimpleAsyncHTTPClient
+from tornado import web
+
+RegExpType = type(re.compile('.'))
+
+
+class MockAsyncHTTPClient(SimpleAsyncHTTPClient):
+    """A mock AsyncHTTPClient that allows registering handlers for mocked requests
+    
+    Call .add_host to mock requests made to a given host.
+    
+    """
+    def initialize(self, *args, **kwargs):
+        super().initialize(*args, **kwargs)
+        self.hosts = {}
+
+    def add_host(self, host, paths):
+        """Add a host whose requests should be mocked.
+        
+        Args:
+            host (str): the host to mock (e.g. 'api.github.com')
+            paths (list(str|regex, callable)): a list of paths (or regexps for paths)
+                and callables to be called for those paths.
+                The mock handlers will receive the request as their only argument.
+        
+        Mock handlers can return:
+            - None
+            - int (empty response with this status code)
+            - str, bytes for raw response content (status=200)
+            - list, dict for JSON response (status=200)
+            - HTTPResponse (passed unmodified)
+
+        Example::
+        
+            client.add_host('api.github.com', [
+                ('/user': lambda request: {'login': 'name'})
+            ])
+        """
+        self.hosts[host] = paths
+
+    def fetch_impl(self, request, response_callback):
+        urlinfo = urlparse(request.url)
+        host = urlinfo.hostname
+        if host not in self.hosts:
+            app_log.warning("Not mocking request to %s", request.url)
+            return super().fetch_impl(request, response_callback)
+        paths = self.hosts[host]
+        response = None
+        for path_spec, handler in paths:
+            if isinstance(path_spec, str):
+                if path_spec == urlinfo.path:
+                    response = handler(request)
+                    break
+            else:
+                if path_spec.match(urlinfo.path):
+                    response = handler(request)
+                    break
+
+        if response is None:
+            response = HTTPResponse(request=request, code=404)
+        elif isinstance(response, int):
+            response = HTTPResponse(request=request, code=response)
+        elif isinstance(response, bytes):
+            response = HTTPResponse(request=request, code=200,
+                buffer=BytesIO(response),
+            )
+        elif isinstance(response, str):
+            response = HTTPResponse(request=request, code=200,
+                buffer=BytesIO(response.encode('utf8')),
+            )
+        elif isinstance(response, (dict, list)):
+            response = HTTPResponse(request=request, code=200,
+                buffer=BytesIO(json.dumps(response).encode('utf8')),
+                headers={'Content-Type': 'application/json'},
+            )
+
+        response_callback(response)
+
+
+def setup_oauth_mock(client, host, access_token_path, user_path, token_type='Bearer'):
+    """setup the mock client for OAuth
+    
+    generates and registers two handlers common to OAuthenticators:
+    
+    - create the access token (POST access_token_path)
+    - get the user info (GET user_path)
+    
+    
+    and adds a method for creating a new mock handler to pass to .authenticate():
+    
+    client.handler_for_user(user)
+    
+    where 
+    
+    Args:
+    
+        host (str): the host to mock (e.g. api.github.com)
+        access_token_path (str): The path for the access token request (e.g. /access_token)
+        user_path (str): The path for requesting  (e.g. /user)
+        token_type (str): the token_type field for the provider
+    """
+
+    oauth_codes = {}
+    access_tokens = {}
+
+    def access_token(request):
+        """Handler for access token endpoint
+
+        Checks code and allocates a new token.
+        Replies with JSON model for the token.
+        """
+        assert request.method == 'POST'
+        query = parse_qs(urlparse(request.url).query)
+        if 'code' not in query:
+            return HTTPResponse(request=request, code=400)
+        code = query['code'][0]
+        if code not in oauth_codes:
+            return HTTPResponse(request=request, code=403)
+
+        # consume code, allocate token
+        token = uuid.uuid4().hex
+        user = oauth_codes.pop(code)
+        access_tokens[token] = user
+        return {
+            'access_token': token,
+            'token_type': token_type,
+        }
+
+    def get_user(request):
+        assert request.method == 'GET'
+        auth_header = request.headers.get('Authorization')
+        if not auth_header:
+            return HTTPResponse(request=request, code=403)
+        token = auth_header.split(None, 1)[1]
+        if token not in access_tokens:
+            return HTTPResponse(request=request, code=403)
+        return access_tokens.get(token)
+
+    if isinstance(host, str):
+        hosts = [host]
+    else:
+        hosts = host
+    for host in hosts:
+        client.add_host(host, [
+            ('/login/oauth/access_token', access_token),
+            ('/user', get_user),
+        ])
+    
+    def handler_for_user(user):
+        """Return a new mock RequestHandler
+        
+        user should be the JSONable model that will ultimately be returned
+        from the get_user request.
+        """
+        code = uuid.uuid4().hex
+        oauth_codes[code] = user
+        handler = Mock(spec=web.RequestHandler)
+        handler.get_argument = Mock(return_value=code)
+        return handler
+
+    client.handler_for_user = handler_for_user

--- a/oauthenticator/tests/mocks.py
+++ b/oauthenticator/tests/mocks.py
@@ -139,11 +139,15 @@ def setup_oauth_mock(client, host, access_token_path, user_path,
             else:
                 code = body['code']
         else:
-            query = parse_qs(urlparse(request.url).query)
+            query = urlparse(request.url).query
+            if not query:
+                query = request.body.decode('utf8')
+            query = parse_qs(query)
             if 'code' not in query:
-                app_log.warning()
                 return HTTPResponse(request=request, code=400,
-                    reason="No code in access token request: %s" % query,
+                    reason="No code in access token request: url=%s, body=%s" % (
+                        request.url, request.body,
+                    )
                 )
             code = query['code'][0]
         if code not in oauth_codes:

--- a/oauthenticator/tests/mocks.py
+++ b/oauthenticator/tests/mocks.py
@@ -117,8 +117,8 @@ def setup_oauth_mock(client, host, access_token_path, user_path,
         token_type (str): the token_type field for the provider
     """
 
-    oauth_codes = {}
-    access_tokens = {}
+    client.oauth_codes = oauth_codes = {}
+    client.access_tokens = access_tokens = {}
 
     def access_token(request):
         """Handler for access token endpoint

--- a/oauthenticator/tests/test_auth0.py
+++ b/oauthenticator/tests/test_auth0.py
@@ -1,0 +1,39 @@
+import os
+from unittest.mock import patch
+
+from pytest import fixture, mark
+
+with patch.dict(os.environ, AUTH0_SUBDOMAIN='jupyterhub-test'):
+    from ..auth0 import Auth0OAuthenticator, AUTH0_SUBDOMAIN
+
+from .mocks import setup_oauth_mock, no_code_test
+
+
+def user_model(username):
+    """Return a user model"""
+    return {
+        'email': username,
+    }
+
+@fixture
+def auth0_client(client):
+    setup_oauth_mock(client,
+        host='%s.auth0.com' % AUTH0_SUBDOMAIN,
+        access_token_path='/oauth/token',
+        user_path='/userinfo',
+        token_request_style='json',
+    )
+    return client
+
+
+@mark.gen_test
+def test_auth0(auth0_client):
+    authenticator = Auth0OAuthenticator()
+    handler = auth0_client.handler_for_user(user_model('kaylee@serenity.now'))
+    name = yield authenticator.authenticate(handler)
+    assert name == 'kaylee@serenity.now'
+
+
+@mark.gen_test
+def test_no_code(auth0_client):
+    yield no_code_test(Auth0OAuthenticator())

--- a/oauthenticator/tests/test_bitbucket.py
+++ b/oauthenticator/tests/test_bitbucket.py
@@ -1,0 +1,86 @@
+import os
+from unittest.mock import patch
+
+from pytest import fixture, mark
+
+from ..bitbucket import BitbucketOAuthenticator
+
+from .mocks import setup_oauth_mock, no_code_test
+
+
+def user_model(username):
+    """Return a user model"""
+    return {
+        'username': username,
+    }
+
+@fixture
+def bitbucket_client(client):
+    setup_oauth_mock(client,
+        host=['bitbucket.org', 'api.bitbucket.org'],
+        access_token_path='/site/oauth2/access_token',
+        user_path='/2.0/user',
+    )
+    return client
+
+
+@mark.gen_test
+def test_bitbucket(bitbucket_client):
+    authenticator = BitbucketOAuthenticator()
+    handler = bitbucket_client.handler_for_user(user_model('yorba'))
+    name = yield authenticator.authenticate(handler)
+    assert name == 'yorba'
+
+
+@mark.gen_test
+def test_no_code(bitbucket_client):
+    yield no_code_test(BitbucketOAuthenticator())
+
+
+@mark.gen_test
+def test_team_whitelist(bitbucket_client):
+    client = bitbucket_client
+    authenticator = BitbucketOAuthenticator()
+    authenticator.team_whitelist = ['blue']
+
+    teams = {
+        'red': ['grif', 'simmons', 'donut', 'sarge', 'lopez'],
+        'blue': ['tucker', 'caboose', 'burns', 'sheila', 'texas'],
+    }
+    def list_teams(request):
+        token = request.headers['Authorization'].split(None, 1)[1]
+        username = client.access_tokens[token]['username']
+        values = []
+        for team, members in teams.items():
+            if username in members:
+                values.append({'username': team})
+        return {
+            'values': values
+        }
+
+    client.hosts['api.bitbucket.org'].append(
+        ('/2.0/teams', list_teams)
+    )
+
+    handler = client.handler_for_user(user_model('caboose'))
+    name = yield authenticator.authenticate(handler)
+    assert name == 'caboose'
+
+    handler = client.handler_for_user(user_model('donut'))
+    name = yield authenticator.authenticate(handler)
+    assert name is None
+
+    # reverse it, just to be safe
+    authenticator.team_whitelist = ['red']
+
+    handler = client.handler_for_user(user_model('caboose'))
+    name = yield authenticator.authenticate(handler)
+    assert name is None
+
+    handler = client.handler_for_user(user_model('donut'))
+    name = yield authenticator.authenticate(handler)
+    assert name == 'donut'
+
+
+
+    

--- a/oauthenticator/tests/test_generic.py
+++ b/oauthenticator/tests/test_generic.py
@@ -1,0 +1,39 @@
+from pytest import fixture, mark
+
+from ..generic import GenericOAuthenticator
+
+from .mocks import setup_oauth_mock, no_code_test
+
+
+def user_model(username):
+    """Return a user model"""
+    return {
+        'username': username,
+    }
+
+def Authenticator():
+    return GenericOAuthenticator(
+        token_url='https://generic.horse/oauth/access_token',
+        userdata_url='https://generic.horse/oauth/userinfo'
+    )
+@fixture
+def generic_client(client):
+    setup_oauth_mock(client,
+        host='generic.horse',
+        access_token_path='/oauth/access_token',
+        user_path='/oauth/userinfo',
+    )
+    return client
+
+
+@mark.gen_test
+def test_generic(generic_client):
+    authenticator = Authenticator()
+    handler = generic_client.handler_for_user(user_model('wash'))
+    name = yield authenticator.authenticate(handler)
+    assert name == 'wash'
+
+
+@mark.gen_test
+def test_no_code(generic_client):
+    yield no_code_test(Authenticator())

--- a/oauthenticator/tests/test_github.py
+++ b/oauthenticator/tests/test_github.py
@@ -1,7 +1,4 @@
-from unittest.mock import Mock
-
-from pytest import fixture, mark, raises
-from tornado import web
+from pytest import fixture, mark
 
 from ..github import GitHubOAuthenticator
 

--- a/oauthenticator/tests/test_github.py
+++ b/oauthenticator/tests/test_github.py
@@ -5,7 +5,7 @@ from tornado import web
 
 from ..github import GitHubOAuthenticator
 
-from .mocks import setup_oauth_mock
+from .mocks import setup_oauth_mock, no_code_test
 
 
 def user_model(username):
@@ -34,10 +34,5 @@ def test_github(github_client):
 
 
 @mark.gen_test
-def test_github_no_code(github_client):
-    authenticator = GitHubOAuthenticator()
-    handler = Mock(spec=web.RequestHandler)
-    handler.get_argument = Mock(return_value=None)
-    with raises(web.HTTPError) as exc:
-        name = yield authenticator.authenticate(handler)
-    assert exc.value.status_code == 400
+def test_no_code(github_client):
+    yield no_code_test(GitHubOAuthenticator())

--- a/oauthenticator/tests/test_github.py
+++ b/oauthenticator/tests/test_github.py
@@ -1,0 +1,43 @@
+from unittest.mock import Mock
+
+from pytest import fixture, mark, raises
+from tornado import web
+
+from ..github import GitHubOAuthenticator
+
+from .mocks import setup_oauth_mock
+
+
+def user_model(username):
+    """Return a user model"""
+    return {
+        'login': username,
+    }
+
+@fixture
+def github_client(client):
+    setup_oauth_mock(client,
+        host=['github.com', 'api.github.com'],
+        access_token_path='/login/oauth/access_token',
+        user_path='/user',
+        token_type='token',
+    )
+    return client
+
+
+@mark.gen_test
+def test_github(github_client):
+    authenticator = GitHubOAuthenticator()
+    handler = github_client.handler_for_user(user_model('wash'))
+    name = yield authenticator.authenticate(handler)
+    assert name == 'wash'
+
+
+@mark.gen_test
+def test_github_no_code(github_client):
+    authenticator = GitHubOAuthenticator()
+    handler = Mock(spec=web.RequestHandler)
+    handler.get_argument = Mock(return_value=None)
+    with raises(web.HTTPError) as exc:
+        name = yield authenticator.authenticate(handler)
+    assert exc.value.status_code == 400

--- a/oauthenticator/tests/test_gitlab.py
+++ b/oauthenticator/tests/test_gitlab.py
@@ -1,0 +1,34 @@
+from pytest import fixture, mark
+
+from ..gitlab import GitLabOAuthenticator
+
+from .mocks import setup_oauth_mock, no_code_test
+
+
+def user_model(username):
+    """Return a user model"""
+    return {
+        'username': username,
+    }
+
+@fixture
+def gitlab_client(client):
+    setup_oauth_mock(client,
+        host='gitlab.com',
+        access_token_path='/oauth/token',
+        user_path='/api/v3/user',
+    )
+    return client
+
+
+@mark.gen_test
+def test_gitlab(gitlab_client):
+    authenticator = GitLabOAuthenticator()
+    handler = gitlab_client.handler_for_user(user_model('wash'))
+    name = yield authenticator.authenticate(handler)
+    assert name == 'wash'
+
+
+@mark.gen_test
+def test_no_code(gitlab_client):
+    yield no_code_test(GitLabOAuthenticator())

--- a/oauthenticator/tests/test_google.py
+++ b/oauthenticator/tests/test_google.py
@@ -1,0 +1,65 @@
+from unittest.mock import Mock
+
+from pytest import fixture, mark, raises
+from tornado.web import Application, HTTPError
+
+from ..google import GoogleOAuthenticator, GoogleOAuthHandler
+
+from .mocks import setup_oauth_mock, no_code_test
+
+def user_model(email):
+    """Return a user model"""
+    return {
+        'email': email,
+        'hd': email.split('@')[1],
+    }
+
+@fixture
+def google_client(client):
+    setup_oauth_mock(client,
+        host=['accounts.google.com', 'www.googleapis.com'],
+        access_token_path='/o/oauth2/token',
+        user_path='/oauth2/v1/userinfo',
+    )
+    original_handler_for_user = client.handler_for_user
+    # testing Google is harder because it invokes methods inherited from tornado
+    # classes
+    def handler_for_user(user):
+        mock_handler = original_handler_for_user(user)
+        mock_handler.request.connection = Mock()
+        real_handler = GoogleOAuthHandler(
+            application=Application(hub=mock_handler.hub),
+            request=mock_handler.request,
+        )
+        return real_handler
+    client.handler_for_user = handler_for_user
+    return client
+
+
+@mark.gen_test
+def test_google(google_client):
+    authenticator = GoogleOAuthenticator()
+    handler = google_client.handler_for_user(user_model('fake@email.com'))
+    name = yield authenticator.authenticate(handler)
+    assert name == 'fake@email.com'
+
+
+@mark.gen_test
+def test_no_code(google_client):
+    yield no_code_test(GoogleOAuthenticator())
+
+
+@mark.gen_test
+def test_hosted_domain(google_client):
+    authenticator = GoogleOAuthenticator(hosted_domain='email.com')
+    handler = google_client.handler_for_user(user_model('fake@email.com'))#, authenticator)
+    # result = yield handler.get()
+    name = yield authenticator.authenticate(handler)
+    assert name == 'fake'
+
+    handler = google_client.handler_for_user(user_model('notallowed@notemail.com'))
+    with raises(HTTPError) as exc:
+        name = yield authenticator.authenticate(handler)
+    assert exc.value.status_code == 403
+
+

--- a/oauthenticator/tests/test_openshift.py
+++ b/oauthenticator/tests/test_openshift.py
@@ -1,0 +1,36 @@
+from pytest import fixture, mark
+
+from ..openshift import OpenShiftOAuthenticator
+
+from .mocks import setup_oauth_mock, no_code_test
+
+
+def user_model(username):
+    """Return a user model"""
+    return {
+        'metadata': {
+            'name': username,
+        }
+    }
+
+@fixture
+def openshift_client(client):
+    setup_oauth_mock(client,
+        host=['localhost'],
+        access_token_path='/oauth/token',
+        user_path='/oapi/v1/users/~',
+    )
+    return client
+
+
+@mark.gen_test
+def test_openshift(openshift_client):
+    authenticator = OpenShiftOAuthenticator()
+    handler = openshift_client.handler_for_user(user_model('wash'))
+    name = yield authenticator.authenticate(handler)
+    assert name == 'wash'
+
+
+@mark.gen_test
+def test_no_code(openshift_client):
+    yield no_code_test(OpenShiftOAuthenticator())

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,5 +1,4 @@
 -r ./requirements.txt
--r ./cilogon-requirements.txt
 codecov
 flake8
 pytest >= 2.8

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,0 +1,7 @@
+-r ./requirements.txt
+-r ./cilogon-requirements.txt
+codecov
+flake8
+pytest >= 2.8
+pytest-cov
+pytest-tornado


### PR DESCRIPTION
Adds basic mocking utilities for exercising OAuthenticators.

- [x] utilities for mocking OAuth providers
- [x] auth0
- [x] bitbucket
- [ ] cilogon
- [x] generic
- [x] github
- [x] gitlab
- [x] google
- [ ] mediawiki
- [x] openshift

Since this mocks out the OAuth provider, the functionality of the OAuthenticator talking to the provider correctly is not tested except by assuming that the mocked responses are accurate.