### PR TITLE
Override normalize_username in MWOAuthenticator to allow case to be kept FIX:#168

### DIFF
--- a/oauthenticator/mediawiki.py
+++ b/oauthenticator/mediawiki.py
@@ -99,6 +99,13 @@ class MWOAuthenticator(OAuthenticator):
         config=True,
     )
     executor = Any()
+
+    def normalize_username(self, username):
+        """
+        Override normalize_username to avoid lowercasing usernames
+        """
+        return username
+
     def _executor_default(self):
         return ThreadPoolExecutor(self.executor_threads)
 


### PR DESCRIPTION
FIX:#168
Override normalize_username in MWOAuthenticator to allow case to be kept