### PR TITLE
Allow for a tuple of whitelisted Google Apps domains

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ Set the generated client ID and secret in your `jupyterhub_config`:
 ```
 For a Google Apps domain you can set:
 ```
-    c.GoogleOAuthenticator.hosted_domain = 'mycollege.edu'
+    c.GoogleOAuthenticator.hosted_domain = ('mycollege.edu')
     c.GoogleOAuthenticator.login_service = 'My College'
 ```
 

--- a/oauthenticator/google.py
+++ b/oauthenticator/google.py
@@ -11,7 +11,7 @@ from tornado             import gen
 from tornado.auth        import GoogleOAuth2Mixin
 from tornado.web         import HTTPError
 
-from traitlets           import Unicode
+from traitlets           import Unicode, Tuple, default
 
 from jupyterhub.auth     import LocalAuthenticator
 from jupyterhub.utils    import url_path_join
@@ -41,16 +41,20 @@ class GoogleOAuthenticator(OAuthenticator, GoogleOAuth2Mixin):
     login_handler = GoogleLoginHandler
     callback_handler = GoogleOAuthHandler
 
-    hosted_domain = Unicode(
-        os.environ.get('HOSTED_DOMAIN', ''),
+    hosted_domain = Tuple(
         config=True,
-        help="""Hosted domain used to restrict sign-in, e.g. mycollege.edu"""
+        help="""Tuple of hosted domains used to restrict sign-in, e.g. mycollege.edu"""
     )
     login_service = Unicode(
         os.environ.get('LOGIN_SERVICE', 'Google'),
         config=True,
         help="""Google Apps hosted domain string, e.g. My College"""
     )
+
+    @default('hosted_domain')
+    def _get_hosted_domain(self):
+        domains = os.environ.get('HOSTED_DOMAIN', '')
+        return tuple([domain.strip() for domain in domains.split(',')])
 
     @gen.coroutine
     def authenticate(self, handler, data=None):
@@ -83,15 +87,16 @@ class GoogleOAuthenticator(OAuthenticator, GoogleOAuth2Mixin):
 
         username = bodyjs['email']
 
-        if self.hosted_domain:
-            if not username.endswith('@'+self.hosted_domain) or \
-                bodyjs['hd'] != self.hosted_domain:
+        self.hosted_domains = self._get_hosted_domain()
+
+        if self.hosted_domains:
+            username, _, domain = username.partition('@')
+            if not domain in self.hosted_domains or \
+                bodyjs['hd'] not in self.hosted_domains:
                 raise HTTPError(403,
                     "You are not signed in to your {} account.".format(
-                        self.hosted_domain)
+                        domain)
                 )
-            else:
-                username = username.split('@')[0]
 
         return username
 


### PR DESCRIPTION
This is an attempt to address #63 

I should note that making `hosted_domain` a `tuple` might mess up existing installations, since traitlets will be angry when it gets a `str` instead of a `tuple`.