### PR TITLE
Fix auth_state for Zero-To-Jupyterhub on Globus Auth

### DIFF
--- a/oauthenticator/globus.py
+++ b/oauthenticator/globus.py
@@ -140,7 +140,7 @@ class GlobusOAuthenticator(OAuthenticator):
             globus_data = base64.b64encode(
                 pickle.dumps(state)
             )
-            spawner.environment['GLOBUS_DATA'] = globus_data
+            spawner.environment['GLOBUS_DATA'] = globus_data.decode('utf-8')
 
     def globus_portal_client(self):
         return globus_sdk.ConfidentialAppAuthClient(


### PR DESCRIPTION
Zero-To-Jupyterhub differs slightly in that it serializes auth_state
data in JSON before sending it off to a user's newly created pod.
This will fail if any of the data isn't JSON-serializable. This
change simply encodes it to be JSON friendly. The regular Jupyterhub
does not send auth_state data to the spawner as JSON so it isn't
affected by this bug.