### PR TITLE
fix gitlab request headers

### DIFF
--- a/oauthenticator/gitlab.py
+++ b/oauthenticator/gitlab.py
@@ -32,7 +32,7 @@ GITLAB_API = '%s/api/v3' % GITLAB_HOST
 def _api_headers(access_token):
     return {"Accept": "application/json",
             "User-Agent": "JupyterHub",
-            "Authorization": "token {}".format(access_token)
+            "Authorization": "Bearer {}".format(access_token)
            }
 
 


### PR DESCRIPTION
Authentication token as a header should be `"Authorization": "Bearer {access_token}"`