### PR TITLE
Removed incorrect body being sent with GET request to USERDATA_URL

### DIFF
--- a/oauthenticator/generic.py
+++ b/oauthenticator/generic.py
@@ -136,9 +136,7 @@ class GenericOAuthenticator(OAuthenticator):
         req = HTTPRequest(url,
                           method=self.userdata_method,
                           headers=headers,
-                          validate_cert=self.tls_verify,
-                          body=urllib.parse.urlencode({'access_token': access_token})
-                          )
+                          validate_cert=self.tls_verify)
         resp = yield http_client.fetch(req)
         resp_json = json.loads(resp.body.decode('utf8', 'replace'))
 


### PR DESCRIPTION
Last change is creating an issue as USERDATA_URL is by default a GET.  This fixes it for me.  Perhaps more logic around support for whether config is POST or GET and set as parameter or body