### PR TITLE
Minor comment change.

### DIFF
--- a/oauthenticator/oauth2.py
+++ b/oauthenticator/oauth2.py
@@ -1,5 +1,5 @@
 """
-Base classes for Custom Authenticator to use GitHub OAuth with JupyterHub
+Base classes for Custom Authenticator to use OAuth with JupyterHub
 
 Most of the code c/o Kyle Kelley (@rgbkrk)
 """


### PR DESCRIPTION
Changed "GitHub OAuth" to "OAuth", given that base class works for multiple OAuth providers.