### PR TITLE
Fix token_url default value and help

### DIFF
--- a/oauthenticator/generic.py
+++ b/oauthenticator/generic.py
@@ -61,9 +61,9 @@ class GenericOAuthenticator(OAuthenticator):
     )
 
     token_url = Unicode(
-        os.environ.get('OAUTH2_TOKEN_URL', 'GET'),
+        os.environ.get('OAUTH2_TOKEN_URL', ''),
         config=True,
-        help="Userdata method to get user data login information"
+        help="Token url to get the user token"
     )
 
     @gen.coroutine


### PR DESCRIPTION
These look wrong. A default value of GET makes no sense for an URL. Looks like it was just copy pasted from USERDATA_METHOD above.

Fixing with sane values.