### PR TITLE
Scope needs to be an attribute of OpenShiftOAuthenticator class.

### DIFF
--- a/oauthenticator/openshift.py
+++ b/oauthenticator/openshift.py
@@ -28,7 +28,9 @@ class OpenShiftMixin(OAuth2Mixin):
 class OpenShiftLoginHandler(OAuthLoginHandler, OpenShiftMixin):
     # This allows `Service Accounts as OAuth Clients` scenario
     # https://docs.openshift.org/latest/architecture/additional_concepts/authentication.html#service-accounts-as-oauth-clients
-    scope=['user:info']
+    @property
+    def scope(self):
+        return self.authenticator.scope
 
 
 class OpenShiftOAuthenticator(OAuthenticator):
@@ -36,6 +38,8 @@ class OpenShiftOAuthenticator(OAuthenticator):
     login_service = "OpenShift"
 
     login_handler = OpenShiftLoginHandler
+
+    scope = ['user:info']
 
     @gen.coroutine
     def authenticate(self, handler, data=None):


### PR DESCRIPTION
Following directions in:

* https://github.com/jupyterhub/oauthenticator#openshift-setup

for how to use OpenShift authenticator would fail for case of using service account.

As noted in https://github.com/jupyterhub/oauthenticator/issues/165 this is because the scope attribute appears to be on the wrong class in the OpenShift authenticator implementation.

This PR, adds the scope to the ``OpenShiftOAuthenticator`` which once done results in everything then working.

In case the scope still needs to be on ``OpenShiftLoginHandler`` for some reason, like is done in the Google authenticator code, it was replaced with a property which references it from the ``OpenShiftOAuthenticator`` class.