### PR TITLE
Fix failing GenericOAuthenticator tests

### DIFF
--- a/oauthenticator/generic.py
+++ b/oauthenticator/generic.py
@@ -68,10 +68,14 @@ class GenericOAuthenticator(OAuthenticator):
         help="Disable basic authentication for access token request",
     )
 
+    def http_client(self):
+        return AsyncHTTPClient(force_instance=True, defaults=dict(validate_cert=self.tls_verify))
+
+
     async def authenticate(self, handler, data=None):
         code = handler.get_argument("code")
         # TODO: Configure the curl_httpclient for tornado
-        http_client = AsyncHTTPClient(force_instance=True, defaults=dict(validate_cert=self.tls_verify))
+        http_client = self.http_client()
 
         params = dict(
             redirect_uri=self.get_callback_url(handler),

--- a/oauthenticator/tests/test_generic.py
+++ b/oauthenticator/tests/test_generic.py
@@ -3,6 +3,7 @@ from pytest import fixture, mark
 from ..generic import GenericOAuthenticator
 
 from .mocks import setup_oauth_mock
+from unittest import mock
 
 
 def user_model(username, **kwargs):
@@ -32,25 +33,30 @@ def generic_client(client):
 
 
 async def test_generic(generic_client):
-    authenticator = Authenticator()
-    handler = generic_client.handler_for_user(user_model('wash'))
-    user_info = await authenticator.authenticate(handler)
-    assert sorted(user_info) == ['auth_state', 'name']
-    name = user_info['name']
-    assert name == 'wash'
-    auth_state = user_info['auth_state']
-    assert 'access_token' in auth_state
-    assert 'oauth_user' in auth_state
-    assert 'refresh_token' in auth_state
-    assert 'scope' in auth_state
+    with mock.patch.object(GenericOAuthenticator, 'http_client') as fake_client:
+        fake_client.return_value = generic_client
+        authenticator = Authenticator()
+
+        handler = generic_client.handler_for_user(user_model('wash'))
+        user_info = await authenticator.authenticate(handler)
+        assert sorted(user_info) == ['auth_state', 'name']
+        name = user_info['name']
+        assert name == 'wash'
+        auth_state = user_info['auth_state']
+        assert 'access_token' in auth_state
+        assert 'oauth_user' in auth_state
+        assert 'refresh_token' in auth_state
+        assert 'scope' in auth_state
 
 
 async def test_generic_callable_username_key(generic_client):
-    authenticator = Authenticator(
-        username_key=lambda r: r['alternate_username']
-    )
-    handler = generic_client.handler_for_user(
-        user_model('wash', alternate_username='zoe')
-    )
-    user_info = await authenticator.authenticate(handler)
-    assert user_info['name'] == 'zoe'
+    with mock.patch.object(GenericOAuthenticator, 'http_client') as fake_client:
+        fake_client.return_value = generic_client
+        authenticator = Authenticator(
+            username_key=lambda r: r['alternate_username']
+        )
+        handler = generic_client.handler_for_user(
+            user_model('wash', alternate_username='zoe')
+        )
+        user_info = await authenticator.authenticate(handler)
+        assert user_info['name'] == 'zoe'


### PR DESCRIPTION
Creating the `AsyncHTTPClient` with `force_instance=True` attribute in `GenericOAuthenticator` made the tests fail because the mocked http client was not being used anymore and instead an actual `AsyncHttpClient` instance was being created and used (ref: https://github.com/tornadoweb/tornado/blob/master/tornado/httpclient.py#L200).

This PR forces the `GenericOAuthenticator` tests use the mocked http client.