### PR TITLE
[MRG] Add refresh token to auth_state if it is available

### DIFF
--- a/oauthenticator/generic.py
+++ b/oauthenticator/generic.py
@@ -106,6 +106,7 @@ class GenericOAuthenticator(OAuthenticator):
         resp_json = json.loads(resp.body.decode('utf8', 'replace'))
 
         access_token = resp_json['access_token']
+        refresh_token = resp_json.get('refresh_token', None)
         token_type = resp_json['token_type']
 
         # Determine who the logged in user is
@@ -134,6 +135,7 @@ class GenericOAuthenticator(OAuthenticator):
             'name': resp_json.get(self.username_key),
             'auth_state': {
                 'access_token': access_token,
+                'refresh_token': refresh_token,
                 'oauth_user': resp_json,
             }
         }

--- a/oauthenticator/tests/test_generic.py
+++ b/oauthenticator/tests/test_generic.py
@@ -37,5 +37,4 @@ def test_generic(generic_client):
     auth_state = user_info['auth_state']
     assert 'access_token' in auth_state
     assert 'oauth_user' in auth_state
-
-
+    assert 'refresh_token' in auth_state


### PR DESCRIPTION
If the OAuth2 server sends a refresh token, add it to the `auth_state`.