### PR TITLE
Fix callback_url -> oauth_callback_url in docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ $OAUTH_CLIENT_SECRET
 You can also set these values in your **configuration file**, `jupyterhub_config.py`:
 
 ```python
-c.MyOAuthenticator.callback_url = 'http[s]://[your-host]/hub/oauth_callback'
+c.MyOAuthenticator.oauth_callback_url = 'http[s]://[your-host]/hub/oauth_callback'
 c.MyOAuthenticator.client_id = 'your-client-id'
 c.MyOAuthenticator.client_secret = 'your-client-secret'
 ```


### PR DESCRIPTION
See the variable name in `oauth2.py` https://github.com/jupyterhub/oauthenticator/blob/master/oauthenticator/oauth2.py#L201