### PR TITLE
Make is_admin=False by default for GitLab

### DIFF
--- a/oauthenticator/gitlab.py
+++ b/oauthenticator/gitlab.py
@@ -107,7 +107,7 @@ class GitLabOAuthenticator(OAuthenticator):
 
         username = resp_json["username"]
         user_id = resp_json["id"]
-        is_admin = resp_json["is_admin"]
+        is_admin = resp_json.get("is_admin", False)
 
         # Check if user is a member of any whitelisted organizations.
         # This check is performed here, as it requires `access_token`.


### PR DESCRIPTION
Newer versions of the GitLab API do not add the "is_admin" field unless the call
made by an admin user:

https://gitlab.com/gitlab-org/gitlab-ce/merge_requests/12211

This change adds a default when this field is missing.
It closes #115 