### PR TITLE
update link to Jupyter contributor guide

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,3 +1,15 @@
 # Contributing
 
-We mainly follow the [IPython Contributing Guide](https://github.com/ipython/ipython/blob/master/CONTRIBUTING.md).
+Welcome! As a Jupyter, we follow the [Jupyter contributor guide](https://jupyter.readthedocs.io/en/latest/contributor/content-contributor.html).
+
+To set up a development environment for this repository:
+
+1. Clone this repository:
+
+        git clone https://github.com/jupyterhub/oauthenticator
+
+2. Do a development install with pip:
+
+        cd oauthenticator
+        pip install -e .
+


### PR DESCRIPTION
we only had the IPython placeholder from before the Jupyter contributor docs

cc @willingc

I think we're in the same situation on several JupyterHub repos. I can update the rest if this seems reasonable.