### PR TITLE
Truncate username to max 30 chars when fetching from AzureAD

### DIFF
--- a/oauthenticator/azuread.py
+++ b/oauthenticator/azuread.py
@@ -81,7 +81,7 @@ class AzureAdOAuthenticator(OAuthenticator):
         id_token = resp_json['id_token']
         decoded = jwt.decode(id_token, verify=False)
 
-        userdict = {"name": decoded[self.username_claim]}
+        userdict = {"name": decoded[self.username_claim][0:30]}
         userdict["auth_state"] = auth_state = {}
         auth_state['access_token'] = access_token
         # results in a decoded JWT for the user data


### PR DESCRIPTION
One of our client deployments has extremely long username_claim names, exceeding 63 characters.  This results in numerous cascading failures downstream, since the name field is leveraged in a number of places - such as pod name, volume name and as part of the URL