### PR TITLE
Google Groups whitelist and admin group

### DIFF
--- a/oauthenticator/google.py
+++ b/oauthenticator/google.py
@@ -29,7 +29,7 @@ class GoogleOAuthenticator(OAuthenticator, GoogleOAuth2Mixin):
         """get default google apis url from env"""
         google_api_url = os.getenv('GOOGLE_API_URL')
 
-        # default to gitlab.com
+        # default to googleapis.com
         if not google_api_url:
             google_api_url = 'https://www.googleapis.com'
 
@@ -170,14 +170,14 @@ class GoogleOAuthenticator(OAuthenticator, GoogleOAuth2Mixin):
         no_config_specified = not is_group_specified
 
         if is_admin_group_specified and is_admin:
-            self.log.info("%s is in the admin group", username)
+            self.log.debug("%s is in the admin group", username)
             return {
                 'name': username,
                 'auth_state': {'access_token': access_token, 'google_user': bodyjs},
                 'admin': is_admin,
             }
         elif is_admin_group_specified and is_group_specified and user_in_group:
-            self.log.info("%s can login on this server", username)
+            self.log.debug"%s can login on this server", username)
             return {
                 'name': username,
                 'auth_state': {'access_token': access_token, 'google_user': bodyjs},
@@ -187,7 +187,7 @@ class GoogleOAuthenticator(OAuthenticator, GoogleOAuth2Mixin):
             (is_group_specified and user_in_group)
             or no_config_specified
         ):
-            self.log.info("%s can login on this server", username)
+            self.log.debug("%s can login on this server", username)
             return {
                 'name': username,
                 'auth_state': {'access_token': access_token, 'google_user': bodyjs},

--- a/oauthenticator/google.py
+++ b/oauthenticator/google.py
@@ -25,7 +25,7 @@ class GoogleOAuthenticator(OAuthenticator, GoogleOAuth2Mixin):
     google_api_url = Unicode("https://www.googleapis.com", config=True)
 
     @default('google_api_base_url')
-    def _google_api_base_url(self)
+    def _default_google_api_base_url(self):
         """get default google apis url from env"""
         google_api_url = os.getenv('GOOGLE_API_URL')
 
@@ -53,9 +53,11 @@ class GoogleOAuthenticator(OAuthenticator, GoogleOAuth2Mixin):
         config=True, help="Automatically whitelist members of selected groups"
     )
 
-    user_info_url = Unicode(
-        "%s/oauth2/v1/userinfo" % (self.google_api_url), config=True
-    )
+    user_info_url = Unicode(config=True)
+
+    @default('user_info_url')
+    def _user_info_url(self):
+        return "%s/oauth2/v1/userinfo" % (self.google_api_url)
 
     hosted_domain = List(
         Unicode(),

--- a/oauthenticator/google.py
+++ b/oauthenticator/google.py
@@ -36,14 +36,14 @@ class GoogleOAuthenticator(OAuthenticator, GoogleOAuth2Mixin):
 
     @default("token_url")
     def _token_url_default(self):
-        return "%s/oauth2/v4/token" % (self.google_api_base_url)
+        return "%s/oauth2/v4/token" % (google_api_base_url)
 
     google_group_whitelist = Set(
         config=True, help="Automatically whitelist members of selected groups"
     )
 
     user_info_url = Unicode(
-        "%s/oauth2/v1/userinfo" % (self.google_api_base_url), config=True
+        "%s/oauth2/v1/userinfo" % (google_api_base_url), config=True
     )
 
     hosted_domain = List(

--- a/oauthenticator/google.py
+++ b/oauthenticator/google.py
@@ -177,7 +177,7 @@ class GoogleOAuthenticator(OAuthenticator, GoogleOAuth2Mixin):
                 'admin': is_admin,
             }
         elif is_admin_group_specified and is_group_specified and user_in_group:
-            self.log.debug"%s can login on this server", username)
+            self.log.debug("%s can login on this server", username)
             return {
                 'name': username,
                 'auth_state': {'access_token': access_token, 'google_user': bodyjs},

--- a/oauthenticator/google.py
+++ b/oauthenticator/google.py
@@ -22,7 +22,7 @@ from .oauth2 import OAuthLoginHandler, OAuthCallbackHandler, OAuthenticator
 
 
 class GoogleOAuthenticator(OAuthenticator, GoogleOAuth2Mixin):
-    google_api_base_url = "https://www.googleapis.com"
+    google_api_base_url = Unicode("https://www.googleapis.com", config=True)
 
     # add the following to your jupyterhub_config.py to check groups
     # c.GoogleOAuthenticator.scope = ['openid', 'email', 'https://www.googleapis.com/auth/admin.directory.group.readonly']
@@ -165,7 +165,7 @@ class GoogleOAuthenticator(OAuthenticator, GoogleOAuth2Mixin):
         # Check if user is a member of any group in the whitelist
         for group in map(url_escape, self.google_group_whitelist):
             url = "%s/admin/directory/v1/groups/%s/members/%s" % (
-                self.google_api_base_url,
+                google_api_base_url,
                 "%s@%s" % (user_email, user_email_domain),
                 user_email,
             )

--- a/oauthenticator/google.py
+++ b/oauthenticator/google.py
@@ -13,7 +13,7 @@ from tornado.httpclient import AsyncHTTPClient
 from tornado.auth import GoogleOAuth2Mixin
 from tornado.web import HTTPError
 
-from traitlets import Unicode, List, default, validate
+from traitlets import Set, Unicode, List, default, validate
 
 from jupyterhub.auth import LocalAuthenticator
 from jupyterhub.utils import url_path_join


### PR DESCRIPTION
in ` jupyterhub_config.py` add the lines below:

```python
c.GoogleOAuthenticator.google_group_whitelist = { 'someGSuiteGroup' }
c.GoogleOAuthenticator.admin_google_groups = {'gSuiteGroupWhoseMembersShouldBeAdmins'}
c.GoogleOAuthenticator.scope = ['openid', 'email', 'https://www.googleapis.com/auth/admin.directory.group.readonly']
```

I have to admit I made the changes to make it work, but this is not pretty, let me know if there is something you'd like me to change.