### PR TITLE
default to 'email' scope for okpy

### DIFF
--- a/oauthenticator/okpy.py
+++ b/oauthenticator/okpy.py
@@ -34,7 +34,7 @@ class OkpyOAuthenticator(OAuthenticator, OAuth2Mixin):
     
     @default('scope')
     def _default_scope(self):
-        return ['all']
+        return ['email']
 
     def get_auth_request(self, code):
         params = dict(


### PR DESCRIPTION
default scopes should be authentication-only now that scopes are configurable.

Deployments can set `Okpy.scope = ['all']` to request 'all' permissions.