### PR TITLE
add moodle OAuth2

### DIFF
--- a/oauthenticator/moodle.py
+++ b/oauthenticator/moodle.py
@@ -1,0 +1,150 @@
+"""
+Custom Authenticator to use generic OAuth2 with JupyterHub
+"""
+
+
+import json
+import os
+import base64
+import urllib
+
+from tornado.auth import OAuth2Mixin
+from tornado import gen, web
+
+from tornado.httputil import url_concat
+from tornado.httpclient import HTTPRequest, AsyncHTTPClient
+
+from jupyterhub.auth import LocalAuthenticator
+
+from traitlets import Unicode, Dict
+
+from .oauth2 import OAuthLoginHandler, OAuthenticator
+
+
+class GenericEnvMixin(OAuth2Mixin):
+    _OAUTH_ACCESS_TOKEN_URL = os.environ.get('OAUTH2_TOKEN_URL', '')
+    _OAUTH_AUTHORIZE_URL = os.environ.get('OAUTH2_AUTHORIZE_URL', '')
+
+
+class GenericLoginHandler(OAuthLoginHandler, GenericEnvMixin):
+    pass
+
+
+class GenericOAuthenticator(OAuthenticator):
+
+    login_service = Unicode(
+        "SAGE Campus",
+        config=True
+    )
+
+    login_handler = GenericLoginHandler
+
+    userdata_url = Unicode(
+        os.environ.get('OAUTH2_USERDATA_URL', ''),
+        config=True,
+        help="Userdata url to get user data login information"
+    )
+    token_url = Unicode(
+        os.environ.get('OAUTH2_TOKEN_URL', ''),
+        config=True,
+        help="Access token endpoint URL"
+    )
+
+    username_key = Unicode(
+        os.environ.get('OAUTH2_USERNAME_KEY', 'username'),
+        config=True,
+        help="Userdata username key from returned json for USERDATA_URL"
+    )
+    userdata_params = Dict(
+        os.environ.get('OAUTH2_USERDATA_PARAMS', {}),
+        help="Userdata params to get user data login information"
+    ).tag(config=True)
+
+    userdata_method = Unicode(
+        os.environ.get('OAUTH2_USERDATA_METHOD', 'POST'),
+        config=True,
+        help="Userdata method to get user data login information"
+    )
+
+    @gen.coroutine
+    def authenticate(self, handler, data=None):
+        code = handler.get_argument("code")
+        # TODO: Configure the curl_httpclient for tornado
+        http_client = AsyncHTTPClient()
+
+        params = dict(
+            redirect_uri=self.get_callback_url(handler),
+            code=code,
+            grant_type='authorization_code',
+            client_id=self.client_id,
+            client_secret=self.client_secret,
+            scope='user_info'
+        )
+
+        url = self.token_url
+
+        b64key = base64.b64encode(
+            bytes(
+                "{}:{}".format(self.client_id, self.client_secret),
+                "utf8"
+            )
+        )
+
+        headers = {
+            "Accept": "application/json",
+            "User-Agent": "JupyterHub",
+            "Authorization": "Basic {}".format(b64key.decode("utf8"))
+        }
+        req = HTTPRequest(url,
+                          method="POST",
+                          headers=headers,
+                          # Body is required for a POST...
+                          body=urllib.parse.urlencode(params)
+                          )
+
+        resp = yield http_client.fetch(req)
+
+        resp_json = json.loads(resp.body.decode('utf8', 'replace'))
+
+        access_token = resp_json['access_token']
+        token_type = resp_json['token_type']
+
+        # Determine who the logged in user is
+        headers = {
+            "Accept": "application/json",
+            "User-Agent": "JupyterHub",
+            "Authorization": "{} {}".format(token_type, access_token)
+        }
+
+        url = url_concat(self.userdata_url, self.userdata_params)
+
+        userdata_params = dict(access_token=access_token)
+
+        req = HTTPRequest(url,
+                          method=self.userdata_method,
+                          headers=headers,
+                          body=urllib.parse.urlencode(userdata_params)
+                          )
+        resp = yield http_client.fetch(req)
+        resp_json = json.loads(resp.body.decode('utf8', 'replace'))
+
+        if not resp_json.get(self.username_key):
+            self.log.error(
+                "OAuth user contains no key %s: %s",
+                self.username_key,
+                resp_json)
+            return
+
+        return {
+            'name': resp_json.get(self.username_key),
+            'auth_state': {
+                'access_token': access_token,
+                'oauth_user': resp_json,
+            }
+        }
+
+
+class LocalGenericOAuthenticator(LocalAuthenticator, GenericOAuthenticator):
+
+    """A version that mixes in local system user creation"""
+    pass

--- a/oauthenticator/moodle.py
+++ b/oauthenticator/moodle.py
@@ -1,5 +1,7 @@
 """
-Custom Authenticator to use generic OAuth2 with JupyterHub
+Custom Authenticator for Moodle to use OAuth2 with JupyterHub.
+Configured for use with Moodle OAuth2 Server Plugin from
+https://github.com/projectestac/moodle-local_oauth .
 """
 
 
@@ -21,33 +23,28 @@ from traitlets import Unicode, Dict
 from .oauth2 import OAuthLoginHandler, OAuthenticator
 
 
-class GenericEnvMixin(OAuth2Mixin):
+class MoodleEnvMixin(OAuth2Mixin):
     _OAUTH_ACCESS_TOKEN_URL = os.environ.get('OAUTH2_TOKEN_URL', '')
     _OAUTH_AUTHORIZE_URL = os.environ.get('OAUTH2_AUTHORIZE_URL', '')
 
 
-class GenericLoginHandler(OAuthLoginHandler, GenericEnvMixin):
+class MoodleLoginHandler(OAuthLoginHandler, MoodleEnvMixin):
     pass
 
 
-class GenericOAuthenticator(OAuthenticator):
+class MoodleOAuthenticator(OAuthenticator):
 
     login_service = Unicode(
-        "SAGE Campus",
+        "Moodle",
         config=True
     )
 
-    login_handler = GenericLoginHandler
+    login_handler = MoodleLoginHandler
 
     userdata_url = Unicode(
         os.environ.get('OAUTH2_USERDATA_URL', ''),
         config=True,
         help="Userdata url to get user data login information"
-    )
-    token_url = Unicode(
-        os.environ.get('OAUTH2_TOKEN_URL', ''),
-        config=True,
-        help="Access token endpoint URL"
     )
 
     username_key = Unicode(
@@ -55,15 +52,11 @@ class GenericOAuthenticator(OAuthenticator):
         config=True,
         help="Userdata username key from returned json for USERDATA_URL"
     )
-    userdata_params = Dict(
-        os.environ.get('OAUTH2_USERDATA_PARAMS', {}),
-        help="Userdata params to get user data login information"
-    ).tag(config=True)
 
-    userdata_method = Unicode(
-        os.environ.get('OAUTH2_USERDATA_METHOD', 'POST'),
+    token_url = Unicode(
+        os.environ.get('OAUTH2_TOKEN_URL', ''),
         config=True,
-        help="Userdata method to get user data login information"
+        help="Access token endpoint URL"
     )
 
     @gen.coroutine
@@ -116,14 +109,10 @@ class GenericOAuthenticator(OAuthenticator):
             "Authorization": "{} {}".format(token_type, access_token)
         }
 
-        url = url_concat(self.userdata_url, self.userdata_params)
-
-        userdata_params = dict(access_token=access_token)
-
-        req = HTTPRequest(url,
-                          method=self.userdata_method,
+        req = HTTPRequest(self.userdata_url,
+                          method="POST",
                           headers=headers,
-                          body=urllib.parse.urlencode(userdata_params)
+                          body=urllib.parse.urlencode({'access_token': access_token})
                           )
         resp = yield http_client.fetch(req)
         resp_json = json.loads(resp.body.decode('utf8', 'replace'))
@@ -144,7 +133,7 @@ class GenericOAuthenticator(OAuthenticator):
         }
 
 
-class LocalGenericOAuthenticator(LocalAuthenticator, GenericOAuthenticator):
+class LocalMoodleOAuthenticator(LocalAuthenticator, MoodleOAuthenticator):
 
     """A version that mixes in local system user creation"""
     pass

--- a/oauthenticator/moodle.py
+++ b/oauthenticator/moodle.py
@@ -74,7 +74,10 @@ class MoodleOAuthenticator(OAuthenticator):
             scope='user_info'
         )
 
-        url = self.token_url
+        if self.token_url:
+            url = self.token_url
+        else:
+            raise ValueError("Please set the OAUTH2_TOKEN_URL environment variable")
 
         b64key = base64.b64encode(
             bytes(

--- a/oauthenticator/tests/test_moodle.py
+++ b/oauthenticator/tests/test_moodle.py
@@ -1,0 +1,37 @@
+from pytest import fixture, mark
+
+from ..moodle import MoodleOAuthenticator
+
+from .mocks import setup_oauth_mock
+
+
+def user_model(username):
+    """Return a user model"""
+    return {
+        'metadata': {
+            'name': username,
+        }
+    }
+
+
+@fixture
+def moodle_client(client):
+    setup_oauth_mock(client,
+                     host=['localhost'],
+                     access_token_path='/oauth/token',
+                     user_path='/oauth/user',
+                     )
+    return client
+
+
+@mark.gen_test
+def test_moodle(moodle_client):
+    authenticator = MoodleOAuthenticator()
+    handler = moodle_client.handler_for_user(user_model('test.user'))
+    user_info = yield authenticator.authenticate(handler)
+    assert sorted(user_info) == ['auth_state', 'name']
+    name = user_info['name']
+    assert name == 'test.user'
+    auth_state = user_info['auth_state']
+    assert 'access_token' in auth_state
+    assert 'oauth_user' in auth_state

--- a/oauthenticator/tests/test_moodle.py
+++ b/oauthenticator/tests/test_moodle.py
@@ -13,11 +13,17 @@ def user_model(username):
         }
     }
 
+def Authenticator():
+    return MoodleOAuthenticator(
+        token_url='http://moodledomain.com/local/oauth/token.php',
+        userdata_url='http://moodledomain.com/local/oauth/user_info.php'
+    )
+
 
 @fixture
 def moodle_client(client):
     setup_oauth_mock(client,
-                     host=['localhost'],
+                     host=['moodledomain.com'],
                      access_token_path='/oauth/token',
                      user_path='/oauth/user',
                      )
@@ -26,7 +32,7 @@ def moodle_client(client):
 
 @mark.gen_test
 def test_moodle(moodle_client):
-    authenticator = MoodleOAuthenticator()
+    authenticator = Authenticator()
     handler = moodle_client.handler_for_user(user_model('test.user'))
     user_info = yield authenticator.authenticate(handler)
     assert sorted(user_info) == ['auth_state', 'name']


### PR DESCRIPTION
I've been able to get OAuth2 running for Moodle platforms and the [oauth plugin](https://github.com/projectestac/moodle-local_oauth) .

It only needed slight modifications to the generic oauth, so I'm not sure if you'd rather just generalize the generic a bit more or add this. Specifically, the `params` dict for the token and the access token for the `user_info` post.

I'm also not sure if this was all possible through only modifications to the `jupyterhub_config.py`, but I couldn't figure out how to add the above into that.