### PR TITLE
add moodle support in generic

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ OAuthenticator currently supports the following authentication services:
 - [Globus](#globus-setup)
 - [Google](#google-setup)
 - [MediaWiki](oauthenticator/mediawiki.py)
+- [Moodle](#moodle-setup)
 - [Okpy](#okpyauthenticator)
 - [OpenShift](#openshift-setup)
 
@@ -347,3 +348,30 @@ Use `c.GlobusOAuthenticator.exclude` to prevent tokens from being passed into a
 users environment. By default, `auth.globus.org` is excluded but `transfer.api.globus.org`
 is allowed. If you want to disable transfers, modify `c.GlobusOAuthenticator.scope`
 instead of `c.GlobusOAuthenticator.exclude` to avoid procuring unnecessary tokens.
+
+## Moodle Setup
+
+First install the [OAuth2 Server Plugin](https://github.com/projectestac/moodle-local_oauth) for Moodle.
+
+Use the `GenericOAuthenticator` for Jupyterhub by editing your `jupyterhub_config.py` accordingly:
+
+```python
+from oauthenticator.generic import GenericOAuthenticator
+c.JupyterHub.authenticator_class = GenericOAuthenticator
+
+c.GenericOAuthenticator.oauth_callback_url = 'http://YOUR-JUPYTERHUB.com/hub/oauth_callback'
+c.GenericOAuthenticator.client_id = 'MOODLE-CLIENT-ID'
+c.GenericOAuthenticator.client_secret = 'MOODLE-CLIENT-SECRET-KEY'
+c.GenericOAuthenticator.login_service = 'NAME-OF-SERVICE'
+c.GenericOAuthenticator.userdata_url = 'http://YOUR-MOODLE-DOMAIN.com/local/oauth/user_info.php'
+c.GenericOAuthenticator.token_url = 'http://YOUR-MOODLE-DOMAIN.com/local/oauth/token.php'
+c.GenericOAuthenticator.userdata_method = 'POST'
+c.GenericOAuthenticator.extra_params = {
+    'scope': 'user_info',
+    'client_id': 'MOODLE-CLIENT-ID',
+    'client_secret': 'MOODLE-CLIENT-SECRET-KEY'}
+```
+
+And set your environmental variable `_OAUTH_AUTHORIZE_URL` to:
+
+`http://YOUR-MOODLE-DOMAIN.com/local/oauth/login.php?client_id=MOODLE-CLIENT-ID&response_type=code`

--- a/oauthenticator/generic.py
+++ b/oauthenticator/generic.py
@@ -49,6 +49,10 @@ class GenericOAuthenticator(OAuthenticator):
         config=True,
         help="Access token endpoint URL"
     )
+    extra_params = Dict(
+        os.environ.get('OAUTH2_AUTHENTICATION_PARAMS', {}),
+        help="Extra parameters for first POST request"
+    ).tag(config=True)
 
     username_key = Unicode(
         os.environ.get('OAUTH2_USERNAME_KEY', 'username'),
@@ -77,6 +81,7 @@ class GenericOAuthenticator(OAuthenticator):
             code=code,
             grant_type='authorization_code'
         )
+        params.update(self.extra_params)
 
         if self.token_url:
             url = self.token_url
@@ -124,6 +129,7 @@ class GenericOAuthenticator(OAuthenticator):
         req = HTTPRequest(url,
                           method=self.userdata_method,
                           headers=headers,
+                          body=urllib.parse.urlencode({'access_token': access_token})
                           )
         resp = yield http_client.fetch(req)
         resp_json = json.loads(resp.body.decode('utf8', 'replace'))


### PR DESCRIPTION
Added functionality to specify additional parameters for the first POST request. The Moodle auth requires a `scope` to be defined, as well as sending the `client_id` and `client_secret` as parameters (see README changes).

Also need a body if the last request is going to be POST (default is set to GET now). Moodle requires a POST request with the `access_token` at the end.

I tried to be as minimally invasive as possible here. I'm not sure if adding in the body for the last request will break any other generic uses, I think that's the only change that would. I've tested this with Moodle but no other generic deployments.