### PR TITLE
check state field in oauth callback

### DIFF
--- a/oauthenticator/auth0.py
+++ b/oauthenticator/auth0.py
@@ -59,9 +59,7 @@ class Auth0OAuthenticator(OAuthenticator):
     
     @gen.coroutine
     def authenticate(self, handler, data=None):
-        code = handler.get_argument("code", False)
-        if not code:
-            raise web.HTTPError(400, "oauth callback made without a token")
+        code = handler.get_argument("code")
         # TODO: Configure the curl_httpclient for tornado
         http_client = AsyncHTTPClient()
 

--- a/oauthenticator/bitbucket.py
+++ b/oauthenticator/bitbucket.py
@@ -56,9 +56,7 @@ class BitbucketOAuthenticator(OAuthenticator):
 
     @gen.coroutine
     def authenticate(self, handler, data=None):
-        code = handler.get_argument("code", False)
-        if not code:
-            raise web.HTTPError(400, "oauth callback made without a token")
+        code = handler.get_argument("code")
         # TODO: Configure the curl_httpclient for tornado
         http_client = AsyncHTTPClient()
 

--- a/oauthenticator/generic.py
+++ b/oauthenticator/generic.py
@@ -64,9 +64,7 @@ class GenericOAuthenticator(OAuthenticator):
 
     @gen.coroutine
     def authenticate(self, handler, data=None):
-        code = handler.get_argument("code", False)
-        if not code:
-            raise web.HTTPError(400, "oauth callback made without a token")
+        code = handler.get_argument("code")
         # TODO: Configure the curl_httpclient for tornado
         http_client = AsyncHTTPClient()
 

--- a/oauthenticator/github.py
+++ b/oauthenticator/github.py
@@ -86,9 +86,7 @@ class GitHubOAuthenticator(OAuthenticator):
     
     @gen.coroutine
     def authenticate(self, handler, data=None):
-        code = handler.get_argument("code", False)
-        if not code:
-            raise web.HTTPError(400, "oauth callback made without a token")
+        code = handler.get_argument("code")
         # TODO: Configure the curl_httpclient for tornado
         http_client = AsyncHTTPClient()
         

--- a/oauthenticator/gitlab.py
+++ b/oauthenticator/gitlab.py
@@ -74,9 +74,7 @@ class GitLabOAuthenticator(OAuthenticator):
 
     @gen.coroutine
     def authenticate(self, handler, data=None):
-        code = handler.get_argument("code", False)
-        if not code:
-            raise web.HTTPError(400, "oauth callback made without a token")
+        code = handler.get_argument("code")
         # TODO: Configure the curl_httpclient for tornado
         http_client = AsyncHTTPClient()
 

--- a/oauthenticator/google.py
+++ b/oauthenticator/google.py
@@ -54,9 +54,7 @@ class GoogleOAuthenticator(OAuthenticator, GoogleOAuth2Mixin):
 
     @gen.coroutine
     def authenticate(self, handler, data=None):
-        code = handler.get_argument('code', False)
-        if not code:
-            raise HTTPError(400, "oauth callback made without a token")
+        code = handler.get_argument("code")
         handler.settings['google_oauth'] = {
             'key': self.client_id,
             'secret': self.client_secret,

--- a/oauthenticator/mediawiki.py
+++ b/oauthenticator/mediawiki.py
@@ -91,10 +91,7 @@ class MWOAuthenticator(OAuthenticator):
     
     @gen.coroutine
     def authenticate(self, handler):
-        code = handler.get_argument('code', False)
-        if not code:
-            raise web.HTTPError(400, "oauth callback made without a token")
-
+        code = handler.get_argument("code")
         consumer_token = ConsumerToken(
             self.client_id,
             self.client_secret,

--- a/oauthenticator/openshift.py
+++ b/oauthenticator/openshift.py
@@ -39,10 +39,7 @@ class OpenShiftOAuthenticator(OAuthenticator):
 
     @gen.coroutine
     def authenticate(self, handler, data=None):
-        code = handler.get_argument("code", False)
-        if not code:
-            raise web.HTTPError(400, "oauth callback made without a token")
-
+        code = handler.get_argument("code")
         # TODO: Configure the curl_httpclient for tornado
         http_client = AsyncHTTPClient()
 

--- a/oauthenticator/tests/test_auth0.py
+++ b/oauthenticator/tests/test_auth0.py
@@ -6,7 +6,7 @@ from pytest import fixture, mark
 with patch.dict(os.environ, AUTH0_SUBDOMAIN='jupyterhub-test'):
     from ..auth0 import Auth0OAuthenticator, AUTH0_SUBDOMAIN
 
-from .mocks import setup_oauth_mock, no_code_test
+from .mocks import setup_oauth_mock
 
 
 def user_model(username):
@@ -33,7 +33,3 @@ def test_auth0(auth0_client):
     name = yield authenticator.authenticate(handler)
     assert name == 'kaylee@serenity.now'
 
-
-@mark.gen_test
-def test_no_code(auth0_client):
-    yield no_code_test(Auth0OAuthenticator())

--- a/oauthenticator/tests/test_bitbucket.py
+++ b/oauthenticator/tests/test_bitbucket.py
@@ -5,7 +5,7 @@ from pytest import fixture, mark
 
 from ..bitbucket import BitbucketOAuthenticator
 
-from .mocks import setup_oauth_mock, no_code_test
+from .mocks import setup_oauth_mock
 
 
 def user_model(username):
@@ -30,11 +30,6 @@ def test_bitbucket(bitbucket_client):
     handler = bitbucket_client.handler_for_user(user_model('yorba'))
     name = yield authenticator.authenticate(handler)
     assert name == 'yorba'
-
-
-@mark.gen_test
-def test_no_code(bitbucket_client):
-    yield no_code_test(BitbucketOAuthenticator())
 
 
 @mark.gen_test

--- a/oauthenticator/tests/test_generic.py
+++ b/oauthenticator/tests/test_generic.py
@@ -2,7 +2,7 @@ from pytest import fixture, mark
 
 from ..generic import GenericOAuthenticator
 
-from .mocks import setup_oauth_mock, no_code_test
+from .mocks import setup_oauth_mock
 
 
 def user_model(username):
@@ -34,6 +34,3 @@ def test_generic(generic_client):
     assert name == 'wash'
 
 
-@mark.gen_test
-def test_no_code(generic_client):
-    yield no_code_test(Authenticator())

--- a/oauthenticator/tests/test_github.py
+++ b/oauthenticator/tests/test_github.py
@@ -10,7 +10,7 @@ from tornado.httputil import HTTPHeaders
 
 from ..github import GitHubOAuthenticator
 
-from .mocks import setup_oauth_mock, no_code_test
+from .mocks import setup_oauth_mock
 
 
 def user_model(username):
@@ -36,11 +36,6 @@ def test_github(github_client):
     handler = github_client.handler_for_user(user_model('wash'))
     name = yield authenticator.authenticate(handler)
     assert name == 'wash'
-
-
-@mark.gen_test
-def test_no_code(github_client):
-    yield no_code_test(GitHubOAuthenticator())
 
 
 def make_link_header(urlinfo, page):
@@ -122,3 +117,4 @@ def test_org_whitelist(github_client):
         assert name == 'donut'
 
         client.hosts['api.github.com'].pop()
+

--- a/oauthenticator/tests/test_gitlab.py
+++ b/oauthenticator/tests/test_gitlab.py
@@ -11,7 +11,7 @@ from pytest import fixture, mark
 
 from ..gitlab import GitLabOAuthenticator
 
-from .mocks import setup_oauth_mock, no_code_test
+from .mocks import setup_oauth_mock
 
 
 def user_model(username, id=1, is_admin=False):
@@ -38,11 +38,6 @@ def test_gitlab(gitlab_client):
     handler = gitlab_client.handler_for_user(user_model('wash'))
     name = yield authenticator.authenticate(handler)
     assert name == 'wash'
-
-
-@mark.gen_test
-def test_no_code(gitlab_client):
-    yield no_code_test(GitLabOAuthenticator())
 
 
 def make_link_header(urlinfo, page):
@@ -149,3 +144,4 @@ def test_group_whitelist(gitlab_client):
         assert name == 'grif'
 
         client.hosts['gitlab.com'].pop()
+

--- a/oauthenticator/tests/test_google.py
+++ b/oauthenticator/tests/test_google.py
@@ -5,7 +5,7 @@ from tornado.web import Application, HTTPError
 
 from ..google import GoogleOAuthenticator, GoogleOAuthHandler
 
-from .mocks import setup_oauth_mock, no_code_test
+from .mocks import setup_oauth_mock
 
 def user_model(email):
     """Return a user model"""
@@ -43,10 +43,6 @@ def test_google(google_client):
     name = yield authenticator.authenticate(handler)
     assert name == 'fake@email.com'
 
-
-@mark.gen_test
-def test_no_code(google_client):
-    yield no_code_test(GoogleOAuthenticator())
 
 
 @mark.gen_test

--- a/oauthenticator/tests/test_mediawiki.py
+++ b/oauthenticator/tests/test_mediawiki.py
@@ -9,7 +9,7 @@ import requests_mock
 
 from ..mediawiki import MWOAuthenticator, AUTH_REQUEST_COOKIE_NAME
 
-from .mocks import no_code_test, mock_handler
+from .mocks import mock_handler
 import jwt
 
 MW_URL = 'https://meta.wikimedia.org/w/index.php'
@@ -59,11 +59,6 @@ def test_mediawiki(mediawiki):
     )
     name = yield authenticator.authenticate(handler)
     assert name == 'wash'
-
-
-@mark.gen_test
-def test_no_code(mediawiki):
-    yield no_code_test(new_authenticator())
 
 
 @mark.gen_test

--- a/oauthenticator/tests/test_openshift.py
+++ b/oauthenticator/tests/test_openshift.py
@@ -2,7 +2,7 @@ from pytest import fixture, mark
 
 from ..openshift import OpenShiftOAuthenticator
 
-from .mocks import setup_oauth_mock, no_code_test
+from .mocks import setup_oauth_mock
 
 
 def user_model(username):
@@ -12,6 +12,7 @@ def user_model(username):
             'name': username,
         }
     }
+
 
 @fixture
 def openshift_client(client):
@@ -30,7 +31,3 @@ def test_openshift(openshift_client):
     name = yield authenticator.authenticate(handler)
     assert name == 'wash'
 
-
-@mark.gen_test
-def test_no_code(openshift_client):
-    yield no_code_test(OpenShiftOAuthenticator())


### PR DESCRIPTION
- store state in cookie and compare with url param
- include next_url in state for redirect, so users don't always land on `/home`
- check parameters in top-level handler, removing the redundant 'code' checks from every OAuthenticator