### PR TITLE
Making possible to specify custom claims for username in jupytherhub_config.py

### DIFF
--- a/oauthenticator/cilogon.py
+++ b/oauthenticator/cilogon.py
@@ -2,18 +2,11 @@
 
 Uses OAuth 2.0 with cilogon.org (override with CILOGON_HOST)
 
-Based on the GitHub plugin.
-
-Most of the code c/o Kyle Kelley (@rgbkrk)
-
-CILogon support by Adam Thornton (athornton@lsst.org)
-
 Caveats:
 
-- For user whitelist/admin purposes, username will be the sub claim.  This
-  is unlikely to work as a Unix userid.  Typically an actual implementation
-  will specify the identity provider and scopes sufficient to retrieve an
-  ePPN or other unique identifier more amenable to being used as a username.
+- For user whitelist/admin purposes, username will be the ePPN by default.
+  This may not work as a Unix userid, and normalization may be required
+  to turn the JupyterHub username into a Unix username.
 """
 
 
@@ -33,16 +26,6 @@ from jupyterhub.auth import LocalAuthenticator
 from .oauth2 import OAuthLoginHandler, OAuthenticator
 
 CILOGON_HOST = os.environ.get('CILOGON_HOST') or 'cilogon.org'
-
-
-def _api_headers():
-    return {"Accept": "application/json",
-            "User-Agent": "JupyterHub",
-            }
-
-
-def _add_access_token(access_token, params):
-    params["access_token"] = access_token
 
 
 class CILogonMixin(OAuth2Mixin):
@@ -126,7 +109,11 @@ class CILogonOAuthenticator(OAuthenticator):
 
         # Exchange the OAuth code for a CILogon Access Token
         # See: http://www.cilogon.org/oidc
-        headers = _api_headers()
+        headers = {
+            "Accept": "application/json",
+            "User-Agent": "JupyterHub",
+        }
+
         params = dict(
             client_id=self.client_id,
             client_secret=self.client_secret,
@@ -175,7 +162,7 @@ class CILogonOAuthenticator(OAuthenticator):
         return userdict
 
 
-class LocalGitHubOAuthenticator(LocalAuthenticator, CILogonOAuthenticator):
+class LocalCILogonOAuthenticator(LocalAuthenticator, CILogonOAuthenticator):
 
     """A version that mixes in local system user creation"""
     pass

--- a/oauthenticator/cilogon.py
+++ b/oauthenticator/cilogon.py
@@ -143,7 +143,6 @@ class CILogonOAuthenticator(OAuthenticator):
         resp = yield http_client.fetch(req)
         resp_json = json.loads(resp.body.decode('utf8', 'replace'))
 
-        self.log.info(json.dumps(resp_json, sort_keys=True, indent=4))
         username = resp_json.get(self.username_key)
         if not username:
             self.log.error("Username key %s not found in the response: %s",

--- a/oauthenticator/tests/test_cilogon.py
+++ b/oauthenticator/tests/test_cilogon.py
@@ -1,12 +1,6 @@
-import re
-import functools
 import json
-from io import BytesIO
 
 from pytest import fixture, mark
-from urllib.parse import urlparse, parse_qs
-from tornado.httpclient import HTTPRequest, HTTPResponse
-from tornado.httputil import HTTPHeaders
 
 from ..cilogon import CILogonOAuthenticator
 
@@ -16,7 +10,7 @@ from .mocks import setup_oauth_mock
 def user_model(username):
     """Return a user model"""
     return {
-        'sub': 'http://cilogon.org/dinosaurs/users/%s/1729' % username,
+        'eppn': username + '@serenity.space',
     }
 
 
@@ -38,12 +32,10 @@ def test_cilogon(cilogon_client):
     user_info = yield authenticator.authenticate(handler)
     print(json.dumps(user_info, sort_keys=True, indent=4))
     name = user_info['name']
-    assert name == 'http://cilogon.org/dinosaurs/users/wash/1729'
+    assert name == 'wash@serenity.space'
     auth_state = user_info['auth_state']
     assert 'access_token' in auth_state
     assert auth_state == {
         'access_token': auth_state['access_token'],
-        'cilogon_user': {
-            'sub': name
-        }
+        'cilogon_user': user_model('wash'),
     }


### PR DESCRIPTION
see #133

The provided tests pass, however I did not add a specific test for this per @minrk message regarding having some tests already (probably not pushed yet).

Hope I did "the right thing" since I was not familiar with the way configuration settings "pop up" from the `jupytherhub_config.py` to the classes which actually need them, so I made a few guesses.