### PR TITLE
Disable mwoauth==0.3.6 due to a regression

### DIFF
--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -3,7 +3,7 @@
 codecov
 flake8
 pyjwt
-mwoauth != 0.3.1, != 0.3.5
+mwoauth != 0.3.1, != 0.3.5, != 0.3.6
 pytest >= 2.8
 pytest-cov
 pytest-asyncio


### PR DESCRIPTION
See https://github.com/mediawiki-utilities/python-mwoauth/issues/38