### PR TITLE
Add Support for Globus OAuth

### DIFF
--- a/globus-requirements.txt
+++ b/globus-requirements.txt
@@ -1,4 +1,3 @@
 # extra requirements for globus
 -r ./requirements.txt
-python-jose
-globus_sdk
+globus_sdk[jwt]>=1.0.0,<2.0.0

--- a/globus-requirements.txt
+++ b/globus-requirements.txt
@@ -4,3 +4,4 @@ requests>=2.0.0,<3.0.0
 six==1.10.0
 python-jose
 pycrypto
+globus_sdk

--- a/globus-requirements.txt
+++ b/globus-requirements.txt
@@ -1,0 +1,6 @@
+# extra requirements for globus
+-r ./requirements.txt
+requests>=2.0.0,<3.0.0
+six==1.10.0
+python-jose
+pycrypto

--- a/globus-requirements.txt
+++ b/globus-requirements.txt
@@ -1,7 +1,4 @@
 # extra requirements for globus
 -r ./requirements.txt
-requests>=2.0.0,<3.0.0
-six==1.10.0
 python-jose
-pycrypto
 globus_sdk

--- a/oauthenticator/globus.py
+++ b/oauthenticator/globus.py
@@ -11,9 +11,9 @@ from .oauth2 import OAuthLoginHandler, OAuthenticator
 try:
     import globus_sdk
 except:
-    raise HTTPError(500, ("Trying to use the Globus Auth "
-                          "authenticator, but globus_sdk "
-                          "is not installed"))
+    raise ImportError("Trying to use the Globus Auth "
+                      "authenticator, but globus_sdk "
+                      "is not installed")
 
 
 class GlobusMixin(OAuth2Mixin):
@@ -49,22 +49,6 @@ class GlobusOAuthenticator(OAuthenticator):
     login_service = "Globus"
     login_handler = GlobusLoginHandler
 
-    def get_globus_app_id(self):
-        """
-        Getting the custom configuration value globus_app_id.
-        globus_app_id is the UUID of the Globus app to authenticate
-        against
-        """
-        return self.config.GlobusOAuthenticator.globus_app_id
-
-    def get_globus_app_secret(self):
-        """
-        Getting the custom configuration value globus_app_secret.
-        globus_app_secret is the secret generated on the Globus app
-        website use with Confidential Globus Auth Apps.
-        """
-        return self.config.GlobusOAuthenticator.globus_app_secret
-
     def globus_portal_client(self):
         """
         Create an Globus Auth ConfidentialAppAuthClient
@@ -73,8 +57,8 @@ class GlobusOAuthenticator(OAuthenticator):
         somewhere, which we wont do... for now.
         """
         return globus_sdk.ConfidentialAppAuthClient(
-            self.get_globus_app_id(),
-            self.get_globus_app_secret())
+            self.client_id,
+            self.client_secret)
 
     @gen.coroutine
     def authenticate(self, handler, data=None):
@@ -103,13 +87,7 @@ class GlobusOAuthenticator(OAuthenticator):
                                   "to your {} account.".format("Globus ID")))
         # Need to return a username without the "email" ending
         username = username.split('@')[0]
-        # Checking the user exists... Paranoia!
-        try:
-            pwd.getpwnam(username)
-        except KeyError:
-            raise HTTPError(401, "You do not have an active account")
-        else:
-            return username
+        return username
 
     def get_callback_url(self, handler=None):
         """

--- a/oauthenticator/globus.py
+++ b/oauthenticator/globus.py
@@ -1,0 +1,123 @@
+"""
+Custom Authenticator to use Globus OAuth2 with JupyterHub
+"""
+import pwd
+from tornado import gen, web
+from tornado.auth import OAuth2Mixin
+from tornado.concurrent import return_future
+from tornado.web import HTTPError
+from .oauth2 import OAuthLoginHandler, OAuthenticator
+
+try:
+    import globus_sdk
+except:
+    raise HTTPError(500, ("Trying to use the Globus Auth "
+                          "authenticator, but globus_sdk "
+                          "is not installed"))
+
+
+class GlobusMixin(OAuth2Mixin):
+    """
+    Overriding the tornado function because
+    globus provides it's own method to assemble the
+    authorize url
+    """
+    @return_future
+    def authorize_redirect(self, client=None, callback=None):
+        self.redirect(client.oauth2_get_authorize_url())
+        callback()
+
+
+class GlobusLoginHandler(OAuthLoginHandler, GlobusMixin):
+    def get(self):
+        # Doing the scope weirdness for the globus_sdk
+        scopes = ['openid', 'profile', 'email',
+                  'urn:globus:auth:scope:auth.globus.org:view_identities']
+        scope_string = (' ').join(scopes)
+        redirect_uri = self.authenticator.get_callback_url(self)
+        client = self.authenticator.globus_portal_client()
+        client.oauth2_start_flow(
+            redirect_uri,
+            requested_scopes=scope_string,
+            refresh_tokens=True)
+        self.log.info('globus redirect: %r', redirect_uri)
+        self.authorize_redirect(client)
+
+
+class GlobusOAuthenticator(OAuthenticator):
+
+    login_service = "Globus"
+    login_handler = GlobusLoginHandler
+
+    def get_globus_app_id(self):
+        """
+        Getting the custom configuration value globus_app_id.
+        globus_app_id is the UUID of the Globus app to authenticate
+        against
+        """
+        return self.config.GlobusOAuthenticator.globus_app_id
+
+    def get_globus_app_secret(self):
+        """
+        Getting the custom configuration value globus_app_secret.
+        globus_app_secret is the secret generated on the Globus app
+        website use with Confidential Globus Auth Apps.
+        """
+        return self.config.GlobusOAuthenticator.globus_app_secret
+
+    def globus_portal_client(self):
+        """
+        Create an Globus Auth ConfidentialAppAuthClient
+        Need a ConfidentialAppAuthClient because the NativeAppClient
+        would require user input, i.e. c/p the token from the website
+        somewhere, which we wont do... for now.
+        """
+        return globus_sdk.ConfidentialAppAuthClient(
+            self.get_globus_app_id(),
+            self.get_globus_app_secret())
+
+    @gen.coroutine
+    def authenticate(self, handler, data=None):
+        """
+        Overwritting the authenticate method with a Globus Auth specific one
+        """
+        code = handler.get_argument("code", False)
+        if not code:
+            raise web.HTTPError(400, "oauth callback made without a token")
+        # TODO: Configure the curl_httpclient for tornado
+        scopes = ['openid', 'profile', 'email',
+                  'urn:globus:auth:scope:auth.globus.org:view_identities']
+        scope_string = (' ').join(scopes)
+        redirect_uri = self.get_callback_url(self)
+        client = self.globus_portal_client()
+        client.oauth2_start_flow(
+            redirect_uri,
+            requested_scopes=scope_string,
+            refresh_tokens=True)
+        # Doing the code for token for id_token exchange
+        tokens = client.oauth2_exchange_code_for_tokens(code)
+        id_token = tokens.decode_id_token(client)
+        username = id_token.get('preferred_username')
+        if not username.endswith('@globusid.org'):
+            raise HTTPError(403, ("You are not signed in "
+                                  "to your {} account.".format("Globus ID")))
+        # Need to return a username without the "email" ending
+        username = username.split('@')[0]
+        # Checking the user exists... Paranoia!
+        try:
+            pwd.getpwnam(username)
+        except KeyError:
+            raise HTTPError(401, "You do not have an active account")
+        else:
+            return username
+
+    def get_callback_url(self, handler=None):
+        """
+        Getting the configured callback url
+        """
+        if self.oauth_callback_url is None:
+            raise HTTPError(500, ("No callback url provided. "
+                                  "Please configure by adding "
+                                  "c.GlobusOAuthenticator.oauth_callback_url "
+                                  "to the config"))
+        return self.oauth_callback_url

--- a/oauthenticator/globus.py
+++ b/oauthenticator/globus.py
@@ -1,26 +1,32 @@
 """
 Custom Authenticator to use Globus OAuth2 with JupyterHub
 """
-import pwd
+import os
+import pickle
+import base64
+
 from tornado import gen, web
 from tornado.auth import OAuth2Mixin
 from tornado.concurrent import return_future
 from tornado.web import HTTPError
-from .oauth2 import OAuthLoginHandler, OAuthenticator
+
+from traitlets import List, Unicode, Bool
+from jupyterhub.auth import LocalAuthenticator
+from jupyterhub.utils import url_path_join
+
+from .oauth2 import OAuthLoginHandler, OAuthenticator, OAuthCallbackHandler
+
 
 try:
     import globus_sdk
 except:
-    raise ImportError("Trying to use the Globus Auth "
-                      "authenticator, but globus_sdk "
-                      "is not installed")
+    raise ImportError('globus_sdk is not installed, please see '
+                      '"globus-requirements.txt" for using Globus oauth.')
 
 
 class GlobusMixin(OAuth2Mixin):
     """
-    Overriding the tornado function because
-    globus provides it's own method to assemble the
-    authorize url
+    Use the globus_sdk to get the auth URL.
     """
     @return_future
     def authorize_redirect(self, client=None, callback=None):
@@ -28,65 +34,174 @@ class GlobusMixin(OAuth2Mixin):
         callback()
 
 
-class GlobusLoginHandler(OAuthLoginHandler, GlobusMixin):
+class GlobusOAuthCallbackHandler(OAuthCallbackHandler):
+    """This extra callback handler is needed to store transfer tokens
+    in auth_state. This is needed since there isn't a sensible way to
+    access the database through `authenticate`, although this may change
+    with the following issue:
+    https://github.com/jupyterhub/jupyterhub/issues/1063
+    globus tokens are saved in the database to persist server
+    restarts and closed browser windows. This ensures consistency -- whenever
+    the user is logged in, they will be able to spawn a notebook with tokens.
+    """
+    @gen.coroutine
     def get(self):
-        # Doing the scope weirdness for the globus_sdk
-        scopes = ['openid', 'profile', 'email',
-                  'urn:globus:auth:scope:auth.globus.org:view_identities']
-        scope_string = (' ').join(scopes)
+        username = yield self.authenticator.get_authenticated_user(self, None)
+
+        if username:
+            user = self.user_from_username(username)
+            self.set_globus_data(user)
+            self.set_login_cookie(user)
+            self.redirect(url_path_join(self.hub.server.base_url, 'home'))
+        else:
+            raise web.HTTPError(403)
+
+    def set_globus_data(self, user):
+        user.auth_state = {
+            'globus_data': self.authenticator.globus_data
+        }
+        self.db.commit()
+
+
+class GlobusLoginHandler(OAuthLoginHandler, GlobusMixin):
+    """
+    The login handler sets the scope and provides the redirect URL.
+    The scope can be modified from the config.
+    """
+
+    def get(self):
         redirect_uri = self.authenticator.get_callback_url(self)
         client = self.authenticator.globus_portal_client()
         client.oauth2_start_flow(
             redirect_uri,
-            requested_scopes=scope_string,
-            refresh_tokens=True)
+            requested_scopes=' '.join(self.authenticator.scope),
+            refresh_tokens=self.authenticator.allow_refresh_tokens
+        )
         self.log.info('globus redirect: %r', redirect_uri)
         self.authorize_redirect(client)
 
 
 class GlobusOAuthenticator(OAuthenticator):
+    """The Globus OAuthenticator handles both authorization and passing
+    transfer tokens to the spawner. """
 
-    login_service = "Globus"
+    login_service = 'Globus'
     login_handler = GlobusLoginHandler
+    callback_handler = GlobusOAuthCallbackHandler
+
+    identity_provider = Unicode(help="""Restrict which institution a user
+    can use to login (GlobusID, University of Hogwarts, etc.). This should
+    be set in the app at developers.globus.org, but this acts as an additional
+    check to prevent unnecessary account creation.""").tag(config=True)
+
+    def _identity_provider_default(self):
+        return os.getenv('IDENTITY_PROVIDER', 'globusid.org')
+
+    exclude_tokens = List(
+        help="""Exclude tokens from being passed into user environments
+        when they start notebooks, Terminals, etc."""
+    ).tag(config=True)
+
+    def _exclude_tokens_default(self):
+        return ['auth.globus.org']
+
+    scope = List(
+        help="""Set scope for Globus Auth. The transfer scope can be removed in
+         which case a transfer token will no longer be passed to the spawner.
+         Alternatively, add additional transfer scopes and those transfer
+         tokens will automatically be added."""
+    ).tag(config=True)
+
+    def _scope_default(self):
+        return [
+            'openid',
+            'profile',
+            'urn:globus:auth:scope:transfer.api.globus.org:all'
+        ]
+
+    allow_refresh_tokens = Bool(
+        help="""Allow users to have Refresh Tokens. If Refresh Tokens are not
+        allowed, users must use regular Access Tokens which will expire after
+        a set time. Set to False for increased security, True for increased
+        convenience."""
+    ).tag(config=True)
+
+    def _allow_refresh_tokens_default(self):
+        return True
+
+    globus_local_endpoint = Unicode(help="""If Jupyterhub is also a Globus
+    endpoint, its endpoint id can be specified here.""").tag(config=True)
+
+    def _globus_local_endpoint_default(self):
+        return os.getenv('GLOBUS_LOCAL_ENDPOINT', '')
+
+    def pre_spawn_start(self, user, spawner):
+        """Add tokens to the spawner whenever the spawner starts a notebook.
+        This will allow users to create a transfer client:
+        globus-sdk-python.readthedocs.io/en/stable/tutorial/#tutorial-step4
+        """
+        if self.globus_local_endpoint:
+            spawner.environment.update(
+                {'GLOBUS_LOCAL_ENDPOINT': self.globus_local_endpoint}
+            )
+        if user.auth_state.get('globus_data'):
+            globus_data = base64.b64encode(
+                pickle.dumps(user.auth_state['globus_data'])
+            )
+            spawner.environment['GLOBUS_DATA'] = globus_data
+        else:
+            # This can happen when migrating old users with a valid
+            # Jupyterhub session that have never used this oauthenticator
+            self.log.error('Globus data not found, user will not be able '
+                           'to start transfers until they '
+                           're-authenticate.')
 
     def globus_portal_client(self):
-        """
-        Create an Globus Auth ConfidentialAppAuthClient
-        Need a ConfidentialAppAuthClient because the NativeAppClient
-        would require user input, i.e. c/p the token from the website
-        somewhere, which we wont do... for now.
-        """
         return globus_sdk.ConfidentialAppAuthClient(
             self.client_id,
             self.client_secret)
 
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.globus_data = {}
+
     @gen.coroutine
     def authenticate(self, handler, data=None):
         """
-        Overwritting the authenticate method with a Globus Auth specific one
+        Authenticate with globus.org. Usernames (and therefore Jupyterhub
+        accounts) will correspond to a Globus User ID, so foouser@globusid.org
+        will have the 'foouser' account in Jupyterhub.
         """
-        code = handler.get_argument("code", False)
-        if not code:
-            raise web.HTTPError(400, "oauth callback made without a token")
-        # TODO: Configure the curl_httpclient for tornado
-        scopes = ['openid', 'profile', 'email',
-                  'urn:globus:auth:scope:auth.globus.org:view_identities']
-        scope_string = (' ').join(scopes)
+        code = handler.get_argument("code")
         redirect_uri = self.get_callback_url(self)
+
         client = self.globus_portal_client()
         client.oauth2_start_flow(
             redirect_uri,
-            requested_scopes=scope_string,
-            refresh_tokens=True)
+            requested_scopes=' '.join(self.scope),
+            refresh_tokens=self.allow_refresh_tokens
+        )
         # Doing the code for token for id_token exchange
         tokens = client.oauth2_exchange_code_for_tokens(code)
+        self.globus_data['tokens'] = {
+            tok: v for tok, v in tokens.by_resource_server.items()
+            if tok not in self.exclude_tokens
+        }
+
+        self.globus_data['client_id'] = self.client_id
         id_token = tokens.decode_id_token(client)
-        username = id_token.get('preferred_username')
-        if not username.endswith('@globusid.org'):
-            raise HTTPError(403, ("You are not signed in "
-                                  "to your {} account.".format("Globus ID")))
-        # Need to return a username without the "email" ending
-        username = username.split('@')[0]
+        username, domain = id_token.get('preferred_username').split('@')
+
+        if self.identity_provider and domain != self.identity_provider:
+            raise HTTPError(
+                403,
+                'This site is restricted to {} accounts. Please link your {}'
+                ' account at {}.'.format(
+                    self.identity_provider,
+                    self.identity_provider,
+                    'globus.org/app/account'
+                    )
+            )
         return username
 
     def get_callback_url(self, handler=None):
@@ -94,8 +209,15 @@ class GlobusOAuthenticator(OAuthenticator):
         Getting the configured callback url
         """
         if self.oauth_callback_url is None:
-            raise HTTPError(500, ("No callback url provided. "
-                                  "Please configure by adding "
-                                  "c.GlobusOAuthenticator.oauth_callback_url "
-                                  "to the config"))
+            raise HTTPError(500,
+                            'No callback url provided. '
+                            'Please configure by adding '
+                            'c.GlobusOAuthenticator.oauth_callback_url '
+                            'to the config'
+                            )
         return self.oauth_callback_url
+
+
+class LocalGlobusOAuthenticator(LocalAuthenticator, GlobusOAuthenticator):
+    """A version that mixes in local system user creation"""
+    pass

--- a/oauthenticator/tests/test_globus.py
+++ b/oauthenticator/tests/test_globus.py
@@ -11,13 +11,14 @@ def user_model(username):
         'login': username,
     }
 
+
 @fixture
 def globus_client(client):
     setup_oauth_mock(client,
-        host=['github.com', 'api.github.com'],
-        access_token_path='/login/oauth/access_token',
-        user_path='/user',
-        token_type='token',
+        host=['auth.globus.org'],
+        access_token_path='/v2/oauth2/token',
+        user_path='/userinfo',
+        token_type='bearer',
     )
     return client
 

--- a/oauthenticator/tests/test_globus.py
+++ b/oauthenticator/tests/test_globus.py
@@ -1,4 +1,8 @@
-from pytest import fixture, mark
+from pytest import fixture, mark, raises
+from tornado import web
+from unittest.mock import Mock
+
+from globus_sdk import ConfidentialAppAuthClient
 
 from ..globus import GlobusOAuthenticator
 
@@ -13,8 +17,35 @@ def user_model(username):
 
 
 @fixture
+def mock_globus_sdk(monkeypatch):
+    """Mock the globus_sdk request for 'oauth2_exchange_code_for_tokens', and
+    mock some of the items within the returned 'Tokens' class. """
+
+    class Tokens:
+
+        by_resource_server = {
+            'transfer.api.globus.org': {'access_token': 'TRANSFER_TOKEN'},
+            'auth.globus.org': {'access_token': 'AUTH_TOKEN'}
+
+        }
+        id_token = {'preferred_username': 'wash@globusid.org'}
+
+        def decode_id_token(self, client):
+            return self.id_token
+
+    tokens = Tokens()
+    monkeypatch.setattr(
+        ConfidentialAppAuthClient,
+        'oauth2_exchange_code_for_tokens',
+        lambda self, code: tokens
+    )
+    return tokens
+
+
+@fixture
 def globus_client(client):
-    setup_oauth_mock(client,
+    setup_oauth_mock(
+        client,
         host=['auth.globus.org'],
         access_token_path='/v2/oauth2/token',
         user_path='/userinfo',
@@ -24,13 +55,54 @@ def globus_client(client):
 
 
 @mark.gen_test
-def test_globus(github_client):
+def test_globus(globus_client, mock_globus_sdk):
     authenticator = GlobusOAuthenticator()
     handler = globus_client.handler_for_user(user_model('wash'))
     name = yield authenticator.authenticate(handler)
     assert name == 'wash'
+    assert list(authenticator.globus_data['tokens'].keys()) == \
+        ['transfer.api.globus.org']
 
 
 @mark.gen_test
-def test_no_code(test_globus):
-    yield no_code_test(GlobusOAuthenticator())
+def test_allow_refresh_tokens(globus_client, mock_globus_sdk, monkeypatch):
+    authenticator = GlobusOAuthenticator()
+    # Sanity check, this field should be set to True
+    assert authenticator.allow_refresh_tokens is True
+    authenticator.allow_refresh_tokens = False
+    monkeypatch.setattr(
+        ConfidentialAppAuthClient,
+        'oauth2_start_flow',
+        Mock()
+    )
+    handler = globus_client.handler_for_user(user_model('wash'))
+    yield authenticator.authenticate(handler)
+    ConfidentialAppAuthClient.oauth2_start_flow.assert_called_with(
+        authenticator.get_callback_url(None),
+        requested_scopes=' '.join(authenticator.scope),
+        refresh_tokens=False
+    )
+
+
+@mark.gen_test
+def test_restricted_domain(globus_client, mock_globus_sdk):
+    mock_globus_sdk.id_token = {'preferred_username': 'wash@serenity.com'}
+    authenticator = GlobusOAuthenticator()
+    authenticator.identity_provider = 'alliance.gov'
+    handler = globus_client.handler_for_user(user_model('wash'))
+    with raises(web.HTTPError) as exc:
+        yield authenticator.authenticate(handler)
+    assert exc.value.status_code == 403
+
+
+@mark.gen_test
+def test_token_exclusion(globus_client, mock_globus_sdk):
+    authenticator = GlobusOAuthenticator()
+    authenticator.exclude_tokens = [
+        'transfer.api.globus.org',
+        'auth.globus.org'
+    ]
+    handler = globus_client.handler_for_user(user_model('wash'))
+    name = yield authenticator.authenticate(handler)
+    assert name == 'wash'
+    assert list(authenticator.globus_data['tokens'].keys()) == []

--- a/oauthenticator/tests/test_globus.py
+++ b/oauthenticator/tests/test_globus.py
@@ -1,0 +1,35 @@
+from pytest import fixture, mark
+
+from ..globus import GlobusOAuthenticator
+
+from .mocks import setup_oauth_mock, no_code_test
+
+
+def user_model(username):
+    """Return a user model"""
+    return {
+        'login': username,
+    }
+
+@fixture
+def globus_client(client):
+    setup_oauth_mock(client,
+        host=['github.com', 'api.github.com'],
+        access_token_path='/login/oauth/access_token',
+        user_path='/user',
+        token_type='token',
+    )
+    return client
+
+
+@mark.gen_test
+def test_globus(github_client):
+    authenticator = GlobusOAuthenticator()
+    handler = globus_client.handler_for_user(user_model('wash'))
+    name = yield authenticator.authenticate(handler)
+    assert name == 'wash'
+
+
+@mark.gen_test
+def test_no_code(test_globus):
+    yield no_code_test(GlobusOAuthenticator())

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,4 +1,5 @@
 -r ./requirements.txt
+-r ./globus-requirements.txt
 codecov
 flake8
 jwt


### PR DESCRIPTION
The following adds support for Globus Auth, allowing users to login with their GlobusID. Alternatively, this authenticator supports other organizations supported by Globus Auth. For instance if someone wanted to setup their Jupyterhub server and restrict logins to the University of Chicago, they can configure their app to do so. The full list of institutions supported can be found [here](https://www.globus.org/app/transfer). 

In addition to Authentication, Globus also provides a transfer service for transferring data across nodes. This Authenticator is setup to procure `access_tokens` for users when they login, allowing them to easily transfer data from their python notebook with little hassle. 

I followed the discussion [here](https://github.com/jupyterhub/jupyterhub/issues/1063) on storing tokens in auth_state, and in some outside discussion decided `auth_state` was the best place to do it. If security is a concern, admins can easily turn off transfer `access_tokens` in their `jupyterhub_config.py` file. By default, the Authenticator excludes user Auth `access_tokens`. 