### PR TITLE
[generic] remove unused userdata_method body

### DIFF
--- a/oauthenticator/generic.py
+++ b/oauthenticator/generic.py
@@ -137,7 +137,6 @@ class GenericOAuthenticator(OAuthenticator):
                           method=self.userdata_method,
                           headers=headers,
                           validate_cert=self.tls_verify,
-                          body=urllib.parse.urlencode({'access_token': access_token})
                           )
         resp = yield http_client.fetch(req)
         resp_json = json.loads(resp.body.decode('utf8', 'replace'))


### PR DESCRIPTION
since userdata_method is GET, having a body doesn't make sense. The auth info is already passed in the Authorization header.

closes #197