### PR TITLE
Allow supplementary username_claim list

### DIFF
--- a/oauthenticator/_version.py
+++ b/oauthenticator/_version.py
@@ -6,7 +6,7 @@
 version_info = (
     0,
     9,
-    0,
+    1,
     'dev',  # comment-out this line for a release
 )
 __version__ = '.'.join(map(str, version_info[:3]))

--- a/oauthenticator/tests/test_cilogon.py
+++ b/oauthenticator/tests/test_cilogon.py
@@ -1,6 +1,8 @@
 import json
 
-from pytest import fixture, mark
+from pytest import fixture, mark, raises
+
+from tornado.web import HTTPError
 
 from ..cilogon import CILogonOAuthenticator
 
@@ -11,6 +13,13 @@ def user_model(username):
     """Return a user model"""
     return {
         'eppn': username + '@serenity.space',
+    }
+
+
+def alternative_user_model(username, claimname):
+    """Return a user model with alternate claim name"""
+    return {
+        claimname: username,
     }
 
 
@@ -40,3 +49,49 @@ async def test_cilogon(cilogon_client):
         'cilogon_user': user_model('wash'),
         'token_response': auth_state['token_response'],
     }
+
+
+async def test_cilogon_alternate_claim(cilogon_client):
+    authenticator = CILogonOAuthenticator(username_claim='uid')
+    handler = cilogon_client.handler_for_user(
+        alternative_user_model('jtkirk@ufp.gov', 'uid'))
+    user_info = await authenticator.authenticate(handler)
+    print(json.dumps(user_info, sort_keys=True, indent=4))
+    name = user_info['name']
+    assert name == 'jtkirk@ufp.gov'
+    auth_state = user_info['auth_state']
+    assert 'access_token' in auth_state
+    assert 'token_response' in auth_state
+    assert auth_state == {
+        'access_token': auth_state['access_token'],
+        'cilogon_user': alternative_user_model('jtkirk@ufp.gov',
+                                               'uid'),
+        'token_response': auth_state['token_response'],
+    }
+
+
+async def test_cilogon_additional_claim(cilogon_client):
+    authenticator = CILogonOAuthenticator(additional_username_claims=['uid'])
+    handler = cilogon_client.handler_for_user(
+        alternative_user_model('jtkirk@ufp.gov', 'uid'))
+    user_info = await authenticator.authenticate(handler)
+    print(json.dumps(user_info, sort_keys=True, indent=4))
+    name = user_info['name']
+    assert name == 'jtkirk@ufp.gov'
+    auth_state = user_info['auth_state']
+    assert 'access_token' in auth_state
+    assert 'token_response' in auth_state
+    assert auth_state == {
+        'access_token': auth_state['access_token'],
+        'cilogon_user': alternative_user_model('jtkirk@ufp.gov',
+                                               'uid'),
+        'token_response': auth_state['token_response'],
+    }
+
+
+async def test_cilogon_missing_alternate_claim(cilogon_client):
+    authenticator = CILogonOAuthenticator()
+    handler = cilogon_client.handler_for_user(
+        alternative_user_model('jtkirk@ufp.gov', 'uid'))
+    with raises(HTTPError):
+        user_info = await authenticator.authenticate(handler)


### PR DESCRIPTION
The new functionality hasn't been tested; I'm waiting on some client OAuth work at CILogon to do it.  It doesn't break anything when called *without* the new parameter.

Once I get that go-ahead and test against CILogon I will update the comments, and update the sources if need be.