### PR TITLE
adopt async def instead of gen.coroutine

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,10 @@
 language: python
 sudo: false
 cache: pip
+dist: xenial
 python:
   - nightly
+  - 3.7
   - 3.6
   - 3.5
 install:
@@ -24,5 +26,5 @@ after_success:
 
 matrix:
   include:
-    python: 3.6
-    env: TEST_LINT=1
+    - python: 3.7
+      env: TEST_LINT=1

--- a/oauthenticator/auth0.py
+++ b/oauthenticator/auth0.py
@@ -28,13 +28,11 @@ jupyterhub_config.py :
 
 """
 
-
 import json
 import os
 
 from tornado.auth import OAuth2Mixin
-from tornado import gen, web
-
+from tornado import web
 from tornado.httpclient import HTTPRequest, AsyncHTTPClient
 
 from jupyterhub.auth import LocalAuthenticator
@@ -51,14 +49,14 @@ class Auth0Mixin(OAuth2Mixin):
 class Auth0LoginHandler(OAuthLoginHandler, Auth0Mixin):
     pass
 
+
 class Auth0OAuthenticator(OAuthenticator):
 
     login_service = "Auth0"
-    
+
     login_handler = Auth0LoginHandler
-    
-    @gen.coroutine
-    def authenticate(self, handler, data=None):
+
+    async def authenticate(self, handler, data=None):
         code = handler.get_argument("code")
         # TODO: Configure the curl_httpclient for tornado
         http_client = AsyncHTTPClient()
@@ -77,12 +75,12 @@ class Auth0OAuthenticator(OAuthenticator):
                           headers={"Content-Type": "application/json"},
                           body=json.dumps(params)
                           )
-        
-        resp = yield http_client.fetch(req)
+
+        resp = await http_client.fetch(req)
         resp_json = json.loads(resp.body.decode('utf8', 'replace'))
-        
+
         access_token = resp_json['access_token']
-        
+
         # Determine who the logged in user is
         headers={"Accept": "application/json",
                  "User-Agent": "JupyterHub",
@@ -92,7 +90,7 @@ class Auth0OAuthenticator(OAuthenticator):
                           method="GET",
                           headers=headers
                           )
-        resp = yield http_client.fetch(req)
+        resp = await http_client.fetch(req)
         resp_json = json.loads(resp.body.decode('utf8', 'replace'))
 
         return {

--- a/oauthenticator/azuread.py
+++ b/oauthenticator/azuread.py
@@ -13,7 +13,7 @@ import sys
 
 from tornado.auth import OAuth2Mixin
 from tornado.log import app_log
-from tornado import gen, web
+from tornado import web
 
 from tornado.httputil import url_concat
 from tornado.httpclient import HTTPRequest, AsyncHTTPClient
@@ -64,8 +64,7 @@ class AzureAdOAuthenticator(OAuthenticator):
             app_log.info('ID4: {0}'.format(tenant_id))
             return tenant_id
 
-    @gen.coroutine
-    def authenticate(self, handler, data=None):
+    async def authenticate(self, handler, data=None):
         code = handler.get_argument("code")
         http_client = AsyncHTTPClient()
 
@@ -93,7 +92,7 @@ class AzureAdOAuthenticator(OAuthenticator):
             body=data  # Body is required for a POST...
         )
 
-        resp = yield http_client.fetch(req)
+        resp = await http_client.fetch(req)
         resp_json = json.loads(resp.body.decode('utf8', 'replace'))
 
         # app_log.info("Response %s", resp_json)

--- a/oauthenticator/bitbucket.py
+++ b/oauthenticator/bitbucket.py
@@ -2,12 +2,11 @@
 Custom Authenticator to use Bitbucket OAuth with JupyterHub
 """
 
-
 import json
 import urllib
 
 from tornado.auth import OAuth2Mixin
-from tornado import gen, web
+from tornado import web
 
 from tornado.httputil import url_concat
 from tornado.httpclient import HTTPRequest, AsyncHTTPClient
@@ -24,6 +23,7 @@ def _api_headers(access_token):
             "User-Agent": "JupyterHub",
             "Authorization": "Bearer {}".format(access_token)
            }
+
 
 class BitbucketMixin(OAuth2Mixin):
     _OAUTH_AUTHORIZE_URL = "https://bitbucket.org/site/oauth2/authorize"
@@ -54,8 +54,7 @@ class BitbucketOAuthenticator(OAuthenticator):
                "Authorization": "Bearer {}"
                }
 
-    @gen.coroutine
-    def authenticate(self, handler, data=None):
+    async def authenticate(self, handler, data=None):
         code = handler.get_argument("code")
         # TODO: Configure the curl_httpclient for tornado
         http_client = AsyncHTTPClient()
@@ -82,7 +81,7 @@ class BitbucketOAuthenticator(OAuthenticator):
                           headers=bb_header
                           )
 
-        resp = yield http_client.fetch(req)
+        resp = await http_client.fetch(req)
         resp_json = json.loads(resp.body.decode('utf8', 'replace'))
 
         access_token = resp_json['access_token']
@@ -93,7 +92,7 @@ class BitbucketOAuthenticator(OAuthenticator):
                           method="GET",
                           headers=_api_headers(access_token)
                           )
-        resp = yield http_client.fetch(req)
+        resp = await http_client.fetch(req)
         resp_json = json.loads(resp.body.decode('utf8', 'replace'))
 
         username = resp_json["username"]
@@ -101,7 +100,7 @@ class BitbucketOAuthenticator(OAuthenticator):
         # Check if user is a member of any whitelisted teams.
         # This check is performed here, as the check requires `access_token`.
         if self.bitbucket_team_whitelist:
-            user_in_team = yield self._check_team_whitelist(username, access_token)
+            user_in_team = await self._check_team_whitelist(username, access_token)
             if not user_in_team:
                 self.log.warning("%s not in team whitelist", username)
                 return None
@@ -114,8 +113,7 @@ class BitbucketOAuthenticator(OAuthenticator):
             }
         }
 
-    @gen.coroutine
-    def _check_team_whitelist(self, username, access_token):
+    async def _check_team_whitelist(self, username, access_token):
         http_client = AsyncHTTPClient()
 
         headers = _api_headers(access_token)
@@ -124,7 +122,7 @@ class BitbucketOAuthenticator(OAuthenticator):
                                {'role': 'member'})
         while next_page:
             req = HTTPRequest(next_page, method="GET", headers=headers)
-            resp = yield http_client.fetch(req)
+            resp = await http_client.fetch(req)
             resp_json = json.loads(resp.body.decode('utf8', 'replace'))
             next_page = resp_json.get('next', None)
 

--- a/oauthenticator/cilogon.py
+++ b/oauthenticator/cilogon.py
@@ -13,12 +13,11 @@ Caveats:
   email instead of ePPN as the JupyterHub username.
 """
 
-
 import json
 import os
 
 from tornado.auth import OAuth2Mixin
-from tornado import gen, web
+from tornado import web
 
 from tornado.httputil import url_concat
 from tornado.httpclient import HTTPRequest, AsyncHTTPClient
@@ -123,8 +122,7 @@ class CILogonOAuthenticator(OAuthenticator):
         """
     )
 
-    @gen.coroutine
-    def authenticate(self, handler, data=None):
+    async def authenticate(self, handler, data=None):
         """We set up auth_state based on additional CILogon info if we
         receive it.
         """
@@ -155,7 +153,7 @@ class CILogonOAuthenticator(OAuthenticator):
                           body=''
                           )
 
-        resp = yield http_client.fetch(req)
+        resp = await http_client.fetch(req)
         token_response = json.loads(resp.body.decode('utf8', 'replace'))
         access_token = token_response['access_token']
         self.log.info("Access token acquired.")
@@ -165,7 +163,7 @@ class CILogonOAuthenticator(OAuthenticator):
                                      CILOGON_HOST, params),
                           headers=headers
                           )
-        resp = yield http_client.fetch(req)
+        resp = await http_client.fetch(req)
         resp_json = json.loads(resp.body.decode('utf8', 'replace'))
 
         claimlist = [self.username_claim]

--- a/oauthenticator/generic.py
+++ b/oauthenticator/generic.py
@@ -9,7 +9,7 @@ import base64
 import urllib
 
 from tornado.auth import OAuth2Mixin
-from tornado import gen, web
+from tornado import web
 
 from tornado.httputil import url_concat
 from tornado.httpclient import HTTPRequest, AsyncHTTPClient
@@ -85,8 +85,7 @@ class GenericOAuthenticator(OAuthenticator):
         help="Disable basic authentication for access token request"
     )
 
-    @gen.coroutine
-    def authenticate(self, handler, data=None):
+    async def authenticate(self, handler, data=None):
         code = handler.get_argument("code")
         # TODO: Configure the curl_httpclient for tornado
         http_client = AsyncHTTPClient()
@@ -124,7 +123,7 @@ class GenericOAuthenticator(OAuthenticator):
                           body=urllib.parse.urlencode(params)  # Body is required for a POST...
                           )
 
-        resp = yield http_client.fetch(req)
+        resp = await http_client.fetch(req)
 
         resp_json = json.loads(resp.body.decode('utf8', 'replace'))
 
@@ -154,7 +153,7 @@ class GenericOAuthenticator(OAuthenticator):
                           headers=headers,
                           validate_cert=self.tls_verify,
                           )
-        resp = yield http_client.fetch(req)
+        resp = await http_client.fetch(req)
         resp_json = json.loads(resp.body.decode('utf8', 'replace'))
 
         if not resp_json.get(self.username_key):

--- a/oauthenticator/google.py
+++ b/oauthenticator/google.py
@@ -74,22 +74,21 @@ class GoogleOAuthenticator(OAuthenticator, GoogleOAuth2Mixin):
         help="""Google Apps hosted domain string, e.g. My College"""
     )
 
-    @gen.coroutine
-    def authenticate(self, handler, data=None):
+    async def authenticate(self, handler, data=None):
         code = handler.get_argument("code")
         handler.settings['google_oauth'] = {
             'key': self.client_id,
             'secret': self.client_secret,
             'scope': self.scope,
         }
-        user = yield handler.get_authenticated_user(
+        user = await handler.get_authenticated_user(
             redirect_uri=self.get_callback_url(handler),
             code=code)
         access_token = str(user['access_token'])
 
         http_client = handler.get_auth_http_client()
 
-        response = yield http_client.fetch(
+        response = await http_client.fetch(
             self._OAUTH_USERINFO_URL + '?access_token=' + access_token
         )
 

--- a/oauthenticator/oauth2.py
+++ b/oauthenticator/oauth2.py
@@ -10,7 +10,7 @@ import os
 from urllib.parse import quote, urlparse
 import uuid
 
-from tornado import gen, web
+from tornado import web
 from tornado.log import app_log
 
 from jupyterhub.handlers import BaseHandler
@@ -182,13 +182,12 @@ class OAuthCallbackHandler(BaseHandler):
             return super().get_next_url(user)
         return url_path_join(self.hub.server.base_url, 'home')
 
-    @gen.coroutine
-    def _login_user_pre_08(self):
+    async def _login_user_pre_08(self):
         """login_user simplifies the login+cookie+auth_state process in JupyterHub 0.8
 
         _login_user_07 is for backward-compatibility with JupyterHub 0.7
         """
-        user_info = yield self.authenticator.get_authenticated_user(self, None)
+        user_info = await self.authenticator.get_authenticated_user(self, None)
         if user_info is None:
             return
         if isinstance(user_info, dict):
@@ -203,10 +202,9 @@ class OAuthCallbackHandler(BaseHandler):
         # JupyterHub 0.7 doesn't have .login_user
         login_user = _login_user_pre_08
 
-    @gen.coroutine
-    def get(self):
+    async def get(self):
         self.check_arguments()
-        user = yield self.login_user()
+        user = await self.login_user()
         if user is None:
             # todo: custom error page?
             raise web.HTTPError(403)
@@ -293,6 +291,5 @@ class OAuthenticator(Authenticator):
             (r'/oauth_callback', self.callback_handler),
         ]
 
-    @gen.coroutine
-    def authenticate(self, handler, data=None):
+    async def authenticate(self, handler, data=None):
         raise NotImplementedError()

--- a/oauthenticator/okpy.py
+++ b/oauthenticator/okpy.py
@@ -5,7 +5,7 @@ import json
 from binascii import a2b_base64
 
 from tornado.auth import OAuth2Mixin
-from tornado import gen, web
+from tornado import web
 from tornado.httpclient import HTTPRequest, AsyncHTTPClient
 from tornado.httputil import url_concat
 from traitlets import default
@@ -63,20 +63,19 @@ class OkpyOAuthenticator(OAuthenticator, OAuth2Mixin):
         req = HTTPRequest(url, method = "GET", headers = headers)
         return req
 
-    @gen.coroutine
-    def authenticate(self, handler, data = None):
+    async def authenticate(self, handler, data = None):
         code = handler.get_argument("code", False)
         if not code:
             raise web.HTTPError(400, "Authentication Cancelled.")
         http_client = AsyncHTTPClient()
         auth_request = self.get_auth_request(code)
-        response = yield http_client.fetch(auth_request)
+        response = await http_client.fetch(auth_request)
         if not response:
             raise web.HTTPError(500, 'Authentication Failed: Token Not Acquired')
         state = json.loads(response.body.decode('utf8', 'replace'))
         access_token = state['access_token']
         info_request = self.get_user_info_request(access_token)
-        response = yield http_client.fetch(info_request)
+        response = await http_client.fetch(info_request)
         user = json.loads(response.body.decode('utf8', 'replace'))
         # TODO: preserve state in auth_state when JupyterHub supports encrypted auth_state
         return {

--- a/oauthenticator/openshift.py
+++ b/oauthenticator/openshift.py
@@ -9,7 +9,7 @@ import json
 import os
 
 from tornado.auth import OAuth2Mixin
-from tornado import gen, web
+from tornado import web
 
 from tornado.httputil import url_concat
 from tornado.httpclient import HTTPRequest, AsyncHTTPClient
@@ -45,8 +45,7 @@ class OpenShiftOAuthenticator(OAuthenticator):
 
     users_rest_api_path = '/apis/user.openshift.io/v1/users/~'
 
-    @gen.coroutine
-    def authenticate(self, handler, data=None):
+    async def authenticate(self, handler, data=None):
         code = handler.get_argument("code")
         # TODO: Configure the curl_httpclient for tornado
         http_client = AsyncHTTPClient()
@@ -71,7 +70,7 @@ class OpenShiftOAuthenticator(OAuthenticator):
                           body='' # Body is required for a POST...
                           )
 
-        resp = yield http_client.fetch(req)
+        resp = await http_client.fetch(req)
 
         resp_json = json.loads(resp.body.decode('utf8', 'replace'))
 
@@ -88,7 +87,7 @@ class OpenShiftOAuthenticator(OAuthenticator):
                           validate_cert=False,
                           headers=headers)
 
-        resp = yield http_client.fetch(req)
+        resp = await http_client.fetch(req)
         resp_json = json.loads(resp.body.decode('utf8', 'replace'))
 
         return {

--- a/oauthenticator/tests/mocks.py
+++ b/oauthenticator/tests/mocks.py
@@ -10,7 +10,6 @@ import uuid
 
 import pytest
 
-from tornado import gen
 from tornado.httpclient import HTTPResponse
 from tornado.httputil import HTTPServerRequest
 from tornado.log import app_log


### PR DESCRIPTION
avoid deprecated interface which has become buggy with tornado 6,
causing things like StreamClosedError on GitHub oauth (#246)

closes #246
closes #270

This bumps our minimum Python to 3.5, which may have been true already, but makes it official in package metadata