### PR TITLE
Allow a list of email domains with Google OAuth 2.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -189,12 +189,17 @@ Then, add the following to your `jupyterhub_config.py` file:
     from oauthenticator.google import GoogleOAuthenticator
     c.JupyterHub.authenticator_class = GoogleOAuthenticator
 
-For a Google Apps domain you can set:
-
+By default, any domain is allowed to login but you can restrict authorized domains with a list (recommended):
 ```python
-c.GoogleOAuthenticator.hosted_domain = 'mycollege.edu'
+c.GoogleOAuthenticator.hosted_domain = ['mycollege.edu', 'mycompany.com']
+```
+
+You can customize the sign in button text:
+```python
 c.GoogleOAuthenticator.login_service = 'My College'
 ```
+
+If you don't set 
 
 ## OpenShift Setup
 

--- a/README.md
+++ b/README.md
@@ -194,12 +194,10 @@ By default, any domain is allowed to login but you can restrict authorized domai
 c.GoogleOAuthenticator.hosted_domain = ['mycollege.edu', 'mycompany.com']
 ```
 
-You can customize the sign in button text:
+You can customize the sign in button text (optional):
 ```python
 c.GoogleOAuthenticator.login_service = 'My College'
 ```
-
-If you don't set 
 
 ## OpenShift Setup
 

--- a/oauthenticator/google.py
+++ b/oauthenticator/google.py
@@ -11,7 +11,7 @@ from tornado import gen
 from tornado.auth import GoogleOAuth2Mixin
 from tornado.web import HTTPError
 
-from traitlets import Unicode, List, default
+from traitlets import Unicode, List, default, validate
 
 from jupyterhub.auth import LocalAuthenticator
 from jupyterhub.utils import url_path_join
@@ -41,11 +41,32 @@ class GoogleOAuthenticator(OAuthenticator, GoogleOAuth2Mixin):
         return ['openid', 'email']
 
     hosted_domain = List(
-        # Convert String to List of one element
-        [os.environ.get('HOSTED_DOMAIN', '')],
+        Unicode(),
         config=True,
         help="""List of domains used to restrict sign-in, e.g. mycollege.edu"""
     )
+
+    @default('hosted_domain')
+    def _hosted_domain_from_env(self):
+        domains = []
+        for domain in os.environ.get('HOSTED_DOMAIN', '').split(';'):
+            if domain:
+                # check falsy to avoid trailing separators
+                # adding empty domains
+                domains.append(domain)
+        return domains
+
+    @validate('hosted_domain')
+    def _cast_hosted_domain(self, proposal):
+        """handle backward-compatibility with hosted_domain is a single domain as a string"""
+        if isinstance(proposal.value, str):
+            # pre-0.9 hosted_domain was a string
+            # set it to a single item list
+            # (or if it's empty, an empty list)
+            if proposal.value == '':
+                return []
+            return [proposal.value]
+        return proposal.value
 
     login_service = Unicode(
         os.environ.get('LOGIN_SERVICE', 'Google'),
@@ -77,7 +98,7 @@ class GoogleOAuthenticator(OAuthenticator, GoogleOAuth2Mixin):
             raise HTTPError(500, 'Google authentication failed')
 
         bodyjs = json.loads(response.body.decode())
-        user_email = bodyjs['email']
+        user_email = username = bodyjs['email']
         user_email_domain = user_email.split('@')[1]
 
         if not bodyjs['verified_email']:
@@ -86,15 +107,17 @@ class GoogleOAuthenticator(OAuthenticator, GoogleOAuth2Mixin):
                 "Google email {} not verified".format(user_email)
             )
 
-        if (self.hosted_domain != [''] and (
+        if self.hosted_domain:
+            if (
                 user_email_domain not in self.hosted_domain or
-                bodyjs['hd'] not in self.hosted_domain)):
-            self.log.warning("Google OAuth unauthorized domain attempt: %s", user_email)
-            raise HTTPError(403,
-                "Google account domain @{} not authorized.".format(user_email_domain)
-            )
-        else:
-            username = user_email.split('@')[0]
+                bodyjs['hd'] not in self.hosted_domain
+            ):
+                self.log.warning("Google OAuth unauthorized domain attempt: %s", user_email)
+                raise HTTPError(403,
+                    "Google account domain @{} not authorized.".format(user_email_domain)
+                )
+            else:
+                username = user_email.split('@')[0]
 
         return {
             'name': username,

--- a/oauthenticator/google.py
+++ b/oauthenticator/google.py
@@ -6,7 +6,6 @@ Derived from the GitHub OAuth authenticator.
 
 import os
 import json
-import sys
 
 from tornado import gen
 from tornado.auth import GoogleOAuth2Mixin

--- a/oauthenticator/google.py
+++ b/oauthenticator/google.py
@@ -116,7 +116,8 @@ class GoogleOAuthenticator(OAuthenticator, GoogleOAuth2Mixin):
                 raise HTTPError(403,
                     "Google account domain @{} not authorized.".format(user_email_domain)
                 )
-            else:
+            if len(self.hosted_domain) == 1:
+                # unambiguous domain, use only base name
                 username = user_email.split('@')[0]
 
         return {

--- a/oauthenticator/google.py
+++ b/oauthenticator/google.py
@@ -10,7 +10,6 @@ import json
 from tornado import gen
 from tornado.auth import GoogleOAuth2Mixin
 from tornado.web import HTTPError
-from tornado.log import app_log
 
 from traitlets import Unicode, Tuple, default
 

--- a/oauthenticator/google.py
+++ b/oauthenticator/google.py
@@ -11,7 +11,7 @@ from tornado import gen
 from tornado.auth import GoogleOAuth2Mixin
 from tornado.web import HTTPError
 
-from traitlets import Unicode, List, Tuple, default, validate
+from traitlets import Unicode, List, default
 
 from jupyterhub.auth import LocalAuthenticator
 from jupyterhub.utils import url_path_join

--- a/oauthenticator/tests/test_google.py
+++ b/oauthenticator/tests/test_google.py
@@ -12,7 +12,7 @@ def user_model(email):
     return {
         'email': email,
         'hd': email.split('@')[1],
-        'verified_email': true
+        'verified_email': True
     }
 
 import re

--- a/oauthenticator/tests/test_google.py
+++ b/oauthenticator/tests/test_google.py
@@ -45,7 +45,7 @@ def test_google(google_client):
     user_info = yield authenticator.authenticate(handler)
     assert sorted(user_info) == ['auth_state', 'name']
     name = user_info['name']
-    assert name == 'fake@email.com'
+    assert name == 'fake'
     auth_state = user_info['auth_state']
     assert 'access_token' in auth_state
     assert 'google_user' in auth_state

--- a/oauthenticator/tests/test_google.py
+++ b/oauthenticator/tests/test_google.py
@@ -40,7 +40,7 @@ def google_client(client):
 
 @mark.gen_test
 def test_google(google_client):
-    authenticator = GoogleOAuthenticator(hosted_domain=('email.com'))
+    authenticator = GoogleOAuthenticator(hosted_domain=('email.com', 'mycollege.edu'))
     handler = google_client.handler_for_user(user_model('fake@email.com'))
     user_info = yield authenticator.authenticate(handler)
     assert sorted(user_info) == ['auth_state', 'name']

--- a/oauthenticator/tests/test_google.py
+++ b/oauthenticator/tests/test_google.py
@@ -40,12 +40,12 @@ def google_client(client):
 
 @mark.gen_test
 def test_google(google_client):
-    authenticator = GoogleOAuthenticator(hosted_domain=('email.com', 'mycollege.edu'))
+    authenticator = GoogleOAuthenticator()
     handler = google_client.handler_for_user(user_model('fake@email.com'))
     user_info = yield authenticator.authenticate(handler)
     assert sorted(user_info) == ['auth_state', 'name']
     name = user_info['name']
-    assert name == 'fake'
+    assert name == 'fake@email.com'
     auth_state = user_info['auth_state']
     assert 'access_token' in auth_state
     assert 'google_user' in auth_state
@@ -54,7 +54,7 @@ def test_google(google_client):
 
 @mark.gen_test
 def test_hosted_domain(google_client):
-    authenticator = GoogleOAuthenticator(hosted_domain=('email.com', 'mycollege.edu'))
+    authenticator = GoogleOAuthenticator(hosted_domain=['email.com', 'mycollege.edu'])
 
     handler = google_client.handler_for_user(user_model('fake@email.com'))#, authenticator)
     user_info = yield authenticator.authenticate(handler)

--- a/oauthenticator/tests/test_google.py
+++ b/oauthenticator/tests/test_google.py
@@ -53,7 +53,7 @@ def test_google(google_client):
 
 @mark.gen_test
 def test_hosted_domain(google_client):
-    authenticator = GoogleOAuthenticator(hosted_domain='email.com')
+    authenticator = GoogleOAuthenticator(hosted_domain=('email.com', 'gmail.com'))
     handler = google_client.handler_for_user(user_model('fake@email.com'))#, authenticator)
     user_info = yield authenticator.authenticate(handler)
     name = user_info['name']

--- a/oauthenticator/tests/test_google.py
+++ b/oauthenticator/tests/test_google.py
@@ -12,6 +12,7 @@ def user_model(email):
     return {
         'email': email,
         'hd': email.split('@')[1],
+        'verified_email': true
     }
 
 import re
@@ -53,15 +54,19 @@ def test_google(google_client):
 
 @mark.gen_test
 def test_hosted_domain(google_client):
-    authenticator = GoogleOAuthenticator(hosted_domain=('email.com', 'gmail.com'))
+    authenticator = GoogleOAuthenticator(hosted_domain=('email.com', 'mycollege.edu'))
+
     handler = google_client.handler_for_user(user_model('fake@email.com'))#, authenticator)
     user_info = yield authenticator.authenticate(handler)
     name = user_info['name']
     assert name == 'fake'
 
+    handler = google_client.handler_for_user(user_model('fake2@mycollege.edu'))#, authenticator)
+    user_info = yield authenticator.authenticate(handler)
+    name = user_info['name']
+    assert name == 'fake2'
+
     handler = google_client.handler_for_user(user_model('notallowed@notemail.com'))
     with raises(HTTPError) as exc:
         name = yield authenticator.authenticate(handler)
     assert exc.value.status_code == 403
-
-

--- a/oauthenticator/tests/test_google.py
+++ b/oauthenticator/tests/test_google.py
@@ -46,22 +46,21 @@ async def test_google(google_client):
     user_info = await authenticator.authenticate(handler)
     assert sorted(user_info) == ['auth_state', 'name']
     name = user_info['name']
-    assert name == 'fake'
+    assert name == 'fake@email.com'
     auth_state = user_info['auth_state']
     assert 'access_token' in auth_state
     assert 'google_user' in auth_state
 
 
-
 async def test_hosted_domain(google_client):
     authenticator = GoogleOAuthenticator(hosted_domain=['email.com', 'mycollege.edu'])
-    handler = google_client.handler_for_user(user_model('fake@email.com'))#, authenticator)
+    handler = google_client.handler_for_user(user_model('fake@email.com'))
     user_info = await authenticator.authenticate(handler)
     name = user_info['name']
     assert name == 'fake'
 
-    handler = google_client.handler_for_user(user_model('fake2@mycollege.edu'))#, authenticator)
-    user_info = yield authenticator.authenticate(handler)
+    handler = google_client.handler_for_user(user_model('fake2@mycollege.edu'))
+    user_info = await authenticator.authenticate(handler)
     name = user_info['name']
     assert name == 'fake2'
 

--- a/oauthenticator/tests/test_google.py
+++ b/oauthenticator/tests/test_google.py
@@ -40,7 +40,7 @@ def google_client(client):
 
 @mark.gen_test
 def test_google(google_client):
-    authenticator = GoogleOAuthenticator()
+    authenticator = GoogleOAuthenticator(hosted_domain=('email.com'))
     handler = google_client.handler_for_user(user_model('fake@email.com'))
     user_info = yield authenticator.authenticate(handler)
     assert sorted(user_info) == ['auth_state', 'name']


### PR DESCRIPTION
Rework of #80 
Addressing issue #63 

New features:
* Allows multiple Google OAuth email domains
* Checks for `verified_email` in Google OAuth response
* Log unauthorized attempts as warnings (and not errors)

Sidenotes:
* User `john.doe@domain1.com` and `john.doe@domain2.org` end up with the same jupyterhub user `john.doe` to avoid branking changes