### PR TITLE
hosted_domain can contain domains not hosted with Google but have accounts

### DIFF
--- a/oauthenticator/google.py
+++ b/oauthenticator/google.py
@@ -115,7 +115,7 @@ class GoogleOAuthenticator(OAuthenticator, GoogleOAuth2Mixin):
         if self.hosted_domain:
             if (
                 user_email_domain not in self.hosted_domain
-                or bodyjs['hd'] not in self.hosted_domain
+                or ('hd' in bodyjs and bodyjs['hd'] not in self.hosted_domain)
             ):
                 self.log.warning(
                     "Google OAuth unauthorized domain attempt: %s", user_email

--- a/oauthenticator/google.py
+++ b/oauthenticator/google.py
@@ -113,10 +113,7 @@ class GoogleOAuthenticator(OAuthenticator, GoogleOAuth2Mixin):
             raise HTTPError(403, "Google email {} not verified".format(user_email))
 
         if self.hosted_domain:
-            if (
-                user_email_domain not in self.hosted_domain
-                or ('hd' in bodyjs and bodyjs['hd'] not in self.hosted_domain)
-            ):
+            if user_email_domain not in self.hosted_domain:
                 self.log.warning(
                     "Google OAuth unauthorized domain attempt: %s", user_email
                 )


### PR DESCRIPTION
Very specific use case:

A domain, i.e. business.com, uses self-hosted email... but some users have created Google accounts using @business.com email addresses.

These accounts don't have the hd key in bodyjs[] dict from Google oauth2, but are valid Google accounts and authenticate correctly using the domain name alone.

This allows such Google accounts to auth alongside domains that may be hosted with Google.
