### PR TITLE
Include inherited members in GitLab auth checks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ command line for details.
 
 ## [Unreleased]
 
+- fix GitLab login for inherited group or project members. Requires GitLab 12.4 or newer, falls back to previous behavior for older versions.
+
 ## 0.9
 
 ### [0.9.0] - 2019-07-30

--- a/README.md
+++ b/README.md
@@ -106,7 +106,7 @@ c.MyOAuthenticator.client_secret = 'your-client-secret'
 > export AAD_TENANT_ID='{AAD-TENANT-ID}'
 ```
 
-* Sample code is provided for you in `examples > azuread > sample_jupyter_config.py` 
+* Sample code is provided for you in `examples > azuread > sample_jupyter_config.py`
 * Just add the code below to your `jupyterhub_config.py` file
 * Making sure to replace the values in `'{}'` with your APP, TENANT, DOMAIN, etc. values
 
@@ -180,6 +180,16 @@ You can also use `LocalGitLabOAuthenticator` to map GitLab accounts onto local u
 
 You can use your own GitLab CE/EE instance by setting the `GITLAB_HOST` environment
 flag.
+
+You can restrict access to only accept members of certain projects or groups by setting
+```
+c.GitLabOAuthenticator.gitlab_project_id_whitelist = [ ... ]
+```
+and
+```
+c.GitLabOAuthenticator.gitlab_group_whitelist = [ ... ]
+```
+but be aware that each entry incurs a separate API call, increasing the risk of rate limiting and timeouts.
 
 ## Google Setup
 

--- a/oauthenticator/gitlab.py
+++ b/oauthenticator/gitlab.py
@@ -10,7 +10,6 @@ import json
 import os
 import sys
 import warnings
-import urllib
 
 from tornado.auth import OAuth2Mixin
 from tornado import web

--- a/oauthenticator/gitlab.py
+++ b/oauthenticator/gitlab.py
@@ -186,7 +186,7 @@ class GitLabOAuthenticator(OAuthenticator):
         headers = _api_headers(access_token)
         # Check if user has developer access to any project in the whitelist
         for project in self.gitlab_project_id_whitelist:
-            url = "%s/projects/%s/members/%d" % (GITLAB_API, project, user_id)
+            url = "%s/projects/%s/members/%d/all" % (GITLAB_API, project, user_id)
             req = HTTPRequest(url, method="GET", headers=headers)
             resp = await http_client.fetch(req, raise_error=False)
 

--- a/oauthenticator/gitlab.py
+++ b/oauthenticator/gitlab.py
@@ -173,7 +173,7 @@ class GitLabOAuthenticator(OAuthenticator):
         headers = _api_headers(access_token)
         # Check if user is a member of any group in the whitelist
         for group in map(url_escape, self.gitlab_group_whitelist):
-            url = "%s/groups/%s/members/%d" % (GITLAB_API, group, user_id)
+            url = "%s/groups/%s/members/%d/all" % (GITLAB_API, group, user_id)
             req = HTTPRequest(url, method="GET", headers=headers)
             resp = await http_client.fetch(req, raise_error=False)
             if resp.code == 200:

--- a/oauthenticator/gitlab.py
+++ b/oauthenticator/gitlab.py
@@ -144,12 +144,12 @@ class GitLabOAuthenticator(OAuthenticator):
 
         if self.gitlab_group_whitelist:
             is_group_specified = True
-            user_in_group = await self._check_group_whitelist(username, access_token)
+            user_in_group = await self._check_group_whitelist(user_id, access_token)
 
         # We skip project_id check if user is in whitelisted group.
         if self.gitlab_project_id_whitelist and not user_in_group:
             is_project_id_specified = True
-            user_in_project = await self._check_project_id_whitelist(username, access_token)
+            user_in_project = await self._check_project_id_whitelist(user_id, access_token)
 
         no_config_specified = not (is_group_specified or is_project_id_specified)
 
@@ -168,12 +168,12 @@ class GitLabOAuthenticator(OAuthenticator):
             return None
 
 
-    async def _check_group_whitelist(self, username, access_token):
+    async def _check_group_whitelist(self, user_id, access_token):
         http_client = AsyncHTTPClient()
         headers = _api_headers(access_token)
         # Check if user is a member of any group in the whitelist
         for group in map(url_escape, self.gitlab_group_whitelist):
-            url = "%s/groups/%s/members/all?query=%s" % (GITLAB_API, group, username)
+            url = "%s/groups/%s/members/%d/all" % (GITLAB_API, group, user_id)
             req = HTTPRequest(url, method="GET", headers=headers)
             resp = await http_client.fetch(req, raise_error=False)
             if resp.code == 200:
@@ -181,12 +181,12 @@ class GitLabOAuthenticator(OAuthenticator):
         return False
 
 
-    async def _check_project_id_whitelist(self, username, access_token):
+    async def _check_project_id_whitelist(self, user_id, access_token):
         http_client = AsyncHTTPClient()
         headers = _api_headers(access_token)
         # Check if user has developer access to any project in the whitelist
         for project in self.gitlab_project_id_whitelist:
-            url = "%s/projects/%s/members/all?query=%s" % (GITLAB_API, project, username)
+            url = "%s/projects/%s/members/%d/all" % (GITLAB_API, project, user_id)
             req = HTTPRequest(url, method="GET", headers=headers)
             resp = await http_client.fetch(req, raise_error=False)
 

--- a/oauthenticator/gitlab.py
+++ b/oauthenticator/gitlab.py
@@ -196,10 +196,10 @@ class GitLabOAuthenticator(OAuthenticator):
             if resp.code == 200 and resp.body:
                 resp_json = json.loads(resp.body.decode('utf8', 'replace'))
                 for user in resp_json:
-                    # We only allow access level Developer and above
-                    # Reference: https://docs.gitlab.com/ee/api/members.html
-                    if user['id'] == user_id and user['username'] == username and user['access_level'] >= 30:
-                        return True
+                    if user['id'] == user_id and user['username'] == username:
+                        # We only allow access level Developer and above
+                        # Reference: https://docs.gitlab.com/ee/api/members.html
+                        return user['access_level'] >= 30
         return False
 
 

--- a/oauthenticator/gitlab.py
+++ b/oauthenticator/gitlab.py
@@ -174,6 +174,7 @@ class GitLabOAuthenticator(OAuthenticator):
         # Check if user is a member of any group in the whitelist
         for group in map(url_escape, self.gitlab_group_whitelist):
             url = "%s/groups/%s/members/all?query=%s" % (GITLAB_API, group, username)
+            self.log.warning(url)
             req = HTTPRequest(url, method="GET", headers=headers)
             resp = await http_client.fetch(req, raise_error=False)
             if resp.code == 200:
@@ -187,6 +188,7 @@ class GitLabOAuthenticator(OAuthenticator):
         # Check if user has developer access to any project in the whitelist
         for project in self.gitlab_project_id_whitelist:
             url = "%s/projects/%s/members/all?query=%s" % (GITLAB_API, project, username)
+            self.log.warning(url)
             req = HTTPRequest(url, method="GET", headers=headers)
             resp = await http_client.fetch(req, raise_error=False)
 

--- a/oauthenticator/gitlab.py
+++ b/oauthenticator/gitlab.py
@@ -134,6 +134,7 @@ class GitLabOAuthenticator(OAuthenticator):
         resp_json = json.loads(resp.body.decode('utf8', 'replace'))
 
         username = resp_json["username"]
+        user_id = resp_json["id"]
         is_admin = resp_json.get("is_admin", False)
 
         # Check if user is a member of any whitelisted groups or projects.
@@ -143,12 +144,12 @@ class GitLabOAuthenticator(OAuthenticator):
 
         if self.gitlab_group_whitelist:
             is_group_specified = True
-            user_in_group = await self._check_group_whitelist(username, access_token)
+            user_in_group = await self._check_group_whitelist(user_id, username, access_token)
 
         # We skip project_id check if user is in whitelisted group.
         if self.gitlab_project_id_whitelist and not user_in_group:
             is_project_id_specified = True
-            user_in_project = await self._check_project_id_whitelist(username, access_token)
+            user_in_project = await self._check_project_id_whitelist(user_id, username, access_token)
 
         no_config_specified = not (is_group_specified or is_project_id_specified)
 
@@ -167,7 +168,7 @@ class GitLabOAuthenticator(OAuthenticator):
             return None
 
 
-    async def _check_group_whitelist(self, username, access_token):
+    async def _check_group_whitelist(self, user_id, username, access_token):
         http_client = AsyncHTTPClient()
         headers = _api_headers(access_token)
         # Check if user is a member of any group in the whitelist
@@ -178,12 +179,12 @@ class GitLabOAuthenticator(OAuthenticator):
             if resp.code == 200 and resp.body:
                 resp_json = json.loads(resp.body.decode('utf8', 'replace'))
                 for user in resp_json:
-                    if user['username'] == username:
+                    if user['id'] == user_id and user['username'] == username:
                         return True  # user _is_ in group
         return False
 
 
-    async def _check_project_id_whitelist(self, username, access_token):
+    async def _check_project_id_whitelist(self, user_id, username, access_token):
         http_client = AsyncHTTPClient()
         headers = _api_headers(access_token)
         # Check if user has developer access to any project in the whitelist
@@ -197,7 +198,7 @@ class GitLabOAuthenticator(OAuthenticator):
                 for user in resp_json:
                     # We only allow access level Developer and above
                     # Reference: https://docs.gitlab.com/ee/api/members.html
-                    if user['username'] == username and user['access_level'] >= 30:
+                    if user['id'] == user_id and user['username'] == username and user['access_level'] >= 30:
                         return True
         return False
 

--- a/oauthenticator/gitlab.py
+++ b/oauthenticator/gitlab.py
@@ -174,7 +174,6 @@ class GitLabOAuthenticator(OAuthenticator):
         # Check if user is a member of any group in the whitelist
         for group in map(url_escape, self.gitlab_group_whitelist):
             url = "%s/groups/%s/members/all?query=%s" % (GITLAB_API, group, username)
-            self.log.warning(url)
             req = HTTPRequest(url, method="GET", headers=headers)
             resp = await http_client.fetch(req, raise_error=False)
             if resp.code == 200:
@@ -188,7 +187,6 @@ class GitLabOAuthenticator(OAuthenticator):
         # Check if user has developer access to any project in the whitelist
         for project in self.gitlab_project_id_whitelist:
             url = "%s/projects/%s/members/all?query=%s" % (GITLAB_API, project, username)
-            self.log.warning(url)
             req = HTTPRequest(url, method="GET", headers=headers)
             resp = await http_client.fetch(req, raise_error=False)
 

--- a/oauthenticator/gitlab.py
+++ b/oauthenticator/gitlab.py
@@ -181,8 +181,9 @@ class GitLabOAuthenticator(OAuthenticator):
                           validate_cert=self.validate_server_cert)
         resp = await AsyncHTTPClient().fetch(req, raise_error=True)
         resp_json = json.loads(resp.body.decode('utf8', 'replace'))
-        version_string = re.sub(r'-pre$', '', resp_json['version'])
-        return list(map(int, str.split(version_string, '.')))
+        version_strings = resp_json['version'].split('-')[0].split('.')[:3]
+        version_ints = list(map(int, version_strings))
+        return version_ints
 
 
     async def _check_group_whitelist(self, user_id, access_token):

--- a/oauthenticator/gitlab.py
+++ b/oauthenticator/gitlab.py
@@ -196,10 +196,10 @@ class GitLabOAuthenticator(OAuthenticator):
             if resp.code == 200 and resp.body:
                 resp_json = json.loads(resp.body.decode('utf8', 'replace'))
                 for user in resp_json:
-                    if user['id'] == user_id and user['username'] == username:
-                        # We only allow access level Developer and above
-                        # Reference: https://docs.gitlab.com/ee/api/members.html
-                        return user['access_level'] >= 30
+                    # We only allow access level Developer and above
+                    # Reference: https://docs.gitlab.com/ee/api/members.html
+                    if user['id'] == user_id and user['username'] == username and user['access_level'] >= 30:
+                        return True
         return False
 
 

--- a/oauthenticator/gitlab.py
+++ b/oauthenticator/gitlab.py
@@ -173,7 +173,7 @@ class GitLabOAuthenticator(OAuthenticator):
         headers = _api_headers(access_token)
         # Check if user is a member of any group in the whitelist
         for group in map(url_escape, self.gitlab_group_whitelist):
-            url = "%s/groups/%s/members/%d/all" % (GITLAB_API, group, user_id)
+            url = "%s/groups/%s/members/all/%d" % (GITLAB_API, group, user_id)
             req = HTTPRequest(url, method="GET", headers=headers)
             resp = await http_client.fetch(req, raise_error=False)
             if resp.code == 200:
@@ -186,7 +186,7 @@ class GitLabOAuthenticator(OAuthenticator):
         headers = _api_headers(access_token)
         # Check if user has developer access to any project in the whitelist
         for project in self.gitlab_project_id_whitelist:
-            url = "%s/projects/%s/members/%d/all" % (GITLAB_API, project, user_id)
+            url = "%s/projects/%s/members/all/%d" % (GITLAB_API, project, user_id)
             req = HTTPRequest(url, method="GET", headers=headers)
             resp = await http_client.fetch(req, raise_error=False)
 

--- a/oauthenticator/gitlab.py
+++ b/oauthenticator/gitlab.py
@@ -134,7 +134,6 @@ class GitLabOAuthenticator(OAuthenticator):
         resp_json = json.loads(resp.body.decode('utf8', 'replace'))
 
         username = resp_json["username"]
-        user_id = resp_json["id"]
         is_admin = resp_json.get("is_admin", False)
 
         # Check if user is a member of any whitelisted groups or projects.
@@ -174,11 +173,13 @@ class GitLabOAuthenticator(OAuthenticator):
         # Check if user is a member of any group in the whitelist
         for group in map(url_escape, self.gitlab_group_whitelist):
             url = "%s/groups/%s/members/all?query=%s" % (GITLAB_API, group, username)
-            self.log.warning(url)
             req = HTTPRequest(url, method="GET", headers=headers)
             resp = await http_client.fetch(req, raise_error=False)
-            if resp.code == 200:
-                return True  # user _is_ in group
+            if resp.code == 200 and resp.body:
+                resp_json = json.loads(resp.body.decode('utf8', 'replace'))
+                for user in resp_json:
+                    if user['username'] == username:
+                        return True  # user _is_ in group
         return False
 
 
@@ -188,18 +189,16 @@ class GitLabOAuthenticator(OAuthenticator):
         # Check if user has developer access to any project in the whitelist
         for project in self.gitlab_project_id_whitelist:
             url = "%s/projects/%s/members/all?query=%s" % (GITLAB_API, project, username)
-            self.log.warning(url)
             req = HTTPRequest(url, method="GET", headers=headers)
             resp = await http_client.fetch(req, raise_error=False)
 
-            if resp.body:
+            if resp.code == 200 and resp.body:
                 resp_json = json.loads(resp.body.decode('utf8', 'replace'))
-                access_level = resp_json.get('access_level', 0)
-
-                # We only allow access level Developer and above
-                # Reference: https://docs.gitlab.com/ee/api/members.html
-                if resp.code == 200 and access_level >= 30:
-                    return True
+                for user in resp_json:
+                    # We only allow access level Developer and above
+                    # Reference: https://docs.gitlab.com/ee/api/members.html
+                    if user['username'] == username and user['access_level'] >= 30:
+                        return True
         return False
 
 

--- a/oauthenticator/gitlab.py
+++ b/oauthenticator/gitlab.py
@@ -10,6 +10,7 @@ import json
 import os
 import sys
 import warnings
+import urllib
 
 from tornado.auth import OAuth2Mixin
 from tornado import web
@@ -87,6 +88,7 @@ class GitLabOAuthenticator(OAuthenticator):
         help="Automatically whitelist members with Developer access to selected project ids",
     )
 
+    gitlab_version = None
 
     async def authenticate(self, handler, data=None):
         code = handler.get_argument("code")
@@ -106,7 +108,6 @@ class GitLabOAuthenticator(OAuthenticator):
             redirect_uri=self.get_callback_url(handler),
         )
 
-
         validate_server_cert = self.validate_server_cert
 
         url = url_concat("%s/oauth/token" % GITLAB_URL,
@@ -123,6 +124,11 @@ class GitLabOAuthenticator(OAuthenticator):
         resp_json = json.loads(resp.body.decode('utf8', 'replace'))
 
         access_token = resp_json['access_token']
+
+        # memoize gitlab version for class lifetime
+        if self.gitlab_version is None:
+            self.gitlab_version = await self._get_gitlab_version(access_token)
+            self.member_api_variant = 'all/' if self.gitlab_version >= '12.4' else ''
 
         # Determine who the logged in user is
         req = HTTPRequest("%s/user" % GITLAB_API,
@@ -167,13 +173,22 @@ class GitLabOAuthenticator(OAuthenticator):
             self.log.warning("%s not in group or project whitelist", username)
             return None
 
+    async def _get_gitlab_version(self, access_token):
+        url = '%s/version' % GITLAB_API
+        req = HTTPRequest(url,
+                          method="GET",
+                          headers=_api_headers(access_token),
+                          validate_cert=self.validate_server_cert)
+        resp = await AsyncHTTPClient().fetch(req, raise_error=True)
+        resp_json = json.loads(resp.body.decode('utf8', 'replace'))
+        return resp_json['version']
 
     async def _check_group_whitelist(self, user_id, access_token):
         http_client = AsyncHTTPClient()
         headers = _api_headers(access_token)
         # Check if user is a member of any group in the whitelist
         for group in map(url_escape, self.gitlab_group_whitelist):
-            url = "%s/groups/%s/members/all/%d" % (GITLAB_API, group, user_id)
+            url = "%s/groups/%s/members/%s%d" % (GITLAB_API, group, self.member_api_variant, user_id)
             req = HTTPRequest(url, method="GET", headers=headers)
             resp = await http_client.fetch(req, raise_error=False)
             if resp.code == 200:
@@ -186,7 +201,7 @@ class GitLabOAuthenticator(OAuthenticator):
         headers = _api_headers(access_token)
         # Check if user has developer access to any project in the whitelist
         for project in self.gitlab_project_id_whitelist:
-            url = "%s/projects/%s/members/all/%d" % (GITLAB_API, project, user_id)
+            url = "%s/projects/%s/members/%s%d" % (GITLAB_API, project, self.member_api_variant, user_id)
             req = HTTPRequest(url, method="GET", headers=headers)
             resp = await http_client.fetch(req, raise_error=False)
 

--- a/oauthenticator/tests/test_gitlab.py
+++ b/oauthenticator/tests/test_gitlab.py
@@ -189,7 +189,7 @@ async def test_project_id_whitelist(gitlab_client):
     harry_user_model = user_model('harry', 3588674)
     sheila_user_model = user_model('sheila', 3588675)
 
-    member_regex = re.compile(API_ENDPOINT + r'/projects/(.*)/members/(.*)')
+    member_regex = re.compile(API_ENDPOINT + r'/projects/(.*)/members/(.*)/all')
 
     def is_member(request):
         urlinfo = urlparse(request.url)

--- a/oauthenticator/tests/test_gitlab.py
+++ b/oauthenticator/tests/test_gitlab.py
@@ -74,11 +74,10 @@ async def test_group_whitelist(gitlab_client):
                           is_admin)
 
 
-    member_regex = re.compile(API_ENDPOINT + r'/groups/(.*)/members/(.*)/all')
+    member_regex = re.compile(API_ENDPOINT + r'/groups/(.*)/members/all\?query=(.*)')
     def is_member(request):
         urlinfo = urlparse(request.url)
-        group, uid = member_regex.match(urlinfo.path).group(1, 2)
-        uname = list(user_groups.keys())[int(uid) - 1]
+        group, uname = member_regex.match(urlinfo.path).group(1, 2)
         if group in user_groups[uname]:
             return HTTPResponse(request, 200)
         else:
@@ -163,8 +162,8 @@ async def test_project_id_whitelist(gitlab_client):
 
     user_projects = {
         '1231231': {
-            '3588673': {
-                'id': 3588674,
+            'john': {
+                'id': 3588673,
                 'name': 'john',
                 'username': 'john',
                 'state': 'active',
@@ -173,7 +172,7 @@ async def test_project_id_whitelist(gitlab_client):
                 'access_level': 10,  # Guest
                 'expires_at': '2030-02-23'
             },
-            '3588674': {
+            'harry': {
                 'id': 3588674,
                 'name': 'harry',
                 'username': 'harry',
@@ -189,14 +188,14 @@ async def test_project_id_whitelist(gitlab_client):
     harry_user_model = user_model('harry', 3588674)
     sheila_user_model = user_model('sheila', 3588675)
 
-    member_regex = re.compile(API_ENDPOINT + r'/projects/(.*)/members/(.*)/all')
+    member_regex = re.compile(API_ENDPOINT + r'/projects/(.*)/members/all\?query=(.*)')
 
     def is_member(request):
         urlinfo = urlparse(request.url)
-        project_id, uid = member_regex.match(urlinfo.path).group(1, 2)
+        project_id, uname = member_regex.match(urlinfo.path).group(1, 2)
 
-        if user_projects.get(project_id) and user_projects.get(project_id).get(uid):
-            res = user_projects.get(project_id).get(uid)
+        if user_projects.get(project_id) and user_projects.get(project_id).get(uname):
+            res = user_projects.get(project_id).get(uname)
             return HTTPResponse(request=request, code=200,
                 buffer=BytesIO(json.dumps(res).encode('utf8')),
                 headers={'Content-Type': 'application/json'},

--- a/oauthenticator/tests/test_gitlab.py
+++ b/oauthenticator/tests/test_gitlab.py
@@ -74,10 +74,12 @@ async def test_group_whitelist(gitlab_client):
                           is_admin)
 
 
-    member_regex = re.compile(API_ENDPOINT + r'/groups/(.*)/members/all\?query=(.*)')
+    group_regex = re.compile(API_ENDPOINT + r'/groups/(.*)/members/all')
+    uname_regex = re.compile('query=(.*)')
     def is_member(request):
         urlinfo = urlparse(request.url)
-        group, uname = member_regex.match(urlinfo.path).group(1, 2)
+        group = group_regex.match(urlinfo.path).group(1)
+        uname = uname_regex.match(urlinfo.query).group(1)
         if group in user_groups[uname]:
             return HTTPResponse(request, 200)
         else:
@@ -111,7 +113,7 @@ async def test_group_whitelist(gitlab_client):
                         buffer=BytesIO(json.dumps(ret).encode('utf-8')))
 
     client.hosts['gitlab.com'].append(
-        (member_regex, is_member)
+        (group_regex, is_member)
     )
 
     ## actual tests
@@ -188,11 +190,13 @@ async def test_project_id_whitelist(gitlab_client):
     harry_user_model = user_model('harry', 3588674)
     sheila_user_model = user_model('sheila', 3588675)
 
-    member_regex = re.compile(API_ENDPOINT + r'/projects/(.*)/members/all\?query=(.*)')
+    project_regex = re.compile(API_ENDPOINT + r'/projects/(.*)/members/all')
+    uname_regex = re.compile('query=(.*)')
 
     def is_member(request):
         urlinfo = urlparse(request.url)
-        project_id, uname = member_regex.match(urlinfo.path).group(1, 2)
+        project_id = project_regex.match(urlinfo.path).group(1)
+        uname = uname_regex.match(urlinfo.query).group(1)
 
         if user_projects.get(project_id) and user_projects.get(project_id).get(uname):
             res = user_projects.get(project_id).get(uname)
@@ -206,7 +210,7 @@ async def test_project_id_whitelist(gitlab_client):
             )
 
     client.hosts['gitlab.com'].append(
-        (member_regex, is_member)
+        (project_regex, is_member)
     )
 
     authenticator.gitlab_project_id_whitelist = [1231231]

--- a/oauthenticator/tests/test_gitlab.py
+++ b/oauthenticator/tests/test_gitlab.py
@@ -74,12 +74,10 @@ async def test_group_whitelist(gitlab_client):
                           is_admin)
 
 
-    group_regex = re.compile(API_ENDPOINT + r'/groups/(.*)/members/all')
-    uname_regex = re.compile('query=(.*)')
+    member_regex = re.compile(API_ENDPOINT + r'/groups/(.*)/members/all\?query=(.*)')
     def is_member(request):
         urlinfo = urlparse(request.url)
-        group = group_regex.match(urlinfo.path).group(1)
-        uname = uname_regex.match(urlinfo.query).group(1)
+        group, uname = member_regex.match(urlinfo.path).group(1, 2)
         if group in user_groups[uname]:
             return HTTPResponse(request, 200)
         else:
@@ -113,7 +111,7 @@ async def test_group_whitelist(gitlab_client):
                         buffer=BytesIO(json.dumps(ret).encode('utf-8')))
 
     client.hosts['gitlab.com'].append(
-        (group_regex, is_member)
+        (member_regex, is_member)
     )
 
     ## actual tests
@@ -190,13 +188,11 @@ async def test_project_id_whitelist(gitlab_client):
     harry_user_model = user_model('harry', 3588674)
     sheila_user_model = user_model('sheila', 3588675)
 
-    project_regex = re.compile(API_ENDPOINT + r'/projects/(.*)/members/all')
-    uname_regex = re.compile('query=(.*)')
+    member_regex = re.compile(API_ENDPOINT + r'/projects/(.*)/members/all\?query=(.*)')
 
     def is_member(request):
         urlinfo = urlparse(request.url)
-        project_id = project_regex.match(urlinfo.path).group(1)
-        uname = uname_regex.match(urlinfo.query).group(1)
+        project_id, uname = member_regex.match(urlinfo.path).group(1, 2)
 
         if user_projects.get(project_id) and user_projects.get(project_id).get(uname):
             res = user_projects.get(project_id).get(uname)
@@ -210,7 +206,7 @@ async def test_project_id_whitelist(gitlab_client):
             )
 
     client.hosts['gitlab.com'].append(
-        (project_regex, is_member)
+        (member_regex, is_member)
     )
 
     authenticator.gitlab_project_id_whitelist = [1231231]

--- a/oauthenticator/tests/test_gitlab.py
+++ b/oauthenticator/tests/test_gitlab.py
@@ -74,7 +74,7 @@ async def test_group_whitelist(gitlab_client):
                           is_admin)
 
 
-    member_regex = re.compile(API_ENDPOINT + r'/groups/(.*)/members/(.*)')
+    member_regex = re.compile(API_ENDPOINT + r'/groups/(.*)/members/(.*)/all')
     def is_member(request):
         urlinfo = urlparse(request.url)
         group, uid = member_regex.match(urlinfo.path).group(1, 2)

--- a/oauthenticator/tests/test_gitlab.py
+++ b/oauthenticator/tests/test_gitlab.py
@@ -74,10 +74,11 @@ async def test_group_whitelist(gitlab_client):
                           is_admin)
 
 
-    member_regex = re.compile(API_ENDPOINT + r'/groups/(.*)/members/all\?query=(.*)')
+    member_regex = re.compile(API_ENDPOINT + r'/groups/(.*)/members/(.*)/all')
     def is_member(request):
         urlinfo = urlparse(request.url)
-        group, uname = member_regex.match(urlinfo.path).group(1, 2)
+        group, uid = member_regex.match(urlinfo.path).group(1, 2)
+        uname = list(user_groups.keys())[int(uid) - 1]
         if group in user_groups[uname]:
             return HTTPResponse(request, 200)
         else:
@@ -162,8 +163,8 @@ async def test_project_id_whitelist(gitlab_client):
 
     user_projects = {
         '1231231': {
-            'john': {
-                'id': 3588673,
+            '3588673': {
+                'id': 3588674,
                 'name': 'john',
                 'username': 'john',
                 'state': 'active',
@@ -172,7 +173,7 @@ async def test_project_id_whitelist(gitlab_client):
                 'access_level': 10,  # Guest
                 'expires_at': '2030-02-23'
             },
-            'harry': {
+            '3588674': {
                 'id': 3588674,
                 'name': 'harry',
                 'username': 'harry',
@@ -188,14 +189,14 @@ async def test_project_id_whitelist(gitlab_client):
     harry_user_model = user_model('harry', 3588674)
     sheila_user_model = user_model('sheila', 3588675)
 
-    member_regex = re.compile(API_ENDPOINT + r'/projects/(.*)/members/all\?query=(.*)')
+    member_regex = re.compile(API_ENDPOINT + r'/projects/(.*)/members/(.*)/all')
 
     def is_member(request):
         urlinfo = urlparse(request.url)
-        project_id, uname = member_regex.match(urlinfo.path).group(1, 2)
+        project_id, uid = member_regex.match(urlinfo.path).group(1, 2)
 
-        if user_projects.get(project_id) and user_projects.get(project_id).get(uname):
-            res = user_projects.get(project_id).get(uname)
+        if user_projects.get(project_id) and user_projects.get(project_id).get(uid):
+            res = user_projects.get(project_id).get(uid)
             return HTTPResponse(request=request, code=200,
                 buffer=BytesIO(json.dumps(res).encode('utf8')),
                 headers={'Content-Type': 'application/json'},

--- a/oauthenticator/tests/test_gitlab.py
+++ b/oauthenticator/tests/test_gitlab.py
@@ -74,7 +74,7 @@ async def test_group_whitelist(gitlab_client):
                           is_admin)
 
 
-    member_regex = re.compile(API_ENDPOINT + r'/groups/(.*)/members/(.*)/all')
+    member_regex = re.compile(API_ENDPOINT + r'/groups/(.*)/members/all/(.*)')
     def is_member(request):
         urlinfo = urlparse(request.url)
         group, uid = member_regex.match(urlinfo.path).group(1, 2)
@@ -189,7 +189,7 @@ async def test_project_id_whitelist(gitlab_client):
     harry_user_model = user_model('harry', 3588674)
     sheila_user_model = user_model('sheila', 3588675)
 
-    member_regex = re.compile(API_ENDPOINT + r'/projects/(.*)/members/(.*)/all')
+    member_regex = re.compile(API_ENDPOINT + r'/projects/(.*)/members/all/(.*)')
 
     def is_member(request):
         urlinfo = urlparse(request.url)

--- a/oauthenticator/tests/test_gitlab.py
+++ b/oauthenticator/tests/test_gitlab.py
@@ -170,7 +170,7 @@ async def test_group_whitelist(gitlab_client):
 async def test_project_id_whitelist(gitlab_client):
     client = gitlab_client
     authenticator = GitLabOAuthenticator()
-    mock_api_version(client, '12.4')
+    mock_api_version(client, '12.4.0-pre')
 
     user_projects = {
         '1231231': {

--- a/oauthenticator/tests/test_gitlab.py
+++ b/oauthenticator/tests/test_gitlab.py
@@ -48,7 +48,7 @@ def mock_api_version(client, version):
 
 async def test_gitlab(gitlab_client):
     authenticator = GitLabOAuthenticator()
-    mock_api_version(gitlab_client, '12.3')
+    mock_api_version(gitlab_client, '12.3.1-ee')
     handler = gitlab_client.handler_for_user(user_model('wash'))
     user_info = await authenticator.authenticate(handler)
     assert sorted(user_info) == ['auth_state', 'name']
@@ -67,7 +67,7 @@ def make_link_header(urlinfo, page):
 async def test_group_whitelist(gitlab_client):
     client = gitlab_client
     authenticator = GitLabOAuthenticator()
-    mock_api_version(client, '12.4')
+    mock_api_version(client, '12.4.0-ee')
 
     ## set up fake Gitlab API
 

--- a/oauthenticator/tests/test_gitlab.py
+++ b/oauthenticator/tests/test_gitlab.py
@@ -81,9 +81,7 @@ async def test_group_whitelist(gitlab_client):
         }
 
     def group_user_model(username, is_admin=False):
-        return user_model(username,
-                          list(user_groups.keys()).index(username) + 1,
-                          is_admin)
+        return user_model(username, hash(username), is_admin)
 
     group_regex = re.compile(API_ENDPOINT + r'/groups/(.*)/members/all')
     uname_regex = re.compile('query=(.*)')

--- a/oauthenticator/tests/test_gitlab.py
+++ b/oauthenticator/tests/test_gitlab.py
@@ -81,7 +81,9 @@ async def test_group_whitelist(gitlab_client):
         }
 
     def group_user_model(username, is_admin=False):
-        return user_model(username, hash(username), is_admin)
+        return user_model(username,
+                          list(user_groups.keys()).index(username) + 1,
+                          is_admin)
 
     group_regex = re.compile(API_ENDPOINT + r'/groups/(.*)/members/all')
     uname_regex = re.compile('query=(.*)')

--- a/oauthenticator/tests/test_gitlab.py
+++ b/oauthenticator/tests/test_gitlab.py
@@ -68,22 +68,11 @@ async def test_group_whitelist(gitlab_client):
         'burns': ['blue', 'yellow'],
     })
 
-    def mock_user(username):
-        return {
-            'id': hash(username),
-            'name': 'name of ' + username,
-            'username': username,
-            'state': 'active',
-            'avatar_url': 'https://secure.gravatar.com/avatar/382a6b306679b2d97b547bfff3d73242?s=80&d=identicon',
-            'web_url': 'https://gitlab.com/' + username,
-            'access_level': 10,  # Guest
-            'expires_at': '2030-02-23'
-        }
-
     def group_user_model(username, is_admin=False):
         return user_model(username,
                           list(user_groups.keys()).index(username) + 1,
                           is_admin)
+
 
     group_regex = re.compile(API_ENDPOINT + r'/groups/(.*)/members/all')
     uname_regex = re.compile('query=(.*)')
@@ -91,13 +80,10 @@ async def test_group_whitelist(gitlab_client):
         urlinfo = urlparse(request.url)
         group = group_regex.match(urlinfo.path).group(1)
         uname = uname_regex.match(urlinfo.query).group(1)
-
-        res = [mock_user('not_the_user_we_want_to_find')]
         if group in user_groups[uname]:
-            res.append(mock_user(uname))
-
-        return HTTPResponse(request=request, code=200,
-                            buffer=BytesIO(json.dumps(res).encode('utf8')))
+            return HTTPResponse(request, 200)
+        else:
+            return HTTPResponse(request, 404)
 
     def groups(paginate, request):
         urlinfo = urlparse(request.url)
@@ -178,7 +164,7 @@ async def test_project_id_whitelist(gitlab_client):
 
     user_projects = {
         '1231231': {
-            'john': [{
+            'john': {
                 'id': 3588673,
                 'name': 'john',
                 'username': 'john',
@@ -188,17 +174,7 @@ async def test_project_id_whitelist(gitlab_client):
                 'access_level': 10,  # Guest
                 'expires_at': '2030-02-23'
             },
-            {
-                'id': 9999999,
-                'name': 'the other john',
-                'username': 'johntheother',
-                'state': 'active',
-                'avatar_url': 'https://secure.gravatar.com/avatar/382a6b306679b2d97b547bfff3d73242?s=80&d=identicon',
-                'web_url': 'https://gitlab.com/johntheother',
-                'access_level': 30,  # Developer
-                'expires_at': '2030-02-23'
-            }],
-            'harry': [{
+            'harry': {
                 'id': 3588674,
                 'name': 'harry',
                 'username': 'harry',
@@ -207,7 +183,7 @@ async def test_project_id_whitelist(gitlab_client):
                 'web_url': 'https://gitlab.com/harry',
                 'access_level': 30,  # Developer
                 'expires_at': '2030-02-23'
-            }]
+            }
         }
     }
     john_user_model = user_model('john', 3588673)
@@ -229,9 +205,8 @@ async def test_project_id_whitelist(gitlab_client):
                 headers={'Content-Type': 'application/json'},
             )
         else:
-            return HTTPResponse(request=request, code=200,
-                buffer=BytesIO('[]'.encode('utf8')),
-                headers={'Content-Type': 'application/json'},
+            return HTTPResponse(request=request, code=404,
+                buffer=BytesIO(''.encode('utf8'))
             )
 
     client.hosts['gitlab.com'].append(


### PR DESCRIPTION
When triaging a customer issue with the JupyterHub GitLab integration, 
we noticed that some members with access developer or above were
getting 403s when trying to log in via GitLab. The problem, we found, is
that the API call used by JupyterHub only retrieves direct group or project
members, as opposed to all members including inherited ones.

This is easily fixed by adding /all to the call.

See https://docs.gitlab.com/ee/api/members.html#list-all-members-of-a-group-or-project-including-inherited-members