### PR TITLE
test mediawiki

### DIFF
--- a/oauthenticator/mediawiki.py
+++ b/oauthenticator/mediawiki.py
@@ -97,7 +97,7 @@ class MWOAuthenticator(OAuthenticator):
 
         consumer_token = ConsumerToken(
             self.client_id,
-            self.client_secret
+            self.client_secret,
         )
 
         handshaker = Handshaker(
@@ -111,7 +111,9 @@ class MWOAuthenticator(OAuthenticator):
 
         identity = yield self.executor.submit(handshaker.identify, access_token)
         if identity and 'username' in identity:
-            return identity['username']
+            # this shouldn't be necessary anymore,
+            # but keep for backward-compatibility
+            return identity['username'].replace(' ', '_')
         else:
             self.log.error("No username found in %s", identity)
 

--- a/oauthenticator/tests/mocks.py
+++ b/oauthenticator/tests/mocks.py
@@ -2,6 +2,7 @@
 
 from io import BytesIO
 import json
+import os
 import re
 from unittest.mock import Mock
 from urllib.parse import urlparse, parse_qs
@@ -213,6 +214,32 @@ def setup_oauth_mock(client, host, access_token_path, user_path,
 
     client.handler_for_user = handler_for_user
 
+
+def mock_handler(Handler, uri='https://hub.example.com', method='GET', **settings):
+    """Instantiate a Handler in a mock application"""
+    application = web.Application(
+        hub=Mock(
+            server=Mock(
+                base_url='/hub/'
+            ),
+        ),
+        cookie_secret=os.urandom(32),
+        db=Mock(
+            rollback=Mock(return_value=None)
+        ),
+        **settings
+    )
+    request = HTTPServerRequest(
+        method=method,
+        uri=uri,
+        connection=Mock(),
+    )
+    handler = Handler(
+        application=application,
+        request=request,
+    )
+    handler._transforms = []
+    return handler
 
 @gen.coroutine
 def no_code_test(authenticator):

--- a/oauthenticator/tests/test_mediawiki.py
+++ b/oauthenticator/tests/test_mediawiki.py
@@ -1,0 +1,63 @@
+import json
+import re
+import time
+from unittest.mock import Mock
+
+from pytest import fixture, mark
+from tornado import web
+import requests_mock
+
+from ..mediawiki import MWOAuthenticator
+
+from .mocks import no_code_test
+import jwt
+
+MW_URL = 'https://meta.wikimedia.org/w/index.php'
+
+@fixture
+def mediawiki():
+    def post_token(request, context):
+        authorization_header = request.headers['Authorization'].decode('utf8')
+        request_nonce = re.search(r'oauth_nonce="(.*?)"',
+                                  authorization_header).group(1)
+        return jwt.encode({
+                        'username': 'wash',
+                        'aud': 'client_id',
+                        'iss': 'https://meta.wikimedia.org',
+                        'iat': time.time(),
+                        'nonce': request_nonce,
+                    }, 'client_secret')
+
+    with requests_mock.Mocker() as mock:
+        mock.post('/w/index.php?title=Special%3AOAuth%2Ftoken',
+            text='oauth_token=key&oauth_token_secret=secret')
+        mock.post('/w/index.php?title=Special%3AOAuth%2Fidentify',
+            content=post_token)
+        yield mock
+
+def new_authenticator():
+    return MWOAuthenticator(
+        client_id='client_id',
+        client_secret='client_secret',
+    )
+
+@mark.gen_test
+def test_mediawiki(mediawiki):
+    authenticator = new_authenticator()
+    handler = Mock(spec=web.RequestHandler,
+        get_secure_cookie=Mock(
+            return_value=json.dumps(
+                ['key', 'secret']
+            ).encode('utf8')
+        ),
+        request=Mock(
+            query='oauth_token=key&oauth_verifier=me'
+        )
+    )
+    name = yield authenticator.authenticate(handler)
+    assert name == 'wash'
+
+
+@mark.gen_test
+def test_no_code(mediawiki):
+    yield no_code_test(new_authenticator())

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,6 +1,9 @@
 -r ./requirements.txt
 codecov
 flake8
+jwt
+mwoauth
 pytest >= 2.8
 pytest-cov
 pytest-tornado
+requests-mock


### PR DESCRIPTION
- move more MediaWiki logic onto Authenticator, so common handler logic can be reused
- make executor reusable so it isn't recreated on every request

- [x] tests authenticate()
- [x] test LoginHandler.get()