### PR TITLE
Use OAuth2Mixin on base OAuthLoginHandler

### DIFF
--- a/oauthenticator/auth0.py
+++ b/oauthenticator/auth0.py
@@ -32,7 +32,6 @@ jupyterhub_config.py :
 import json
 import os
 
-from tornado.auth import OAuth2Mixin
 from tornado import gen, web
 
 from tornado.httpclient import HTTPRequest, AsyncHTTPClient
@@ -43,7 +42,7 @@ from .oauth2 import OAuthLoginHandler, OAuthenticator
 
 AUTH0_SUBDOMAIN = os.getenv('AUTH0_SUBDOMAIN')
 
-class Auth0Mixin(OAuth2Mixin):
+class Auth0Mixin():
     _OAUTH_AUTHORIZE_URL = "https://%s.auth0.com/authorize" % AUTH0_SUBDOMAIN
     _OAUTH_ACCESS_TOKEN_URL = "https://%s.auth0.com/oauth/token" % AUTH0_SUBDOMAIN
 

--- a/oauthenticator/auth0.py
+++ b/oauthenticator/auth0.py
@@ -48,7 +48,7 @@ class Auth0Mixin(OAuth2Mixin):
     _OAUTH_ACCESS_TOKEN_URL = "https://%s.auth0.com/oauth/token" % AUTH0_SUBDOMAIN
 
 
-class Auth0LoginHandler(OAuthLoginHandler, Auth0Mixin):
+class Auth0LoginHandler(Auth0Mixin, OAuthLoginHandler):
     pass
 
 class Auth0OAuthenticator(OAuthenticator):

--- a/oauthenticator/azuread.py
+++ b/oauthenticator/azuread.py
@@ -11,7 +11,6 @@ import string
 import urllib
 import sys
 
-from tornado.auth import OAuth2Mixin
 from tornado.log import app_log
 from tornado import gen, web
 
@@ -35,7 +34,7 @@ def azure_authorize_url_for(tentant):
         tentant)
 
 
-class AzureAdMixin(OAuth2Mixin):
+class AzureAdMixin():
     tenant_id = os.environ.get('AAD_TENANT_ID', '')
     _OAUTH_ACCESS_TOKEN_URL = azure_token_url_for(tenant_id)
     _OAUTH_AUTHORIZE_URL = azure_authorize_url_for(tenant_id)

--- a/oauthenticator/azuread.py
+++ b/oauthenticator/azuread.py
@@ -41,7 +41,7 @@ class AzureAdMixin(OAuth2Mixin):
     _OAUTH_AUTHORIZE_URL = azure_authorize_url_for(tenant_id)
 
 
-class AzureAdLoginHandler(OAuthLoginHandler, AzureAdMixin):
+class AzureAdLoginHandler(AzureAdMixin, OAuthLoginHandler):
     pass
 
 

--- a/oauthenticator/bitbucket.py
+++ b/oauthenticator/bitbucket.py
@@ -30,7 +30,7 @@ class BitbucketMixin(OAuth2Mixin):
     _OAUTH_ACCESS_TOKEN_URL = "https://bitbucket.org/site/oauth2/access_token"
 
 
-class BitbucketLoginHandler(OAuthLoginHandler, BitbucketMixin):
+class BitbucketLoginHandler(BitbucketMixin, OAuthLoginHandler):
     pass
 
 

--- a/oauthenticator/bitbucket.py
+++ b/oauthenticator/bitbucket.py
@@ -6,7 +6,6 @@ Custom Authenticator to use Bitbucket OAuth with JupyterHub
 import json
 import urllib
 
-from tornado.auth import OAuth2Mixin
 from tornado import gen, web
 
 from tornado.httputil import url_concat
@@ -25,7 +24,7 @@ def _api_headers(access_token):
             "Authorization": "Bearer {}".format(access_token)
            }
 
-class BitbucketMixin(OAuth2Mixin):
+class BitbucketMixin():
     _OAUTH_AUTHORIZE_URL = "https://bitbucket.org/site/oauth2/authorize"
     _OAUTH_ACCESS_TOKEN_URL = "https://bitbucket.org/site/oauth2/access_token"
 

--- a/oauthenticator/cilogon.py
+++ b/oauthenticator/cilogon.py
@@ -17,7 +17,6 @@ Caveats:
 import json
 import os
 
-from tornado.auth import OAuth2Mixin
 from tornado import gen, web
 
 from tornado.httputil import url_concat
@@ -32,7 +31,7 @@ from .oauth2 import OAuthLoginHandler, OAuthenticator
 CILOGON_HOST = os.environ.get('CILOGON_HOST') or 'cilogon.org'
 
 
-class CILogonMixin(OAuth2Mixin):
+class CILogonMixin():
     _OAUTH_AUTHORIZE_URL = "https://%s/authorize" % CILOGON_HOST
     _OAUTH_TOKEN_URL = "https://%s/oauth2/token" % CILOGON_HOST
 

--- a/oauthenticator/cilogon.py
+++ b/oauthenticator/cilogon.py
@@ -37,7 +37,7 @@ class CILogonMixin(OAuth2Mixin):
     _OAUTH_TOKEN_URL = "https://%s/oauth2/token" % CILOGON_HOST
 
 
-class CILogonLoginHandler(OAuthLoginHandler, CILogonMixin):
+class CILogonLoginHandler(CILogonMixin, OAuthLoginHandler):
     """See http://www.cilogon.org/oidc for general information."""
 
     def authorize_redirect(self, *args, **kwargs):

--- a/oauthenticator/generic.py
+++ b/oauthenticator/generic.py
@@ -26,7 +26,7 @@ class GenericEnvMixin(OAuth2Mixin):
     _OAUTH_AUTHORIZE_URL = os.environ.get('OAUTH2_AUTHORIZE_URL', '')
 
 
-class GenericLoginHandler(OAuthLoginHandler, GenericEnvMixin):
+class GenericLoginHandler(GenericMixin, OAuthLoginHandler):
     pass
 
 

--- a/oauthenticator/generic.py
+++ b/oauthenticator/generic.py
@@ -8,7 +8,6 @@ import os
 import base64
 import urllib
 
-from tornado.auth import OAuth2Mixin
 from tornado import gen, web
 
 from tornado.httputil import url_concat
@@ -21,7 +20,7 @@ from traitlets import Unicode, Dict, Bool
 from .oauth2 import OAuthLoginHandler, OAuthenticator
 
 
-class GenericEnvMixin(OAuth2Mixin):
+class GenericMixin():
     _OAUTH_ACCESS_TOKEN_URL = os.environ.get('OAUTH2_TOKEN_URL', '')
     _OAUTH_AUTHORIZE_URL = os.environ.get('OAUTH2_AUTHORIZE_URL', '')
 

--- a/oauthenticator/github.py
+++ b/oauthenticator/github.py
@@ -12,7 +12,6 @@ import os
 import re
 import string
 
-from tornado.auth import OAuth2Mixin
 from tornado import gen, web
 
 from tornado.httputil import url_concat
@@ -46,7 +45,7 @@ def _api_headers(access_token):
             }
 
 
-class GitHubMixin(OAuth2Mixin):
+class GitHubMixin():
     _OAUTH_AUTHORIZE_URL = "%s://%s/login/oauth/authorize" % (GITHUB_PROTOCOL, GITHUB_HOST)
     _OAUTH_ACCESS_TOKEN_URL = "%s://%s/login/oauth/access_token" % (GITHUB_PROTOCOL, GITHUB_HOST)
 

--- a/oauthenticator/github.py
+++ b/oauthenticator/github.py
@@ -51,7 +51,7 @@ class GitHubMixin(OAuth2Mixin):
     _OAUTH_ACCESS_TOKEN_URL = "%s://%s/login/oauth/access_token" % (GITHUB_PROTOCOL, GITHUB_HOST)
 
 
-class GitHubLoginHandler(OAuthLoginHandler, GitHubMixin):
+class GitHubLoginHandler(GitHubMixin, OAuthLoginHandler):
     pass
 
 

--- a/oauthenticator/gitlab.py
+++ b/oauthenticator/gitlab.py
@@ -63,7 +63,7 @@ class GitLabMixin(OAuth2Mixin):
     _OAUTH_ACCESS_TOKEN_URL = "%s/oauth/access_token" % GITLAB_URL
 
 
-class GitLabLoginHandler(OAuthLoginHandler, GitLabMixin):
+class GitLabLoginHandler(GitLabMixin, OAuthLoginHandler):
     pass
 
 

--- a/oauthenticator/gitlab.py
+++ b/oauthenticator/gitlab.py
@@ -11,7 +11,6 @@ import os
 import sys
 import warnings
 
-from tornado.auth import OAuth2Mixin
 from tornado import gen, web
 
 from tornado.escape import url_escape
@@ -58,7 +57,7 @@ def _api_headers(access_token):
            }
 
 
-class GitLabMixin(OAuth2Mixin):
+class GitLabMixin():
     _OAUTH_AUTHORIZE_URL = "%s/oauth/authorize" % GITLAB_URL
     _OAUTH_ACCESS_TOKEN_URL = "%s/oauth/access_token" % GITLAB_URL
 

--- a/oauthenticator/globus.py
+++ b/oauthenticator/globus.py
@@ -28,7 +28,7 @@ class GlobusMixin(OAuth2Mixin):
     _OAUTH_AUTHORIZE_URL = 'https://auth.globus.org/v2/oauth2/authorize'
 
 
-class GlobusLoginHandler(OAuthLoginHandler, GlobusMixin):
+class GlobusLoginHandler(GlobusMixin, OAuthLoginHandler):
     pass
 
 

--- a/oauthenticator/globus.py
+++ b/oauthenticator/globus.py
@@ -6,7 +6,6 @@ import pickle
 import base64
 
 from tornado import gen, web
-from tornado.auth import OAuth2Mixin
 from tornado.web import HTTPError
 
 from traitlets import List, Unicode, Bool
@@ -24,7 +23,7 @@ except:
                       '"globus-requirements.txt" for using Globus oauth.')
 
 
-class GlobusMixin(OAuth2Mixin):
+class GlobusMixin():
     _OAUTH_AUTHORIZE_URL = 'https://auth.globus.org/v2/oauth2/authorize'
 
 

--- a/oauthenticator/google.py
+++ b/oauthenticator/google.py
@@ -31,7 +31,7 @@ class GoogleOAuthHandler(OAuthCallbackHandler, GoogleOAuth2Mixin):
     pass
 
 
-class GoogleOAuthenticator(OAuthenticator, GoogleOAuth2Mixin):
+class GoogleOAuthenticator(OAuthenticator):
 
     login_handler = GoogleLoginHandler
     callback_handler = GoogleOAuthHandler
@@ -90,7 +90,7 @@ class GoogleOAuthenticator(OAuthenticator, GoogleOAuth2Mixin):
         http_client = handler.get_auth_http_client()
 
         response = yield http_client.fetch(
-            self._OAUTH_USERINFO_URL + '?access_token=' + access_token
+            handler._OAUTH_USERINFO_URL + '?access_token=' + access_token
         )
 
         if not response:

--- a/oauthenticator/google.py
+++ b/oauthenticator/google.py
@@ -27,14 +27,9 @@ class GoogleLoginHandler(OAuthLoginHandler, GoogleOAuth2Mixin):
         return self.authenticator.scope
 
 
-class GoogleOAuthHandler(OAuthCallbackHandler, GoogleOAuth2Mixin):
-    pass
-
-
 class GoogleOAuthenticator(OAuthenticator):
 
     login_handler = GoogleLoginHandler
-    callback_handler = GoogleOAuthHandler
 
     @default('scope')
     def _scope_default(self):

--- a/oauthenticator/google.py
+++ b/oauthenticator/google.py
@@ -19,7 +19,7 @@ from jupyterhub.utils import url_path_join
 from .oauth2 import OAuthLoginHandler, OAuthCallbackHandler, OAuthenticator
 
 
-class GoogleLoginHandler(OAuthLoginHandler, GoogleOAuth2Mixin):
+class GoogleLoginHandler(GoogleOAuth2Mixin, OAuthLoginHandler):
     '''An OAuthLoginHandler that provides scope to GoogleOAuth2Mixin's
        authorize_redirect.'''
     @property

--- a/oauthenticator/oauth2.py
+++ b/oauthenticator/oauth2.py
@@ -10,6 +10,7 @@ import os
 import uuid
 
 from tornado import gen, web
+from tornado.auth import OAuth2Mixin
 from tornado.log import app_log
 
 from jupyterhub.handlers import BaseHandler
@@ -56,7 +57,7 @@ def _deserialize_state(b64_state):
         return {}
 
 
-class OAuthLoginHandler(BaseHandler):
+class OAuthLoginHandler(OAuth2Mixin, BaseHandler):
     """Base class for OAuth login handler
 
     Typically subclasses will need

--- a/oauthenticator/okpy.py
+++ b/oauthenticator/okpy.py
@@ -4,7 +4,6 @@ Custom Authenticator to use okpy OAuth with JupyterHub
 import json
 from binascii import a2b_base64
 
-from tornado.auth import OAuth2Mixin
 from tornado import gen, web
 from tornado.httpclient import HTTPRequest, AsyncHTTPClient
 from tornado.httputil import url_concat
@@ -19,7 +18,7 @@ OKPY_ACCESS_TOKEN_URL = "https://okpy.org/oauth/token"
 OKPY_AUTHORIZE_URL =  "https://okpy.org/oauth/authorize"
 
 
-class OkpyMixin(OAuth2Mixin):
+class OkpyMixin():
     _OAUTH_ACCESS_TOKEN_URL = OKPY_ACCESS_TOKEN_URL
     _OAUTH_AUTHORIZE_URL = OKPY_AUTHORIZE_URL
 

--- a/oauthenticator/okpy.py
+++ b/oauthenticator/okpy.py
@@ -28,7 +28,7 @@ class OkpyLoginHandler(OAuthLoginHandler, OkpyMixin):
     pass
 
 
-class OkpyOAuthenticator(OAuthenticator, OAuth2Mixin):
+class OkpyOAuthenticator(OAuthenticator):
     login_service = "Okpy"
     login_handler = OkpyLoginHandler
     

--- a/oauthenticator/okpy.py
+++ b/oauthenticator/okpy.py
@@ -24,7 +24,7 @@ class OkpyMixin(OAuth2Mixin):
     _OAUTH_AUTHORIZE_URL = OKPY_AUTHORIZE_URL
 
 
-class OkpyLoginHandler(OAuthLoginHandler, OkpyMixin):
+class OkpyLoginHandler(OkpyMixin, OAuthLoginHandler):
     pass
 
 

--- a/oauthenticator/openshift.py
+++ b/oauthenticator/openshift.py
@@ -25,7 +25,7 @@ class OpenShiftMixin(OAuth2Mixin):
     _OAUTH_ACCESS_TOKEN_URL = "%s/oauth/token" % OPENSHIFT_URL
 
 
-class OpenShiftLoginHandler(OAuthLoginHandler, OpenShiftMixin):
+class OpenShiftLoginHandler(OpenShiftMixin, OAuthLoginHandler):
     # This allows `Service Accounts as OAuth Clients` scenario
     # https://docs.openshift.org/latest/architecture/additional_concepts/authentication.html#service-accounts-as-oauth-clients
     @property

--- a/oauthenticator/openshift.py
+++ b/oauthenticator/openshift.py
@@ -8,7 +8,6 @@ Derived from the GitHub OAuth authenticator.
 import json
 import os
 
-from tornado.auth import OAuth2Mixin
 from tornado import gen, web
 
 from tornado.httputil import url_concat
@@ -20,7 +19,7 @@ from .oauth2 import OAuthLoginHandler, OAuthenticator
 
 OPENSHIFT_URL = os.environ.get('OPENSHIFT_URL') or 'https://localhost:8443'
 
-class OpenShiftMixin(OAuth2Mixin):
+class OpenShiftMixin():
     _OAUTH_AUTHORIZE_URL = "%s/oauth/authorize" % OPENSHIFT_URL
     _OAUTH_ACCESS_TOKEN_URL = "%s/oauth/token" % OPENSHIFT_URL
 

--- a/oauthenticator/tests/test_google.py
+++ b/oauthenticator/tests/test_google.py
@@ -4,7 +4,7 @@ from unittest.mock import Mock
 from pytest import fixture, mark, raises
 from tornado.web import Application, HTTPError
 
-from ..google import GoogleOAuthenticator, GoogleOAuthHandler
+from ..google import GoogleOAuthenticator, GoogleLoginHandler
 
 from .mocks import setup_oauth_mock
 
@@ -31,7 +31,7 @@ def google_client(client):
     def handler_for_user(user):
         mock_handler = original_handler_for_user(user)
         mock_handler.request.connection = Mock()
-        real_handler = GoogleOAuthHandler(
+        real_handler = GoogleLoginHandler(
             application=Application(hub=mock_handler.hub),
             request=mock_handler.request,
         )


### PR DESCRIPTION
I struggled with understanding the Authenticator classes and ran into #250. This PR removes mixing in the OAuth2Mixin from tornado.auth unless it is actually used by the classes, and makes sure to mix it in when it is actually needed.

The PR seems functional to me without breaking any tests. But, I have not tested things on a JupyterHub and made an actual login to google etc though. Speaking of that, what would the best way to do that be? It is unreasonable to me to test all authenticator classes but perhaps I could setup and run a E2E test with say google auth. Please help me decide on the level of verification needed before merge.