### PR TITLE
Disable MediaWiki's mwoauth==0.3.5 due to a regression

### DIFF
--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -3,7 +3,7 @@
 codecov
 flake8
 pyjwt
-mwoauth != 0.3.1
+mwoauth != 0.3.1, != 0.3.5
 pytest >= 2.8
 pytest-cov
 pytest-asyncio


### PR DESCRIPTION
An issue is created upstream:
https://github.com/mediawiki-utilities/python-mwoauth/issues/35#issuecomment-546483608