### PR TITLE
[MRG] Travis: Deploy releases to pypi

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,14 +21,17 @@ after_success:
   - codecov
 
 jobs:
+  allow_failures:
+    - python: nightly
+  fast_finish: true
   include:
     # Default stage: test
     - python: 3.7
       env: TEST_LINT=1
-    - python: nightly
     - python: 3.7
     - python: 3.6
     - python: 3.5
+    - python: nightly
     # Only deploy if all test jobs passed
     - stage: deploy
       python: 3.7

--- a/.travis.yml
+++ b/.travis.yml
@@ -39,4 +39,4 @@ jobs:
       deploy:
         provider: pypi
         user: __token__
-        password: $PYPI_TOKEN
+        # password: see secret PYPI_PASSWORD variable

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,11 +2,7 @@ language: python
 sudo: false
 cache: pip
 dist: xenial
-python:
-  - nightly
-  - 3.7
-  - 3.6
-  - 3.5
+
 install:
   - pip install --upgrade pip
   - pip install --upgrade --pre -r test-requirements.txt .
@@ -24,7 +20,22 @@ script:
 after_success:
   - codecov
 
-matrix:
+jobs:
   include:
+    # Default stage: test
     - python: 3.7
       env: TEST_LINT=1
+    - python: nightly
+    - python: 3.7
+    - python: 3.6
+    - python: 3.5
+    # Only deploy if all test jobs passed
+    - stage: deploy
+      python: 3.7
+      if: tag IS present
+      deploy:
+        provider: pypi
+        user: __token__
+        password: $PYPI_TOKEN
+        on:
+          tags: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -37,5 +37,3 @@ jobs:
         provider: pypi
         user: __token__
         password: $PYPI_TOKEN
-        on:
-          tags: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -40,3 +40,4 @@ jobs:
         provider: pypi
         user: __token__
         # password: see secret PYPI_PASSWORD variable
+        distributions: sdist bdist_wheel


### PR DESCRIPTION
Release tagged builds to PyPi using Travis.

A matrix build will normally deploy multiple times. The usual way of deploying once is to use either [`skip_existing: true`](https://docs.travis-ci.com/user/deployment/pypi/#upload-artifacts-only-once) or a conditional that matches one of the jobs. The downside is that the deploy only depends on whether that particular job passes, other jobs in the matrix may fail.

I think using build stages is better because the deploy only happens if all matrix jobs pass. It's also clearer in travis since the deploy runs as it's own job.

I've tested this on testpypi:
- https://github.com/manics/oauthenticator/commit/aa53d6d1408d4881b499b48ab23c9869df6b2b6e
- https://test.pypi.org/project/oauthenticator-testpypi/0.0.1.dev3/
-  https://travis-ci.com/manics/oauthenticator/builds/135826346
![manics-oauthenticator-testpypi-travis](https://user-images.githubusercontent.com/1644105/68546570-9b7d1180-03cf-11ea-8ad3-53a21bf748ad.png)

Next steps:
- [ ] Either add a secret environment variable `PYPI_TOKEN` to Travis or add an encrypted secret to travis.yml

Related:
- https://github.com/jupyterhub/oauthenticator/issues/299
- https://github.com/jupyterhub/oauthenticator/pull/294 (I'll help update this if we decide to go ahead with the automatic deploy for this release)
- https://github.com/jupyterhub/team-compass/issues/213#issuecomment-548124874