### PR TITLE
Add support for nested userdata in generic authenticator.

### DIFF
--- a/oauthenticator/tests/test_generic.py
+++ b/oauthenticator/tests/test_generic.py
@@ -12,24 +12,57 @@ def user_model(username):
         'scope': 'basic',
     }
 
-def Authenticator():
+
+def nested_user_model(username):
+    """Return a user model"""
+    return {
+        'data': {
+            'user': {
+                'id': username,
+            }
+        },
+        'scope': 'basic',
+    }
+
+
+def Authenticator(**kwargs):
     return GenericOAuthenticator(
         token_url='https://generic.horse/oauth/access_token',
-        userdata_url='https://generic.horse/oauth/userinfo'
+        userdata_url='https://generic.horse/oauth/userinfo',
+        **kwargs
     )
+
+
 @fixture
 def generic_client(client):
     setup_oauth_mock(client,
-        host='generic.horse',
-        access_token_path='/oauth/access_token',
-        user_path='/oauth/userinfo',
-    )
+                     host='generic.horse',
+                     access_token_path='/oauth/access_token',
+                     user_path='/oauth/userinfo',
+                     )
     return client
 
 
 async def test_generic(generic_client):
     authenticator = Authenticator()
     handler = generic_client.handler_for_user(user_model('wash'))
+    user_info = await authenticator.authenticate(handler)
+    assert sorted(user_info) == ['auth_state', 'name']
+    name = user_info['name']
+    assert name == 'wash'
+    auth_state = user_info['auth_state']
+    assert 'access_token' in auth_state
+    assert 'oauth_user' in auth_state
+    assert 'refresh_token' in auth_state
+    assert 'scope' in auth_state
+
+
+async def test_generic_nested(generic_client):
+    authenticator = Authenticator(
+        username_key_nested=True,
+        username_key="data.user.id"
+    )
+    handler = generic_client.handler_for_user(nested_user_model('wash'))
     user_info = await authenticator.authenticate(handler)
     assert sorted(user_info) == ['auth_state', 'name']
     name = user_info['name']


### PR DESCRIPTION
Services like NextCloud return a nested data-structure at the userdata
endpoint. A single key to get the username is not sufficient here.
This adds a new envvar "OAUTH2_USERNAME_KEY_NESTED" to tell that the
username-key is a dot-separated sequence of keys to access nested
userdata responses. For Nextcloud this would be "ocs.data.id".

Unittests are implemented to test also with nested data.