### PR TITLE
Use traitlet.default for Azure AD tenant_id

### DIFF
--- a/oauthenticator/azuread.py
+++ b/oauthenticator/azuread.py
@@ -46,17 +46,9 @@ class AzureAdOAuthenticator(OAuthenticator):
     tenant_id = Unicode(config=True)
     username_claim = Unicode(config=True)
 
-    def get_tenant(self):
-        if hasattr(self, 'tenant_id') and self.tenant_id:
-            app_log.info('ID3: {0}'.format(self.tenant_id))
-            return self.tenant_id
-        else:
-            tenant_id = Unicode(
-                os.environ.get('AAD_TENANT_ID', ''),
-                config=True,
-                help="Tenant")
-            app_log.info('ID4: {0}'.format(tenant_id))
-            return tenant_id
+    @default('tenant_id')
+    def _tenant_id_default(self):
+        return os.environ.get('AAD_TENANT_ID', '')
 
     @default('username_claim')
     def _username_claim_default(self):
@@ -77,7 +69,7 @@ class AzureAdOAuthenticator(OAuthenticator):
         data = urllib.parse.urlencode(
             params, doseq=True, encoding='utf-8', safe='=')
 
-        url = azure_token_url_for(self.get_tenant())
+        url = azure_token_url_for(self.tenant_id)
 
         headers = {
             'Content-Type':

--- a/oauthenticator/tests/test_azuread.py
+++ b/oauthenticator/tests/test_azuread.py
@@ -1,22 +1,10 @@
 from pytest import mark
 from ..azuread import AzureAdOAuthenticator
 
-_t_id = 'XXX-XXX-XXXX'
-
-
-class Config(object):
-    tenant_id = _t_id
-
-
-def test_gettenant_with_tenant_id():
-    t_id = AzureAdOAuthenticator.get_tenant(Config())
-    assert t_id == _t_id
-
-
 import os
 os.environ["AAD_TENANT_ID"] = "some_random_id"
 
 
-def test_gettenant_from_env():
-    t_id = AzureAdOAuthenticator.get_tenant(object)
-    assert t_id.default_value == "some_random_id"
+def test_tenant_id_from_env():
+    aad = AzureAdOAuthenticator()
+    assert aad.tenant_id == "some_random_id"


### PR DESCRIPTION
This implements the suggestion in https://github.com/jupyterhub/oauthenticator/pull/280 to simplify `tenant_id` by using `traitlet.default`. This allows removing the `get_tenant()` function entirely. As before, the default value is retrieved from the `AAD_TENANT_ID` environment variable.