### PR TITLE
Allow configuration for Generic OAuthenticator login_service

### DIFF
--- a/oauthenticator/generic.py
+++ b/oauthenticator/generic.py
@@ -32,7 +32,10 @@ class GenericLoginHandler(OAuthLoginHandler, GenericEnvMixin):
 
 class GenericOAuthenticator(OAuthenticator):
 
-    login_service = "GenericOAuth2"
+    login_service = Unicode(
+        "GenericOAuth2",
+        config=True
+    )
 
     login_handler = GenericLoginHandler
 


### PR DESCRIPTION
This is useful to specify the name of a custom OAuth provider.