### PR TITLE
Scope can be an array, so we need to handle that case as well

### DIFF
--- a/oauthenticator/generic.py
+++ b/oauthenticator/generic.py
@@ -120,7 +120,9 @@ class GenericOAuthenticator(OAuthenticator):
         access_token = resp_json['access_token']
         refresh_token = resp_json.get('refresh_token', None)
         token_type = resp_json['token_type']
-        scope = (resp_json.get('scope', '')).split(' ')
+	scope = resp_json.get('scope', '')
+        if (isinstance(scope, basestring)):
+                scope = (resp_json.get('scope', '')).split(' ')        
 
         # Determine who the logged in user is
         headers = {

--- a/oauthenticator/generic.py
+++ b/oauthenticator/generic.py
@@ -121,7 +121,7 @@ class GenericOAuthenticator(OAuthenticator):
         refresh_token = resp_json.get('refresh_token', None)
         token_type = resp_json['token_type']
         scope = resp_json.get('scope', '')
-        if (isinstance(scope, str):
+        if (isinstance(scope, str)):
                 scope = scope.split(' ')        
 
         # Determine who the logged in user is

--- a/oauthenticator/generic.py
+++ b/oauthenticator/generic.py
@@ -120,7 +120,7 @@ class GenericOAuthenticator(OAuthenticator):
         access_token = resp_json['access_token']
         refresh_token = resp_json.get('refresh_token', None)
         token_type = resp_json['token_type']
-	scope = resp_json.get('scope', '')
+        scope = resp_json.get('scope', '')
         if (isinstance(scope, basestring)):
                 scope = (resp_json.get('scope', '')).split(' ')        
 

--- a/oauthenticator/generic.py
+++ b/oauthenticator/generic.py
@@ -121,7 +121,7 @@ class GenericOAuthenticator(OAuthenticator):
         refresh_token = resp_json.get('refresh_token', None)
         token_type = resp_json['token_type']
         scope = resp_json.get('scope', '')
-        if (isinstance(scope, basestring)):
+        if (isinstance(scope, str):
                 scope = scope.split(' ')        
 
         # Determine who the logged in user is

--- a/oauthenticator/generic.py
+++ b/oauthenticator/generic.py
@@ -122,7 +122,7 @@ class GenericOAuthenticator(OAuthenticator):
         token_type = resp_json['token_type']
         scope = resp_json.get('scope', '')
         if (isinstance(scope, basestring)):
-                scope = (resp_json.get('scope', '')).split(' ')        
+                scope = scope.split(' ')        
 
         # Determine who the logged in user is
         headers = {


### PR DESCRIPTION
I have created an Issue: https://github.com/jupyterhub/oauthenticator/issues/220
This is an easy fix to that case. If scope is already a list, we can't split it. 