### PR TITLE
Bug fix for Globus when user logs in with an Identity Provider Namespace

### DIFF
--- a/oauthenticator/globus.py
+++ b/oauthenticator/globus.py
@@ -166,7 +166,10 @@ class GlobusOAuthenticator(OAuthenticator):
         # Doing the code for token for id_token exchange
         tokens = client.oauth2_exchange_code_for_tokens(code)
         id_token = tokens.decode_id_token(client)
-        username, domain = id_token.get('preferred_username').split('@')
+        id_chunks = id_token.get('preferred_username').split('@')
+        # It's possible for identity provider domains to be namespaced
+        # https://docs.globus.org/api/auth/specification/#identity_provider_namespaces # noqa
+        username, domain = id_chunks[0], '@'.join(id_chunks[1:])
 
         if self.identity_provider and domain != self.identity_provider:
             raise HTTPError(

--- a/oauthenticator/globus.py
+++ b/oauthenticator/globus.py
@@ -166,10 +166,9 @@ class GlobusOAuthenticator(OAuthenticator):
         # Doing the code for token for id_token exchange
         tokens = client.oauth2_exchange_code_for_tokens(code)
         id_token = tokens.decode_id_token(client)
-        id_chunks = id_token.get('preferred_username').split('@')
         # It's possible for identity provider domains to be namespaced
         # https://docs.globus.org/api/auth/specification/#identity_provider_namespaces # noqa
-        username, domain = id_chunks[0], '@'.join(id_chunks[1:])
+        username, domain = id_token.get('preferred_username').split('@', 1)
 
         if self.identity_provider and domain != self.identity_provider:
             raise HTTPError(

--- a/oauthenticator/tests/test_globus.py
+++ b/oauthenticator/tests/test_globus.py
@@ -96,6 +96,18 @@ def test_restricted_domain(globus_client, mock_globus_sdk):
 
 
 @mark.gen_test
+def test_namespaced_domain(globus_client, mock_globus_sdk):
+    mock_globus_sdk.id_token = {'preferred_username':
+                                'wash@legitshipping.com@serenity.com'}
+    authenticator = GlobusOAuthenticator()
+    # Allow any idp
+    authenticator.identity_provider = ''
+    handler = globus_client.handler_for_user(user_model('wash'))
+    data = yield authenticator.authenticate(handler)
+    assert data['name'] == 'wash'
+
+
+@mark.gen_test
 def test_token_exclusion(globus_client, mock_globus_sdk):
     authenticator = GlobusOAuthenticator()
     authenticator.exclude_tokens = [


### PR DESCRIPTION
Previously, the Globus Oauthenticator only expected usernames like `johndoe@uchicago.edu`, but it's also possible for Identity Providers to namespace their domains and log users in with usernames like `johndoe@uchicago.edu@provider.org`. 

More documentation: https://docs.globus.org/api/auth/specification/#identity_provider_namespaces