### PR TITLE
Preserve user-info in auth_state for all authenticators

### DIFF
--- a/oauthenticator/auth0.py
+++ b/oauthenticator/auth0.py
@@ -95,7 +95,13 @@ class Auth0OAuthenticator(OAuthenticator):
         resp = yield http_client.fetch(req)
         resp_json = json.loads(resp.body.decode('utf8', 'replace'))
 
-        return resp_json["email"]
+        return {
+            'username': resp_json["email"],
+            'auth_state': {
+                'access_token': access_token,
+                'auth0_user': resp_json,
+            }
+        }
 
 
 class LocalAuth0OAuthenticator(LocalAuthenticator, Auth0OAuthenticator):

--- a/oauthenticator/bitbucket.py
+++ b/oauthenticator/bitbucket.py
@@ -102,9 +102,17 @@ class BitbucketOAuthenticator(OAuthenticator):
         # This check is performed here, as the check requires `access_token`.
         if self.bitbucket_team_whitelist:
             user_in_team = yield self._check_team_whitelist(username, access_token)
-            return username if user_in_team else None
-        else:  # no team whitelisting
-            return username
+            if not user_in_team:
+                self.log.warning("%s not in team whitelist", username)
+                return None
+
+        return {
+            'username': username,
+            'auth_state': {
+                'access_token': access_token,
+                'bitbucket_user': resp_json,
+            }
+        }
 
     @gen.coroutine
     def _check_team_whitelist(self, username, access_token):

--- a/oauthenticator/generic.py
+++ b/oauthenticator/generic.py
@@ -117,8 +117,17 @@ class GenericOAuthenticator(OAuthenticator):
         resp = yield http_client.fetch(req)
         resp_json = json.loads(resp.body.decode('utf8', 'replace'))
 
-        if resp_json.get(self.username_key):
-            return resp_json[self.username_key]
+        if not resp_json.get(self.username_key):
+            self.log.error("OAuth user contains no key %s: %s", self.username_key, resp_json)
+            return
+
+        return {
+            'username': resp_json.get(self.username_key),
+            'auth_state': {
+                'access_token': access_token,
+                'oauth_user': resp_json,
+            }
+        }
 
 
 class LocalGenericOAuthenticator(LocalAuthenticator, GenericOAuthenticator):

--- a/oauthenticator/gitlab.py
+++ b/oauthenticator/gitlab.py
@@ -114,9 +114,16 @@ class GitLabOAuthenticator(OAuthenticator):
         if self.gitlab_group_whitelist:
             user_in_group = yield self._check_group_whitelist(
                 username, user_id, is_admin, access_token)
-            return username if user_in_group else None
-        else:  # no organization whitelisting
-            return username
+            if not user_in_group:
+                self.log.warning("%s not in group whitelist", username)
+                return None
+        return {
+            'username': username,
+            'auth_state': {
+                'access_token': access_token,
+                'gitlab_user': resp_json,
+            }
+        }
 
 
     @gen.coroutine

--- a/oauthenticator/google.py
+++ b/oauthenticator/google.py
@@ -74,9 +74,7 @@ class GoogleOAuthenticator(OAuthenticator, GoogleOAuth2Mixin):
             self.clear_all_cookies()
             raise HTTPError(500, 'Google authentication failed')
 
-        body = response.body.decode()
-        self.log.debug('response.body.decode(): {}'.format(body))
-        bodyjs = json.loads(body)
+        bodyjs = json.loads(response.body.decode())
 
         username = bodyjs['email']
 
@@ -90,7 +88,13 @@ class GoogleOAuthenticator(OAuthenticator, GoogleOAuth2Mixin):
             else:
                 username = username.split('@')[0]
 
-        return username
+        return {
+            'username': username,
+            'auth_state': {
+                'access_token': access_token,
+                'google_user': bodyjs,
+            }
+        }
 
 class LocalGoogleOAuthenticator(LocalAuthenticator, GoogleOAuthenticator):
     """A version that mixes in local system user creation"""

--- a/oauthenticator/okpy.py
+++ b/oauthenticator/okpy.py
@@ -79,7 +79,13 @@ class OkpyOAuthenticator(OAuthenticator, OAuth2Mixin):
         response = yield http_client.fetch(info_request)
         user = json.loads(response.body.decode('utf8', 'replace'))
         # TODO: preserve state in auth_state when JupyterHub supports encrypted auth_state
-        return user["email"] # , state
+        return {
+            'username': user['email'],
+            'auth_state': {
+                'access_token': access_token,
+                'okpy_user': user,
+            }
+        }
 
 class LocalOkpyOAuthenticator(LocalAuthenticator, OkpyOAuthenticator):
     """A version that mixes in local system user creation"""

--- a/oauthenticator/openshift.py
+++ b/oauthenticator/openshift.py
@@ -83,7 +83,14 @@ class OpenShiftOAuthenticator(OAuthenticator):
         resp = yield http_client.fetch(req)
         resp_json = json.loads(resp.body.decode('utf8', 'replace'))
 
-        return resp_json["metadata"]["name"]
+        return {
+            'username': resp_json['metadata']['name'],
+            'auth_state': {
+                'access_token': access_token,
+                'openshift_user': resp_json,
+            }
+        }
+
 
 class LocalOpenShiftOAuthenticator(LocalAuthenticator, OpenShiftOAuthenticator):
 

--- a/oauthenticator/tests/mocks.py
+++ b/oauthenticator/tests/mocks.py
@@ -152,7 +152,6 @@ def setup_oauth_mock(client, host, access_token_path, user_path,
                 )
             code = query['code'][0]
         if code not in oauth_codes:
-            app_log.warning()
             return HTTPResponse(request=request, code=403,
                 reason="No such code: %s" % code,
             )

--- a/oauthenticator/tests/test_auth0.py
+++ b/oauthenticator/tests/test_auth0.py
@@ -30,6 +30,11 @@ def auth0_client(client):
 def test_auth0(auth0_client):
     authenticator = Auth0OAuthenticator()
     handler = auth0_client.handler_for_user(user_model('kaylee@serenity.now'))
-    name = yield authenticator.authenticate(handler)
+    user_info = yield authenticator.authenticate(handler)
+    assert sorted(user_info) == ['auth_state', 'username']
+    name = user_info['username']
     assert name == 'kaylee@serenity.now'
+    auth_state = user_info['auth_state']
+    assert 'access_token' in auth_state
+    assert 'auth0_user' in auth_state
 

--- a/oauthenticator/tests/test_bitbucket.py
+++ b/oauthenticator/tests/test_bitbucket.py
@@ -28,8 +28,13 @@ def bitbucket_client(client):
 def test_bitbucket(bitbucket_client):
     authenticator = BitbucketOAuthenticator()
     handler = bitbucket_client.handler_for_user(user_model('yorba'))
-    name = yield authenticator.authenticate(handler)
+    user_info = yield authenticator.authenticate(handler)
+    assert sorted(user_info) == ['auth_state', 'username']
+    name = user_info['username']
     assert name == 'yorba'
+    auth_state = user_info['auth_state']
+    assert 'access_token' in auth_state
+    assert 'bitbucket_user' in auth_state
 
 
 @mark.gen_test
@@ -58,7 +63,8 @@ def test_team_whitelist(bitbucket_client):
     )
 
     handler = client.handler_for_user(user_model('caboose'))
-    name = yield authenticator.authenticate(handler)
+    user_info = yield authenticator.authenticate(handler)
+    name = user_info['username']
     assert name == 'caboose'
 
     handler = client.handler_for_user(user_model('donut'))
@@ -73,5 +79,6 @@ def test_team_whitelist(bitbucket_client):
     assert name is None
 
     handler = client.handler_for_user(user_model('donut'))
-    name = yield authenticator.authenticate(handler)
+    user_info = yield authenticator.authenticate(handler)
+    name = user_info['username']
     assert name == 'donut'

--- a/oauthenticator/tests/test_generic.py
+++ b/oauthenticator/tests/test_generic.py
@@ -30,7 +30,12 @@ def generic_client(client):
 def test_generic(generic_client):
     authenticator = Authenticator()
     handler = generic_client.handler_for_user(user_model('wash'))
-    name = yield authenticator.authenticate(handler)
+    user_info = yield authenticator.authenticate(handler)
+    assert sorted(user_info) == ['auth_state', 'username']
+    name = user_info['username']
     assert name == 'wash'
+    auth_state = user_info['auth_state']
+    assert 'access_token' in auth_state
+    assert 'oauth_user' in auth_state
 
 

--- a/oauthenticator/tests/test_globus.py
+++ b/oauthenticator/tests/test_globus.py
@@ -58,9 +58,13 @@ def globus_client(client):
 def test_globus(globus_client, mock_globus_sdk):
     authenticator = GlobusOAuthenticator()
     handler = globus_client.handler_for_user(user_model('wash'))
-    name = yield authenticator.authenticate(handler)
+    user_info = yield authenticator.authenticate(handler)
+    assert sorted(user_info) == ['auth_state', 'username']
+    name = user_info['username']
     assert name == 'wash'
-    assert list(authenticator.globus_data['tokens'].keys()) == \
+    auth_state = user_info['auth_state']
+    assert 'globus_data' in auth_state
+    assert list(auth_state['globus_data']['tokens'].keys()) == \
         ['transfer.api.globus.org']
 
 
@@ -103,6 +107,9 @@ def test_token_exclusion(globus_client, mock_globus_sdk):
         'auth.globus.org'
     ]
     handler = globus_client.handler_for_user(user_model('wash'))
-    name = yield authenticator.authenticate(handler)
+    user_info = yield authenticator.authenticate(handler)
+    name = user_info['username']
     assert name == 'wash'
-    assert list(authenticator.globus_data['tokens'].keys()) == []
+    auth_state = user_info['auth_state']
+    assert 'globus_data' in auth_state
+    assert list(auth_state['globus_data']['tokens'].keys()) == []

--- a/oauthenticator/tests/test_google.py
+++ b/oauthenticator/tests/test_google.py
@@ -40,8 +40,13 @@ def google_client(client):
 def test_google(google_client):
     authenticator = GoogleOAuthenticator()
     handler = google_client.handler_for_user(user_model('fake@email.com'))
-    name = yield authenticator.authenticate(handler)
+    user_info = yield authenticator.authenticate(handler)
+    assert sorted(user_info) == ['auth_state', 'username']
+    name = user_info['username']
     assert name == 'fake@email.com'
+    auth_state = user_info['auth_state']
+    assert 'access_token' in auth_state
+    assert 'google_user' in auth_state
 
 
 
@@ -49,8 +54,8 @@ def test_google(google_client):
 def test_hosted_domain(google_client):
     authenticator = GoogleOAuthenticator(hosted_domain='email.com')
     handler = google_client.handler_for_user(user_model('fake@email.com'))#, authenticator)
-    # result = yield handler.get()
-    name = yield authenticator.authenticate(handler)
+    user_info = yield authenticator.authenticate(handler)
+    name = user_info['username']
     assert name == 'fake'
 
     handler = google_client.handler_for_user(user_model('notallowed@notemail.com'))

--- a/oauthenticator/tests/test_okpy.py
+++ b/oauthenticator/tests/test_okpy.py
@@ -26,8 +26,13 @@ def okpy_client(client):
 def test_okpy(okpy_client):
     authenticator = OkpyOAuthenticator()
     handler = okpy_client.handler_for_user(user_model('testing@example.com'))
-    name = yield authenticator.authenticate(handler)
+    user_info = yield authenticator.authenticate(handler)
+    assert sorted(user_info) == ['auth_state', 'username']
+    name = user_info['username']
     assert name == 'testing@example.com'
+    auth_state = user_info['auth_state']
+    assert 'access_token' in auth_state
+    assert 'okpy_user' in auth_state
 
 
 @mark.gen_test

--- a/oauthenticator/tests/test_openshift.py
+++ b/oauthenticator/tests/test_openshift.py
@@ -28,6 +28,11 @@ def openshift_client(client):
 def test_openshift(openshift_client):
     authenticator = OpenShiftOAuthenticator()
     handler = openshift_client.handler_for_user(user_model('wash'))
-    name = yield authenticator.authenticate(handler)
+    user_info = yield authenticator.authenticate(handler)
+    assert sorted(user_info) == ['auth_state', 'username']
+    name = user_info['username']
     assert name == 'wash'
+    auth_state = user_info['auth_state']
+    assert 'access_token' in auth_state
+    assert 'openshift_user' in auth_state
 


### PR DESCRIPTION
Every OAuthenticator stores its access token in `state.access_token` and the user-info reply as-is in e.g. `github_user`.

In the future, we could probably consolidate quite a bit of this if we defined the OAuth stages clearly:

- request access token
- request user-info
- check user-info (e.g. team whitelists)

Doing this ought to simplify maintaining the more standards providers, which is most of them.

Closes #110