### PR TITLE
Adding google groups optional support

### DIFF
--- a/docs/source/google.md
+++ b/docs/source/google.md
@@ -7,14 +7,14 @@ If you'd like to rely on google groups for managing access to jupyterhub you'd h
 ## Install googlegroups `extra_requires`
 
 ```shell
-pip install oauthenticator[oauthenticator]
+pip install oauthenticator[googlegroups]
 ```
 
 ## Create a service account that only has read access to groups and users that can impersonate a G Suite admin user
 
-Google does not offer a way for letting using users check which groups they belong to via an API,
-because of this caveat the way to be able to check what groups an user belongs to we have user a service account
-and allow give it read only access to users and groups.
+Google does not offer a way for letting users check which groups they belong to via an API,
+because of this caveat the way to be able to check what groups an user belongs to we have use a service account
+and give it read only access to users and groups.
 
 ## Instructions
 

--- a/docs/source/google.md
+++ b/docs/source/google.md
@@ -1,0 +1,54 @@
+# Google specific configs
+
+**Note:** The instructions below are to be performed after [finishing setting up google](https://oauthenticator.readthedocs.io/en/latest/getting-started.html#google-setup)
+
+If you'd like to rely on google groups for managing access to jupyterhub you'd have to do the following:
+
+## Install googlegroups `extra_requires`
+
+```shell
+pip install oauthenticator[oauthenticator]
+```
+
+## Create a service account that only has read access to groups and users that can impersonate a G Suite admin user
+
+Google does not offer a way for letting using users check which groups they belong to via an API,
+because of this caveat the way to be able to check what groups an user belongs to we have user a service account
+and allow give it read only access to users and groups.
+
+## Instructions
+
+### Create service account and credentials
+
+1. Open the [**Service accounts** page](https://console.developers.google.com/iam-admin/serviceaccounts). If prompted, select a project.
+2. Click add (`+`) **Create Service Account**, enter a name and description for the service account. You can use the default service account ID, or choose a different, unique one. When done click **Create**.
+3. The **Service account permissions (optional)** section that follows is not required. Click **Continue**.
+4. On the **Grant users access to this service account** screen, scroll down to the **Create key** section. Click add (`+`) **Create key**.
+5. n the side panel that appears, select the format for your key: **JSON**
+6. Click **Create**. Your new public/private key pair is generated and downloaded to your machine; it serves as the only copy of this key. For information on how to store it securely, see [Managing service account keys](https://cloud.google.com/iam/docs/understanding-service-accounts#managing_service_account_keys).
+7. Click **Close** on the **Private key saved to your computer** dialog, then click **Done** to return to the table of your service accounts.
+8. Locate the newly-created service account in the table. Under `Actions`, click  then **Edit**.
+9. In the service account details, click 🔽 **Show domain-wide delegation**, then ensure the **Enable G Suite Domain-wide Delegation** checkbox is checked.
+10. If you haven't yet configured your app's OAuth consent screen, you must do so before you can enable domain-wide delegation. Follow the on-screen instructions to configure the OAuth consent screen, then repeat the above steps and re-check the checkbox.
+11. Click **Save** to update the service account, and return to the table of service accounts. A new column, **Domain-wide delegation**, can be seen. Click **View Client ID**, to obtain and make a note of the client ID.
+
+### Delegate domain-wide authority to your service account
+
+1. Go to your G Suite domain’s [Admin console](http://admin.google.com/).
+2. Select **Security** from the list of controls. If you don't see **Security** listed, select **More controls** from the gray bar at the bottom of the page, then select **Security** from the list of controls.
+3. Select **Advanced settings** from the list of options.
+4. Select **Manage API client access** in the **Authentication** section.
+5. In the **Client name** field, enter the client ID obtained from the service account creation steps above.
+6. In the **One or More API Scopes** field enter the scopes required for your application (for a list of possible scopes, see [Authorize requests](https://developers.google.com/admin-sdk/directory/v1/guides/authorizing)). Please enter: `https://www.googleapis.com/auth/admin.directory.user.readonly, https://www.googleapis.com/auth/admin.directory.group.readonly`
+7. Click the **Authorize** button.
+
+### Configure `jupyterhub_config.py` add the lines below:
+
+```python
+c.GoogleOAuthenticator.gsuite_administrator = {'example.com': 'someuser'}
+c.GoogleOAuthenticator.google_service_account_keys = {'example.com': '/path/to/service_account.json'}
+c.GoogleOAuthenticator.admin_google_groups = {'example.com': ['someadmingroup']}
+c.GoogleOAuthenticator.google_group_whitelist = {'example.com': ['somegroupwithaccess', 'othergroupwithaccess'] }
+```
+
+### You are done!

--- a/docs/source/google.md
+++ b/docs/source/google.md
@@ -44,6 +44,10 @@ and give it read only access to users and groups.
 
 ### Configure `jupyterhub_config.py` add the lines below:
 
+**Note:** if you remove a member from a google group you will have to force this user to login again in order for the change to take effect
+
+#### if you want to manage admin users and whitelisted via google groups
+
 ```python
 c.GoogleOAuthenticator.gsuite_administrator = {'example.com': 'someuser'}
 c.GoogleOAuthenticator.google_service_account_keys = {'example.com': '/path/to/service_account.json'}
@@ -51,4 +55,11 @@ c.GoogleOAuthenticator.admin_google_groups = {'example.com': ['someadmingroup']}
 c.GoogleOAuthenticator.google_group_whitelist = {'example.com': ['somegroupwithaccess', 'othergroupwithaccess'] }
 ```
 
+#### if you only want to whitelist users via google groups
+
+```python
+c.GoogleOAuthenticator.gsuite_administrator = {'example.com': 'someuser'}
+c.GoogleOAuthenticator.google_service_account_keys = {'example.com': '/path/to/service_account.json'}
+c.GoogleOAuthenticator.google_group_whitelist = {'example.com': ['somegroupwithaccess', 'othergroupwithaccess'] }
+```
 ### You are done!

--- a/oauthenticator/google.py
+++ b/oauthenticator/google.py
@@ -169,7 +169,7 @@ class GoogleOAuthenticator(OAuthenticator, GoogleOAuth2Mixin):
 
         if self.admin_google_groups or self.google_group_whitelist:
                 credentials = await self._service_client_credentials(
-                        scopes=['https://www.googleapis.com/auth/admin.directory.group.readonly'],
+                        scopes=['%s/auth/admin.directory.group.readonly' % (self.google_api_url)],
                         user_email_domain=user_email_domain)
                 google_groups = await self._google_groups_for_user(
                         user_email=user_email,

--- a/oauthenticator/google.py
+++ b/oauthenticator/google.py
@@ -174,6 +174,7 @@ class GoogleOAuthenticator(OAuthenticator, GoogleOAuth2Mixin):
             groups_user_is_member_of = await self._google_groups_for_user(
                     user_email=user_email,
                     credentials=credentials)
+            bodyjs['google_groups'] = groups_user_is_member_of
 
         # Check if user is a member of any admin groups.
         is_admin = False

--- a/oauthenticator/tests/test_google.py
+++ b/oauthenticator/tests/test_google.py
@@ -8,6 +8,7 @@ from ..google import GoogleOAuthenticator
 
 from .mocks import setup_oauth_mock
 
+
 def user_model(email):
     """Return a user model"""
     return {'email': email, 'hd': email.split('@')[1], 'verified_email': True}

--- a/oauthenticator/tests/test_google.py
+++ b/oauthenticator/tests/test_google.py
@@ -76,28 +76,28 @@ async def test_user_in_groups(google_client):
         google_group_whitelist = {'email.com': ['fakegroup'] }
     )
     admin_user = user_model('fakeadmin@email.com')
-    admin_user['groups'] = ['anotherone', 'fakeadmingroup']
+    admin_user['google_groups'] = ['anotherone', 'fakeadmingroup']
     user_is_admin = await check_user_in_groups(
-        member_groups=admin_user['groups'],
+        member_groups=admin_user['google_groups'],
         allowed_groups=authenticator.admin_google_groups[admin_user['hd']]
     )
     assert user_is_admin == True
     whitelist_user = user_model('fakewhitelisted@email.com')
-    whitelist_user['groups'] = ['anotherone', 'fakegroup']
+    whitelist_user['google_groups'] = ['anotherone', 'fakegroup']
     user_is_whitelisted = await check_user_in_groups(
-        member_groups=whitelist_user['groups'],
+        member_groups=whitelist_user['google_groups'],
         allowed_groups=authenticator.google_group_whitelist[whitelist_user['hd']]
     )
     user_is_not_admin = await check_user_in_groups(
-        member_groups=whitelist_user['groups'],
+        member_groups=whitelist_user['google_groups'],
         allowed_groups=authenticator.admin_google_groups[whitelist_user['hd']]
     )
     assert user_is_whitelisted == True
     assert user_is_not_admin == False
     non_whitelist_user = user_model('fakenonwhitelisted@email.com')
-    non_whitelist_user['groups'] = ['anotherone', 'fakenonwhitelistedgroup']
+    non_whitelist_user['google_groups'] = ['anotherone', 'fakenonwhitelistedgroup']
     user_is_not_whitelisted = await check_user_in_groups(
-        member_groups=non_whitelist_user['groups'],
+        member_groups=non_whitelist_user['google_groups'],
         allowed_groups=authenticator.google_group_whitelist[non_whitelist_user['hd']]
     )
     assert user_is_not_whitelisted == False

--- a/oauthenticator/tests/test_google.py
+++ b/oauthenticator/tests/test_google.py
@@ -97,7 +97,9 @@ async def test_user_in_groups(google_client):
     whitelist_handler = google_client.handler_for_user(user_model('fakewhitelisted@email.com'))
     whitelist_user_info = await non_admin_authenticator.authenticate(whitelist_handler, google_groups=['anotherone', 'fakegroup'])
     user_is_whitelisted = whitelist_user_info['auth_state']['google_user']['google_groups']
+    admin_field_does_not_exist = whitelist_user_info.get('admin')
     assert 'fakegroup' in user_is_whitelisted
+    assert admin_field_does_not_exist is None
     non_whitelist_handler = google_client.handler_for_user(user_model('fakenonwhitelisted@email.com'))
     non_whitelist_user_info = await non_admin_authenticator.authenticate(non_whitelist_handler, google_groups=['anotherone', 'fakenonwhitelistedgroup'])
     assert non_whitelist_user_info is None

--- a/oauthenticator/tests/test_google.py
+++ b/oauthenticator/tests/test_google.py
@@ -1,4 +1,3 @@
-import os
 import re
 from unittest.mock import Mock
 

--- a/oauthenticator/tests/test_google.py
+++ b/oauthenticator/tests/test_google.py
@@ -77,18 +77,18 @@ async def test_user_in_groups(google_client):
     )
     admin_user = user_model('fakeadmin@email.com')
     admin_user['google_groups'] = ['anotherone', 'fakeadmingroup']
-    user_is_admin = await check_user_in_groups(
+    user_is_admin = check_user_in_groups(
         member_groups=admin_user['google_groups'],
         allowed_groups=authenticator.admin_google_groups[admin_user['hd']]
     )
     assert user_is_admin == True
     whitelist_user = user_model('fakewhitelisted@email.com')
     whitelist_user['google_groups'] = ['anotherone', 'fakegroup']
-    user_is_whitelisted = await check_user_in_groups(
+    user_is_whitelisted = check_user_in_groups(
         member_groups=whitelist_user['google_groups'],
         allowed_groups=authenticator.google_group_whitelist[whitelist_user['hd']]
     )
-    user_is_not_admin = await check_user_in_groups(
+    user_is_not_admin = check_user_in_groups(
         member_groups=whitelist_user['google_groups'],
         allowed_groups=authenticator.admin_google_groups[whitelist_user['hd']]
     )
@@ -96,7 +96,7 @@ async def test_user_in_groups(google_client):
     assert user_is_not_admin == False
     non_whitelist_user = user_model('fakenonwhitelisted@email.com')
     non_whitelist_user['google_groups'] = ['anotherone', 'fakenonwhitelistedgroup']
-    user_is_not_whitelisted = await check_user_in_groups(
+    user_is_not_whitelisted = check_user_in_groups(
         member_groups=non_whitelist_user['google_groups'],
         allowed_groups=authenticator.google_group_whitelist[non_whitelist_user['hd']]
     )

--- a/setup.py
+++ b/setup.py
@@ -110,6 +110,9 @@ with open('requirements.txt') as f:
             continue
         install_requires.append(req)
 
+setup_args['extras_require'] = {
+    'googlegroups': ['google-api-python-client==1.7.11', 'google-auth-oauthlib==0.4.1']
+}
 
 def main():
     setup(**setup_args)


### PR DESCRIPTION
Learned from my mistakes on https://github.com/jupyterhub/oauthenticator/pull/340

first follow: https://developers.google.com/admin-sdk/directory/v1/guides/delegation#delegate_domain-wide_authority_to_your_service_account

>In the Google G Suite admin console open the [Manage API](https://admin.google.com/ManageOauthClients) click access by going to the _Advanced settings_ in the _Security_ section and clicking _Manage API client access_. Set the Client Name to the Client ID from above. Then set One or More API Scopes to `https://www.googleapis.com/auth/admin.directory.user.readonly, https://www.googleapis.com/auth/admin.directory.group.readonly`. Then click _Authorize_ and the client should show both API scopes as shown below.

These instructions I got them from [here](https://docs.pritunl.com/docs/google)

in ` jupyterhub_config.py` add the lines below:

```python
c.GoogleOAuthenticator.gsuite_administrator = {'example.com': 'someuser'}
c.GoogleOAuthenticator.google_service_account_keys = {'example.com': '/path/to/service_account.json'}
c.GoogleOAuthenticator.admin_google_groups = {'example.com': ['someadmingroup']}
c.GoogleOAuthenticator.google_group_whitelist = {'example.com': ['somegroupwithaccess', 'othergroupwithaccess'] }
```

I have to admit I made the changes to make it work, but this is not pretty, let me know if there is something you'd like me to change.