### PR TITLE
handle get_authenticated_user returning a dict

### DIFF
--- a/oauthenticator/oauth2.py
+++ b/oauthenticator/oauth2.py
@@ -127,7 +127,12 @@ class OAuthCallbackHandler(BaseHandler):
     def get(self):
         self.check_arguments()
 
-        username = yield self.authenticator.get_authenticated_user(self, None)
+        user = yield self.authenticator.get_authenticated_user(self, None)
+        if isinstance(user, dict):
+            # JupyterHub 0.8 returns a dict
+            username = user['name']
+        else:
+            username = user
 
         if username:
             user = self.user_from_username(username)


### PR DESCRIPTION
which it will do in 0.8

The recent change to get_authenticated_user causes
an inscrutable `sqlalchemy.exc.InterfaceError: <unprintable InterfaceError object>` error due to passing a dict for a string arg.

cc @athornton