### PR TITLE
Globus OAuth: Bug fix, code cleanup, and added security features

### DIFF
--- a/README.md
+++ b/README.md
@@ -212,7 +212,7 @@ and set your `OAUTH_` environment variables.
 Visit https://developers.globus.org/ to set up your app. Ensure _Native App_ is
 unchecked and make sure the callback URL looks like:
 
-    https://[your-host]/hub/oauth_callback
+    https://[your-host]/oauth_callback
 
 Set scopes for authorization and transfer. The defaults include:
 
@@ -224,13 +224,22 @@ Set the above settings in your `jupyterhub_config`:
 # Tell JupyterHub to create system accounts
 from oauthenticator.globus import LocalGlobusOAuthenticator
 c.JupyterHub.authenticator_class = LocalGlobusOAuthenticator
+c.LocalGlobusOAuthenticator.enable_auth_state = True
+c.LocalGlobusOAuthenticator.oauth_callback_url = 'https://[your-host]/oauth_callback'
+c.LocalGlobusOAuthenticator.client_id = '[your app client id]'
+c.LocalGlobusOAuthenticator.client_secret = '[your app client secret]'
 ```
 
-and set the `OAUTH_` environment variables or config values.
+Alternatively you can set env variables for the following: `OAUTH_CALLBACK_URL`, `OAUTH_CLIENT_ID`,
+and `OAUTH_CLIENT_SECRET`. Setting `JUPYTERHUB_CRYPT_KEY` is required, and can be generated
+with OpenSSL: `openssl rand -hex 32`
+
+You are all set by this point! Be sure to check below for tweaking settings
+related to User Identity, Transfer, and additional security.
 
 ### User Identity
 
-By default, all users are restricted to their *Globus IDs* (malcolm@globusid.org)
+By default, all users are restricted to their *Globus IDs* (example@globusid.org)
 with the default Jupyterhub config:
 
 ```python
@@ -265,6 +274,11 @@ c.LocalGlobusOAuthenticator.exclude = ['auth.globus.org']
 # If the JupyterHub server is an endpoint, for convenience the endpoint id can be
 # set here. It will show up in the notebook kernel for all users as 'GLOBUS_LOCAL_ENDPOINT'.
 c.LocalGlobusOAuthenticator.globus_local_endpoint = '<Your Local JupyterHub UUID>'
+# Set a custom logout URL for your identity provider
+c.LocalGlobusOAuthenticator.logout_redirect_url = 'https://auth.globus.org/v2/web/logout'
+# For added security, revoke all service tokens when users logout. (Note: users must start
+# a new server to get fresh tokens, logging out does not shut it down by default)
+c.LocalGlobusOAuthenticator.revoke_tokens_on_logout = False
 ```
 
 If you only want to authenticate users with their Globus IDs but don't want to

--- a/README.md
+++ b/README.md
@@ -212,7 +212,7 @@ and set your `OAUTH_` environment variables.
 Visit https://developers.globus.org/ to set up your app. Ensure _Native App_ is
 unchecked and make sure the callback URL looks like:
 
-    https://[your-host]/oauth_callback
+    https://[your-host]/hub/oauth_callback
 
 Set scopes for authorization and transfer. The defaults include:
 
@@ -225,7 +225,7 @@ Set the above settings in your `jupyterhub_config`:
 from oauthenticator.globus import LocalGlobusOAuthenticator
 c.JupyterHub.authenticator_class = LocalGlobusOAuthenticator
 c.LocalGlobusOAuthenticator.enable_auth_state = True
-c.LocalGlobusOAuthenticator.oauth_callback_url = 'https://[your-host]/oauth_callback'
+c.LocalGlobusOAuthenticator.oauth_callback_url = 'https://[your-host]/hub/oauth_callback'
 c.LocalGlobusOAuthenticator.client_id = '[your app client id]'
 c.LocalGlobusOAuthenticator.client_secret = '[your app client secret]'
 ```

--- a/oauthenticator/globus.py
+++ b/oauthenticator/globus.py
@@ -7,7 +7,6 @@ import base64
 
 from tornado import gen, web
 from tornado.auth import OAuth2Mixin
-from tornado.concurrent import return_future
 from tornado.web import HTTPError
 
 from traitlets import List, Unicode, Bool
@@ -26,33 +25,11 @@ except:
 
 
 class GlobusMixin(OAuth2Mixin):
-    """
-    Use the globus_sdk to get the auth URL.
-    """
-    @return_future
-    def authorize_redirect(self, client=None, callback=None):
-        self.redirect(client.oauth2_get_authorize_url())
+    _OAUTH_AUTHORIZE_URL = 'https://auth.globus.org/v2/oauth2/authorize'
 
 
 class GlobusLoginHandler(OAuthLoginHandler, GlobusMixin):
-    """
-    The login handler sets the scope and provides the redirect URL.
-    The scope can be modified from the config.
-    """
-
-    def get(self):
-        redirect_uri = self.authenticator.get_callback_url(self)
-        client = self.authenticator.globus_portal_client()
-        state = self.get_state()
-        self.set_state_cookie(state)
-        client.oauth2_start_flow(
-            redirect_uri,
-            requested_scopes=' '.join(self.authenticator.scope),
-            refresh_tokens=self.authenticator.allow_refresh_tokens,
-            state=state
-        )
-        self.log.info('globus redirect: %r', redirect_uri)
-        self.authorize_redirect(client)
+    pass
 
 
 class GlobusLogoutHandler(LogoutHandler):

--- a/oauthenticator/globus.py
+++ b/oauthenticator/globus.py
@@ -219,11 +219,7 @@ class GlobusOAuthenticator(OAuthenticator):
         return url_path_join(base_url, 'logout')
 
     def get_handlers(self, app):
-        return [
-            (r'/oauth_login', self.login_handler),
-            (r'/oauth_callback', self.callback_handler),
-            (r'/logout', self.logout_handler),
-        ]
+        return super().get_handlers(app) + [(r'/logout', self.logout_handler)]
 
 
 class LocalGlobusOAuthenticator(LocalAuthenticator, GlobusOAuthenticator):

--- a/oauthenticator/globus.py
+++ b/oauthenticator/globus.py
@@ -11,10 +11,11 @@ from tornado.concurrent import return_future
 from tornado.web import HTTPError
 
 from traitlets import List, Unicode, Bool
+from jupyterhub.handlers import LogoutHandler
 from jupyterhub.auth import LocalAuthenticator
 from jupyterhub.utils import url_path_join
 
-from .oauth2 import OAuthLoginHandler, OAuthenticator, OAuthCallbackHandler
+from .oauth2 import OAuthLoginHandler, OAuthenticator
 
 
 try:
@@ -31,36 +32,6 @@ class GlobusMixin(OAuth2Mixin):
     @return_future
     def authorize_redirect(self, client=None, callback=None):
         self.redirect(client.oauth2_get_authorize_url())
-        callback()
-
-
-class GlobusOAuthCallbackHandler(OAuthCallbackHandler):
-    """This extra callback handler is needed to store transfer tokens
-    in auth_state. This is needed since there isn't a sensible way to
-    access the database through `authenticate`, although this may change
-    with the following issue:
-    https://github.com/jupyterhub/jupyterhub/issues/1063
-    globus tokens are saved in the database to persist server
-    restarts and closed browser windows. This ensures consistency -- whenever
-    the user is logged in, they will be able to spawn a notebook with tokens.
-    """
-    @gen.coroutine
-    def get(self):
-        username = yield self.authenticator.get_authenticated_user(self, None)
-
-        if username:
-            user = self.user_from_username(username)
-            self.set_globus_data(user)
-            self.set_login_cookie(user)
-            self.redirect(url_path_join(self.hub.server.base_url, 'home'))
-        else:
-            raise web.HTTPError(403)
-
-    def set_globus_data(self, user):
-        user.auth_state = {
-            'globus_data': self.authenticator.globus_data
-        }
-        self.db.commit()
 
 
 class GlobusLoginHandler(OAuthLoginHandler, GlobusMixin):
@@ -72,13 +43,49 @@ class GlobusLoginHandler(OAuthLoginHandler, GlobusMixin):
     def get(self):
         redirect_uri = self.authenticator.get_callback_url(self)
         client = self.authenticator.globus_portal_client()
+        state = self.get_state()
+        self.set_state_cookie(state)
         client.oauth2_start_flow(
             redirect_uri,
             requested_scopes=' '.join(self.authenticator.scope),
-            refresh_tokens=self.authenticator.allow_refresh_tokens
+            refresh_tokens=self.authenticator.allow_refresh_tokens,
+            state=state
         )
         self.log.info('globus redirect: %r', redirect_uri)
         self.authorize_redirect(client)
+
+
+class GlobusLogoutHandler(LogoutHandler):
+    """
+    Handle custom logout URLs and token revocation. If a custom logout url
+    is specified, the 'logout' button will log the user out of that identity
+    provider in addition to clearing the session with Jupyterhub, otherwise
+    only the Jupyterhub session is cleared.
+    """
+    @gen.coroutine
+    def get(self):
+        user = self.get_current_user()
+        if user:
+            if self.authenticator.revoke_tokens_on_logout:
+                self.clear_tokens(user)
+            self.clear_login_cookie()
+        if self.authenticator.logout_redirect_url:
+            self.redirect(self.authenticator.logout_redirect_url)
+        else:
+            super().get()
+
+    @gen.coroutine
+    def clear_tokens(self, user):
+        if not self.authenticator.revoke_tokens_on_logout:
+            return
+
+        state = yield user.get_auth_state()
+        if state:
+            self.authenticator.revoke_service_tokens(state.get('tokens'))
+            self.log.info('Logout: Revoked tokens for user "{}" services: {}'
+                          .format(user.name, ','.join(state['tokens'].keys())))
+            state['tokens'] = ''
+            user.save_auth_state(state)
 
 
 class GlobusOAuthenticator(OAuthenticator):
@@ -87,7 +94,7 @@ class GlobusOAuthenticator(OAuthenticator):
 
     login_service = 'Globus'
     login_handler = GlobusLoginHandler
-    callback_handler = GlobusOAuthCallbackHandler
+    logout_handler = GlobusLogoutHandler
 
     identity_provider = Unicode(help="""Restrict which institution a user
     can use to login (GlobusID, University of Hogwarts, etc.). This should
@@ -128,26 +135,35 @@ class GlobusOAuthenticator(OAuthenticator):
     def _globus_local_endpoint_default(self):
         return os.getenv('GLOBUS_LOCAL_ENDPOINT', '')
 
+    logout_redirect_url = \
+        Unicode(help="""URL for logging out.""").tag(config=True)
+
+    def _logout_redirect_url_default(self):
+        return os.getenv('LOGOUT_REDIRECT_URL', '')
+
+    revoke_tokens_on_logout = Bool(
+        help="""Revoke tokens so they cannot be used again. Single-user servers
+        MUST be restarted after logout in order to get a fresh working set of
+        tokens."""
+    ).tag(config=True)
+
+    def _revoke_tokens_on_logout_default(self):
+        return False
+
+    @gen.coroutine
     def pre_spawn_start(self, user, spawner):
         """Add tokens to the spawner whenever the spawner starts a notebook.
         This will allow users to create a transfer client:
         globus-sdk-python.readthedocs.io/en/stable/tutorial/#tutorial-step4
         """
-        if self.globus_local_endpoint:
-            spawner.environment.update(
-                {'GLOBUS_LOCAL_ENDPOINT': self.globus_local_endpoint}
-            )
-        if user.auth_state.get('globus_data'):
+        spawner.environment['GLOBUS_LOCAL_ENDPOINT'] = \
+            self.globus_local_endpoint
+        state = yield user.get_auth_state()
+        if state:
             globus_data = base64.b64encode(
-                pickle.dumps(user.auth_state['globus_data'])
+                pickle.dumps(state)
             )
             spawner.environment['GLOBUS_DATA'] = globus_data
-        else:
-            # This can happen when migrating old users with a valid
-            # Jupyterhub session that have never used this oauthenticator
-            self.log.error('Globus data not found, user will not be able '
-                           'to start transfers until they '
-                           're-authenticate.')
 
     def globus_portal_client(self):
         return globus_sdk.ConfidentialAppAuthClient(
@@ -172,11 +188,6 @@ class GlobusOAuthenticator(OAuthenticator):
         )
         # Doing the code for token for id_token exchange
         tokens = client.oauth2_exchange_code_for_tokens(code)
-        globus_data = {'client_id': self.client_id}
-        globus_data['tokens'] = {
-            tok: v for tok, v in tokens.by_resource_server.items()
-            if tok not in self.exclude_tokens
-        }
         id_token = tokens.decode_id_token(client)
         username, domain = id_token.get('preferred_username').split('@')
 
@@ -193,9 +204,26 @@ class GlobusOAuthenticator(OAuthenticator):
         return {
             'name': username,
             'auth_state': {
-                'globus_data': globus_data,
+                'client_id': self.client_id,
+                'tokens': {
+                    tok: v for tok, v in tokens.by_resource_server.items()
+                    if tok not in self.exclude_tokens
+                },
             }
         }
+
+    def revoke_service_tokens(self, services):
+        """Revoke live Globus access and refresh tokens. Revoking inert or
+        non-existent tokens does nothing. Services are defined by dicts
+        returned by tokens.by_resource_server, for example:
+        services = { 'transfer.api.globus.org': {'access_token': 'token'}, ...
+            <Additional services>...
+        }
+        """
+        client = self.globus_portal_client()
+        for service_data in services.values():
+            client.oauth2_revoke_token(service_data['access_token'])
+            client.oauth2_revoke_token(service_data['refresh_token'])
 
     def get_callback_url(self, handler=None):
         """
@@ -209,6 +237,16 @@ class GlobusOAuthenticator(OAuthenticator):
                             'to the config'
                             )
         return self.oauth_callback_url
+
+    def logout_url(self, base_url):
+        return url_path_join(base_url, 'logout')
+
+    def get_handlers(self, app):
+        return [
+            (r'/oauth_login', self.login_handler),
+            (r'/oauth_callback', self.callback_handler),
+            (r'/logout', self.logout_handler),
+        ]
 
 
 class LocalGlobusOAuthenticator(LocalAuthenticator, GlobusOAuthenticator):


### PR DESCRIPTION
The bug fix included in these changes adds the `state` parameter to the OAuth flow. Now that the base authenticator checks for `state`, the authenticator also now properly sets it. 

Since some new changes to `auth_state` for storing confidential user information, old code that stored this information manually has been removed.

New security features include setting a custom logout URL for a specific identity provider, and automatic token revocation whenever a user does a logout. Both of these options are configurable.