### PR TITLE
AzureAD: use AD OID as username to ensure unicity

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,2 @@
 jupyterhub>=0.5
+Unidecode>=1.0.22


### PR DESCRIPTION
This PR requires admin review for compliance with project architecture and potential further testing

### Background
This fix is a suggestion to solve issue #213 concerning Azure AD authentication.

### Changed
- Use `OID` from AD as JupyterHub username instead of `name` property as it is today because the `name` value is not immutable
- Apply normalization when used with local authenticator to comply with unix username restrictions