### PR TITLE
add configurable username claim

### DIFF
--- a/oauthenticator/azuread.py
+++ b/oauthenticator/azuread.py
@@ -73,7 +73,7 @@ class AzureAdOAuthenticator(OAuthenticator):
         if hasattr(self, 'username_claim') and self.username_claim:
             app_log.info('ID5: {0}'.format(self.username_claim))
             return self.username_claim
-        return 'oid'
+        return 'name'
 
     async def authenticate(self, handler, data=None):
         code = handler.get_argument("code")

--- a/oauthenticator/tests/test_azuread.py
+++ b/oauthenticator/tests/test_azuread.py
@@ -2,10 +2,12 @@ from pytest import mark
 from ..azuread import AzureAdOAuthenticator
 
 _t_id = 'XXX-XXX-XXXX'
+_t_username_claim = 'upn'
 
 
 class Config(object):
     tenant_id = _t_id
+    username_claim = _t_username_claim
 
 
 def test_gettenant_with_tenant_id():
@@ -20,3 +22,17 @@ os.environ["AAD_TENANT_ID"] = "some_random_id"
 def test_gettenant_from_env():
     t_id = AzureAdOAuthenticator.get_tenant(object)
     assert t_id.default_value == "some_random_id"
+
+
+def test_username_claim_config():
+    t_username_claim = AzureAdOAuthenticator.get_username_claim(Config())
+    assert t_username_claim == _t_username_claim
+
+
+def test_username_claim_default():
+
+    class Config(object):
+        tenant_id = _t_id
+
+    t_username_claim = AzureAdOAuthenticator.get_username_claim(Config())
+    assert t_username_claim == 'oid'

--- a/oauthenticator/tests/test_azuread.py
+++ b/oauthenticator/tests/test_azuread.py
@@ -2,12 +2,10 @@ from pytest import mark
 from ..azuread import AzureAdOAuthenticator
 
 _t_id = 'XXX-XXX-XXXX'
-_t_username_claim = 'upn'
 
 
 class Config(object):
     tenant_id = _t_id
-    username_claim = _t_username_claim
 
 
 def test_gettenant_with_tenant_id():
@@ -22,17 +20,3 @@ os.environ["AAD_TENANT_ID"] = "some_random_id"
 def test_gettenant_from_env():
     t_id = AzureAdOAuthenticator.get_tenant(object)
     assert t_id.default_value == "some_random_id"
-
-
-def test_username_claim_config():
-    t_username_claim = AzureAdOAuthenticator.get_username_claim(Config())
-    assert t_username_claim == _t_username_claim
-
-
-def test_username_claim_default():
-
-    class Config(object):
-        tenant_id = _t_id
-
-    t_username_claim = AzureAdOAuthenticator.get_username_claim(Config())
-    assert t_username_claim == 'name'

--- a/oauthenticator/tests/test_azuread.py
+++ b/oauthenticator/tests/test_azuread.py
@@ -35,4 +35,4 @@ def test_username_claim_default():
         tenant_id = _t_id
 
     t_username_claim = AzureAdOAuthenticator.get_username_claim(Config())
-    assert t_username_claim == 'oid'
+    assert t_username_claim == 'name'


### PR DESCRIPTION
This is a suggestion to fix https://github.com/jupyterhub/oauthenticator/issues/213 that is similar to https://github.com/jupyterhub/oauthenticator/pull/224, but provides a configurable `username_claim` attribute.

Logic:
1. Read value of `c.AzureAdOAuthenticator.username_claim`
1. Fall back to <del>`oid`</del>name if config isn't set

closes #224