### PR TITLE
OpenShift 4.0 splits OAuth provider out of REST API URL host.

### DIFF
--- a/README.md
+++ b/README.md
@@ -204,8 +204,13 @@ c.GoogleOAuthenticator.login_service = 'My College'
 In case you have an OpenShift deployment with OAuth properly configured (see the
 following sections for a quick reference), you should set the client ID and
 secret by the environment variables `OAUTH_CLIENT_ID`, `OAUTH_CLIENT_SECRET` and
-`OAUTH_CALLBACK_URL`. The OpenShift API URL can be specified by setting the
-variable `OPENSHIFT_URL`.
+`OAUTH_CALLBACK_URL`.
+
+Prior to OpenShift 4.0, the OAuth provider and REST API URL endpoints can
+be specified by setting the single environment variable `OPENSHIFT_URL`. From
+OpenShift 4.0 onwards, these two endpoints are on different hosts. You need to
+set `OPENSHIFT_AUTH_API_URL` to the OAuth provider URL, and
+`OPENSHIFT_REST_API_URL` to the REST API URL endpoint.
 
 The `OAUTH_CALLBACK_URL` should match `http[s]://[your-app-route]/hub/oauth_callback`
 

--- a/oauthenticator/openshift.py
+++ b/oauthenticator/openshift.py
@@ -19,10 +19,12 @@ from jupyterhub.auth import LocalAuthenticator
 from .oauth2 import OAuthLoginHandler, OAuthenticator
 
 OPENSHIFT_URL = os.environ.get('OPENSHIFT_URL') or 'https://localhost:8443'
+OPENSHIFT_AUTH_API_URL = os.environ.get('OPENSHIFT_AUTH_API_URL') or OPENSHIFT_URL
+OPENSHIFT_REST_API_URL = os.environ.get('OPENSHIFT_REST_API_URL') or OPENSHIFT_URL
 
 class OpenShiftMixin(OAuth2Mixin):
-    _OAUTH_AUTHORIZE_URL = "%s/oauth/authorize" % OPENSHIFT_URL
-    _OAUTH_ACCESS_TOKEN_URL = "%s/oauth/token" % OPENSHIFT_URL
+    _OAUTH_AUTHORIZE_URL = "%s/oauth/authorize" % OPENSHIFT_AUTH_API_URL
+    _OAUTH_ACCESS_TOKEN_URL = "%s/oauth/token" % OPENSHIFT_AUTH_API_URL
 
 
 class OpenShiftLoginHandler(OAuthLoginHandler, OpenShiftMixin):
@@ -60,7 +62,7 @@ class OpenShiftOAuthenticator(OAuthenticator):
             code=code
         )
 
-        url = url_concat("%s/oauth/token" % OPENSHIFT_URL, params)
+        url = url_concat(self.login_handler._OAUTH_ACCESS_TOKEN_URL, params)
 
         req = HTTPRequest(url,
                           method="POST",
@@ -81,7 +83,7 @@ class OpenShiftOAuthenticator(OAuthenticator):
                  "Authorization": "Bearer {}".format(access_token)
         }
 
-        req = HTTPRequest("%s%s" % (OPENSHIFT_URL, self.users_rest_api_path),
+        req = HTTPRequest("%s%s" % (OPENSHIFT_REST_API_URL, self.users_rest_api_path),
                           method="GET",
                           validate_cert=False,
                           headers=headers)

--- a/oauthenticator/openshift.py
+++ b/oauthenticator/openshift.py
@@ -41,6 +41,8 @@ class OpenShiftOAuthenticator(OAuthenticator):
 
     scope = ['user:info']
 
+    users_rest_api_path = '/apis/user.openshift.io/v1/users/~'
+
     @gen.coroutine
     def authenticate(self, handler, data=None):
         code = handler.get_argument("code")
@@ -79,7 +81,7 @@ class OpenShiftOAuthenticator(OAuthenticator):
                  "Authorization": "Bearer {}".format(access_token)
         }
 
-        req = HTTPRequest("%s/oapi/v1/users/~" % OPENSHIFT_URL,
+        req = HTTPRequest("%s%s" % (OPENSHIFT_URL, self.users_rest_api_path),
                           method="GET",
                           validate_cert=False,
                           headers=headers)

--- a/oauthenticator/tests/test_openshift.py
+++ b/oauthenticator/tests/test_openshift.py
@@ -19,7 +19,7 @@ def openshift_client(client):
     setup_oauth_mock(client,
         host=['localhost'],
         access_token_path='/oauth/token',
-        user_path='/oapi/v1/users/~',
+        user_path='/apis/user.openshift.io/v1/users/~',
     )
     return client
 


### PR DESCRIPTION
From OpenShift 4.0, the OAuth provider and Kube REST API are not on the same URL. It is necessary to specify them separately via distinct environment variables.

Prior to OpenShift 4.0, you set the the single `OPENSHIFT_URL` environment variable. For OpenShift 4.0+, you now would need to set `OPENSHIFT_AUTH_API_URL` and `OPENSHIFT_REST_API_URL`.

This change also updates the URL path for the REST API query for user information, to use new namespaced URL path convention supported by Kubernetes. This is because old URL path no longer works in OpenShift 4.0+.

This change will mean the current code will no longer work for OpenShift versions older than 3.6. That OpenShift version is quite old now, and so seen as acceptable to make change. If someone really needs to use this with OpenShift 3.5 or older, then can override:

```
OpenShiftOAuthenticator.users_rest_api_path
```

from JupyterHub config file, setting it back to older path of:

```
/oapi/v1/users/~
```

Note that the Jupyter on OpenShift project's deployment method for JupyterHub likely will not work for versions older that OpenShift 3.6, so unlikely this situation would arise, unless someone has been maintaining there own way of deploying JupyterHub to OpenShift.