### PR TITLE
Extend oauth2 params sent to provider on first leg of oauth2 flow

### DIFF
--- a/oauthenticator/oauth2.py
+++ b/oauthenticator/oauth2.py
@@ -72,10 +72,6 @@ class OAuthLoginHandler(OAuth2Mixin, BaseHandler):
     def _OAUTH_USERINFO_URL(self):
         return self.authenticator.userdata_url
 
-    @property
-    def _OAUTH_EXTRA_AUTHORIZE_PARAMS(self):
-        return self.authenticator.extra_authorize_params
-
     def set_state_cookie(self, state):
         self.set_secure_cookie(STATE_COOKIE_NAME, state, expires_days=1, httponly=True)
 
@@ -266,10 +262,6 @@ class OAuthenticator(Authenticator):
         For GitHub in particular, you can see github_scopes.md in this repo.
         """,
     )
-
-    @default("extra_authorize_params")
-    def _extra_authorize_params(self):
-        return os.environ.get("OAUTH2_EXTRA_AUTHORIZE_PARAMS", {})
 
     extra_authorize_params = Dict(
         config=True,


### PR DESCRIPTION
Changes for #244. These changes expose a generic config option for passing in arbitrary options alongside the `state` parameter. One example is requesting refresh tokens, as in #211, which should look like this:

```
c.JupyterHub.authenticator_class.extra_authorize_params = {'access_type': 'offline'}
```

This may also solve #298 in order to select arbitrary accounts for Google. I created an app and tested the following:

```
c.LocalGoogleOAuthenticator.extra_authorize_params = {'prompt': 'select_account'}
```
Which generated the following URL: 
```
302 GET /hub/oauth_login?next= -> 
https://accounts.google.com/o/oauth2/v2/auth?
response_type=code&
redirect_uri=http%3A%2F%2Flocalhost%3A8000%2Fhub%2Foauth_callback&
client_id=[client]&
prompt=select_account&
state=[secret]&
scope=openid+email
```
This appeared to work, although I'm not familiar enough with Google to know if that worked exactly as intended. I tried requesting Google refresh tokens as well, but it didn't seem to want to give me any. I also tested with Globus, and was able to successfully request refresh tokens simply by setting `{'access_type': 'offline'}`.

