### PR TITLE
Vendor link headers from 'requests' module

### DIFF
--- a/oauthenticator/common.py
+++ b/oauthenticator/common.py
@@ -32,3 +32,23 @@ def parse_header_links(value):
         links.append(link)
 
     return links
+
+
+def next_page_from_links(response):
+    """Return the url of the 'next' link header as a string.
+
+    Return None if no link header called 'next' is found.
+
+    Both Gitlab and Github use link headers for pagination:
+        https://docs.gitlab.com/ee/api/README.html#pagination-link-header
+        https://developer.github.com/v3/#pagination
+    """
+    link_header = response.headers.get('Link')
+    if not link_header:
+        return None
+
+    for link in parse_header_links(link_header):
+        if link.get('rel') == 'next':
+            return link['url']
+    # if no "next" link, this page is the last one
+    return None

--- a/oauthenticator/common.py
+++ b/oauthenticator/common.py
@@ -1,0 +1,34 @@
+import re
+
+# vendored from the 'requests' module
+def parse_header_links(value):
+    """Return a dict of parsed link headers proxies.
+
+    i.e. Link: <http:/.../front.jpeg>; rel=front; type="image/jpeg",<http://.../back.jpeg>; rel=back;type="image/jpeg"
+
+    :rtype: list
+    """
+
+    links = []
+
+    replace_chars = ' \'"'
+
+    for val in re.split(', *<', value):
+        try:
+            url, params = val.split(';', 1)
+        except ValueError:
+            url, params = val, ''
+
+        link = {'url': url.strip('<> \'"')}
+
+        for param in params.split(';'):
+            try:
+                key, value = param.split('=')
+            except ValueError:
+                break
+
+            link[key.strip(replace_chars)] = value.strip(replace_chars)
+
+        links.append(link)
+
+    return links

--- a/oauthenticator/github.py
+++ b/oauthenticator/github.py
@@ -12,7 +12,6 @@ import re
 from tornado.auth import OAuth2Mixin
 from tornado import gen, web
 
-import requests
 from tornado.httputil import url_concat
 from tornado.httpclient import HTTPRequest, AsyncHTTPClient
 
@@ -20,6 +19,7 @@ from jupyterhub.auth import LocalAuthenticator
 
 from traitlets import Unicode, Set
 
+from .common import parse_header_links
 from .oauth2 import OAuthLoginHandler, OAuthenticator
 
 # Support github.com and github enterprise installations
@@ -43,7 +43,7 @@ def _get_next_page(response):
     link_header = response.headers.get('Link')
     if not link_header:
         return
-    for link in requests.utils.parse_header_links(link_header):
+    for link in parse_header_links(link_header):
         if link.get('rel') == 'next':
             return link['url']
     # if no "next" page, this is the last one

--- a/oauthenticator/gitlab.py
+++ b/oauthenticator/gitlab.py
@@ -13,7 +13,6 @@ import sys
 from tornado.auth import OAuth2Mixin
 from tornado import gen, web
 
-import requests
 from tornado.escape import url_escape
 from tornado.httputil import url_concat
 from tornado.httpclient import HTTPRequest, AsyncHTTPClient
@@ -22,6 +21,7 @@ from jupyterhub.auth import LocalAuthenticator
 
 from traitlets import Set
 
+from .common import parse_header_links
 from .oauth2 import OAuthLoginHandler, OAuthenticator
 
 # Support gitlab.com and gitlab community edition installations
@@ -42,7 +42,7 @@ def _get_next_page(response):
     link_header = response.headers.get('Link')
     if not link_header:
         return
-    for link in requests.utils.parse_header_links(link_header):
+    for link in parse_header_links(link_header):
         if link.get('rel') == 'next':
             return link['url']
     # if no "next" page, this is the last one

--- a/oauthenticator/gitlab.py
+++ b/oauthenticator/gitlab.py
@@ -21,7 +21,7 @@ from jupyterhub.auth import LocalAuthenticator
 
 from traitlets import Set
 
-from .common import parse_header_links
+from .common import next_page_from_links
 from .oauth2 import OAuthLoginHandler, OAuthenticator
 
 # Support gitlab.com and gitlab community edition installations
@@ -34,19 +34,6 @@ def _api_headers(access_token):
             "User-Agent": "JupyterHub",
             "Authorization": "token {}".format(access_token)
            }
-
-
-def _get_next_page(response):
-    # Gitlab uses Link headers for pagination.
-    # See https://docs.gitlab.com/ee/api/README.html#pagination-link-header
-    link_header = response.headers.get('Link')
-    if not link_header:
-        return
-    for link in parse_header_links(link_header):
-        if link.get('rel') == 'next':
-            return link['url']
-    # if no "next" page, this is the last one
-    return None
 
 
 class GitLabMixin(OAuth2Mixin):
@@ -154,7 +141,7 @@ class GitLabOAuthenticator(OAuthenticator):
                 req = HTTPRequest(next_page, method="GET", headers=headers)
                 resp = yield http_client.fetch(req)
                 resp_json = json.loads(resp.body.decode('utf8', 'replace'))
-                next_page = _get_next_page(resp)
+                next_page = next_page_from_links(resp)
                 user_groups = set(entry["path"] for entry in resp_json)
                 # check if any of the organizations seen thus far are in whitelist
                 if len(self.gitlab_group_whitelist & user_groups) > 0:


### PR DESCRIPTION
This was suggested by @minrk previously, but I did not implement it before #58 was merged.

A separate commit moves out the function for getting the 'next' link header to a common location