### PR TITLE
Support new config for GitLab Authenticator: gitlab_project_id_whitelist

### DIFF
--- a/oauthenticator/gitlab.py
+++ b/oauthenticator/gitlab.py
@@ -184,7 +184,7 @@ class GitLabOAuthenticator(OAuthenticator):
         http_client = AsyncHTTPClient()
         headers = _api_headers(access_token)
         # Check if user has developer access to any project in the whitelist
-        for project in map(url_escape, self.gitlab_project_id_whitelist):
+        for project in self.gitlab_project_id_whitelist:
             url = "%s/projects/%s/members/%d" % (GITLAB_API, project, user_id)
             req = HTTPRequest(url, method="GET", headers=headers)
             resp = yield http_client.fetch(req, raise_error=False)

--- a/oauthenticator/gitlab.py
+++ b/oauthenticator/gitlab.py
@@ -188,13 +188,15 @@ class GitLabOAuthenticator(OAuthenticator):
             url = "%s/projects/%s/members/%d" % (GITLAB_API, project, user_id)
             req = HTTPRequest(url, method="GET", headers=headers)
             resp = yield http_client.fetch(req, raise_error=False)
-            resp_json = json.loads(resp.body.decode('utf8', 'replace'))
-            access_level = resp_json.get('access_level', 0)
 
-            # we only allow access level Developer and above
-            # Reference: https://docs.gitlab.com/ee/api/members.html
-            if resp.code == 200 and access_level >= 30:
-                return True
+            if resp.body:
+                resp_json = json.loads(resp.body.decode('utf8', 'replace'))
+                access_level = resp_json.get('access_level', 0)
+
+                # We only allow access level Developer and above
+                # Reference: https://docs.gitlab.com/ee/api/members.html
+                if resp.code == 200 and access_level >= 30:
+                    return True
         return False
 
 

--- a/oauthenticator/gitlab.py
+++ b/oauthenticator/gitlab.py
@@ -79,6 +79,10 @@ class GitLabOAuthenticator(OAuthenticator):
         config=True,
         help="Automatically whitelist members of selected groups",
     )
+    gitlab_project_id_whitelist = Set(
+        config=True,
+        help="Automatically whitelist members with Developer access to selected project ids",
+    )
 
 
     @gen.coroutine
@@ -131,34 +135,66 @@ class GitLabOAuthenticator(OAuthenticator):
         user_id = resp_json["id"]
         is_admin = resp_json.get("is_admin", False)
 
-        # Check if user is a member of any whitelisted organizations.
-        # This check is performed here, as it requires `access_token`.
+        # Check if user is a member of any whitelisted groups or projects.
+        # These checks are performed here, as it requires `access_token`.
+        user_in_group = user_in_project = False
+        is_group_specified = is_project_id_specified = False
+
         if self.gitlab_group_whitelist:
-            user_in_group = yield self._check_group_whitelist(
-                username, user_id, is_admin, access_token)
-            if not user_in_group:
-                self.log.warning("%s not in group whitelist", username)
-                return None
-        return {
-            'name': username,
-            'auth_state': {
-                'access_token': access_token,
-                'gitlab_user': resp_json,
+            is_group_specified = True
+            user_in_group = yield self._check_group_whitelist(user_id, access_token)
+
+        if self.gitlab_project_id_whitelist:
+            is_project_id_specified = True
+            user_in_project = yield self._check_project_id_whitelist(user_id, access_token)
+
+        no_config_specified = not (is_group_specified or is_project_id_specified)
+
+        if (is_group_specified and user_in_group) or \
+            (is_project_id_specified and user_in_project) or \
+                no_config_specified:
+            return {
+                'name': username,
+                'auth_state': {
+                    'access_token': access_token,
+                    'gitlab_user': resp_json,
+                }
             }
-        }
+        else:
+            self.log.warning("%s not in group or project whitelist", username)
+            return None
 
 
     @gen.coroutine
-    def _check_group_whitelist(self, username, user_id, is_admin, access_token):
+    def _check_group_whitelist(self, user_id, access_token):
         http_client = AsyncHTTPClient()
         headers = _api_headers(access_token)
-        # Check if we are a member of each group in the whitelist
+        # Check if user is a member of any group in the whitelist
         for group in map(url_escape, self.gitlab_group_whitelist):
             url = "%s/groups/%s/members/%d" % (GITLAB_API, group, user_id)
             req = HTTPRequest(url, method="GET", headers=headers)
             resp = yield http_client.fetch(req, raise_error=False)
             if resp.code == 200:
                 return True  # user _is_ in group
+        return False
+
+
+    @gen.coroutine
+    def _check_project_id_whitelist(self, user_id, access_token):
+        http_client = AsyncHTTPClient()
+        headers = _api_headers(access_token)
+        # Check if user has developer access to any project in the whitelist
+        for project in map(url_escape, self.gitlab_project_id_whitelist):
+            url = "%s/projects/%s/members/%d" % (GITLAB_API, project, user_id)
+            req = HTTPRequest(url, method="GET", headers=headers)
+            resp = yield http_client.fetch(req, raise_error=False)
+            resp_json = json.loads(resp.body.decode('utf8', 'replace'))
+            access_level = resp_json.get('access_level', 0)
+
+            # we only allow access level Developer and above
+            # Reference: https://docs.gitlab.com/ee/api/members.html
+            if resp.code == 200 and access_level >= 30:
+                return True
         return False
 
 

--- a/oauthenticator/gitlab.py
+++ b/oauthenticator/gitlab.py
@@ -144,6 +144,7 @@ class GitLabOAuthenticator(OAuthenticator):
             is_group_specified = True
             user_in_group = yield self._check_group_whitelist(user_id, access_token)
 
+        # We skip project_id check if user is in whitelisted group.
         if self.gitlab_project_id_whitelist and not user_in_group:
             is_project_id_specified = True
             user_in_project = yield self._check_project_id_whitelist(user_id, access_token)

--- a/oauthenticator/gitlab.py
+++ b/oauthenticator/gitlab.py
@@ -144,7 +144,7 @@ class GitLabOAuthenticator(OAuthenticator):
             is_group_specified = True
             user_in_group = yield self._check_group_whitelist(user_id, access_token)
 
-        if self.gitlab_project_id_whitelist:
+        if self.gitlab_project_id_whitelist and not user_in_group:
             is_project_id_specified = True
             user_in_project = yield self._check_project_id_whitelist(user_id, access_token)
 

--- a/oauthenticator/tests/test_gitlab.py
+++ b/oauthenticator/tests/test_gitlab.py
@@ -156,3 +156,87 @@ async def test_group_whitelist(gitlab_client):
 
         client.hosts['gitlab.com'].pop()
 
+
+async def test_project_id_whitelist(gitlab_client):
+    client = gitlab_client
+    authenticator = GitLabOAuthenticator()
+
+    user_projects = {
+        '1231231': {
+            '3588673': {
+                'id': 3588674,
+                'name': 'john',
+                'username': 'john',
+                'state': 'active',
+                'avatar_url': 'https://secure.gravatar.com/avatar/382a6b306679b2d97b547bfff3d73242?s=80&d=identicon',
+                'web_url': 'https://gitlab.com/john',
+                'access_level': 10,  # Guest
+                'expires_at': '2030-02-23'
+            },
+            '3588674': {
+                'id': 3588674,
+                'name': 'harry',
+                'username': 'harry',
+                'state': 'active',
+                'avatar_url': 'https://secure.gravatar.com/avatar/382a6b306679b2d97b547bfff3d73242?s=80&d=identicon',
+                'web_url': 'https://gitlab.com/harry',
+                'access_level': 30,  # Developer
+                'expires_at': '2030-02-23'
+            }
+        }
+    }
+    john_user_model = user_model('john', 3588673)
+    harry_user_model = user_model('harry', 3588674)
+    sheila_user_model = user_model('sheila', 3588675)
+
+    member_regex = re.compile(API_ENDPOINT + r'/projects/(.*)/members/(.*)')
+
+    def is_member(request):
+        urlinfo = urlparse(request.url)
+        project_id, uid = member_regex.match(urlinfo.path).group(1, 2)
+
+        if user_projects.get(project_id) and user_projects.get(project_id).get(uid):
+            res = user_projects.get(project_id).get(uid)
+            return HTTPResponse(request=request, code=200,
+                buffer=BytesIO(json.dumps(res).encode('utf8')),
+                headers={'Content-Type': 'application/json'},
+            )
+        else:
+            return HTTPResponse(request, 404)
+
+    client.hosts['gitlab.com'].append(
+        (member_regex, is_member)
+    )
+
+    authenticator.gitlab_project_id_whitelist = [1231231]
+
+    # Forbidden since John has guest access
+    handler = client.handler_for_user(john_user_model)
+    user_info = await authenticator.authenticate(handler)
+    assert user_info is None
+
+    # Authenticated since Harry has developer access to the project
+    handler = client.handler_for_user(harry_user_model)
+    user_info = await authenticator.authenticate(handler)
+    name = user_info['name']
+    assert name == 'harry'
+
+    # Forbidden since Sheila doesn't have access to the project
+    handler = client.handler_for_user(sheila_user_model)
+    user_info = await authenticator.authenticate(handler)
+    assert user_info is None
+
+    authenticator.gitlab_project_id_whitelist = [123123152543]
+
+    # Forbidden since the project does not exist.
+    handler = client.handler_for_user(harry_user_model)
+    user_info = await authenticator.authenticate(handler)
+    assert user_info is None
+
+    authenticator.gitlab_project_id_whitelist = [123123152543, 1231231]
+
+    # Authenticated since Harry has developer access to one of the project in the list
+    handler = client.handler_for_user(harry_user_model)
+    user_info = await authenticator.authenticate(handler)
+    name = user_info['name']
+    assert name == 'harry'

--- a/oauthenticator/tests/test_gitlab.py
+++ b/oauthenticator/tests/test_gitlab.py
@@ -202,7 +202,9 @@ async def test_project_id_whitelist(gitlab_client):
                 headers={'Content-Type': 'application/json'},
             )
         else:
-            return HTTPResponse(request, 404)
+            return HTTPResponse(request=request, code=404,
+                buffer=BytesIO(''.encode('utf8'))
+            )
 
     client.hosts['gitlab.com'].append(
         (member_regex, is_member)


### PR DESCRIPTION
## Requirement
I am working with GitLab team to make [JupyterHub installation from their platform](https://docs.gitlab.com/ee/user/project/clusters/#installing-applications) easy to use.

One of our security requirement is to only let people that have developer (& above) access to a project to be logged in to the JupyterHub installation created under that project. More about the requirement [here](https://gitlab.com/gitlab-org/gitlab-ce/issues/52536#note_130313980).

## Implementation
GitLab authenticator now supports a new config value: `gitlab_project_id_whitelist`. When this config is set, we verify if the user trying to login has developer & above access to at least one project in the list.

`gitlab_project_id_whitelist` plays nicely with existing config `gitlab_group_whitelist`. A user can specify both the configs and their results are OR'ed. I.e. When both the configs are present the user trying to login should either have developer (or higher) access to at least one project in `gitlab_project_id_whitelist` OR the user should be part of at least one group under `gitlab_group_whitelist`. This makes sure that all existing installations work as expected.

## Testing
New tests are added under `test_gitlab.py`. These tests cover all the newly added functionality. Additionally, I have tested the updated OAuthenticator package with local JupyterHub and it works as expected.