### PR TITLE
Adding refresh_token to GoogleOAuthenticator

### DIFF
--- a/docs/source/google.md
+++ b/docs/source/google.md
@@ -74,3 +74,5 @@ c.JupyterHub.authenticator_class = GoogleOAuthenticator
 GoogleLoginHandler.extra_params = {'access_type': 'offline', 'approval_prompt': 'force'}
 c.GoogleOAuthenticator.login_handler = GoogleLoginHandler
 ```
+
+For more params you can use go [here](https://developers.google.com/identity/protocols/oauth2/web-server#creatingclient)

--- a/docs/source/google.md
+++ b/docs/source/google.md
@@ -63,3 +63,14 @@ c.GoogleOAuthenticator.google_service_account_keys = {'example.com': '/path/to/s
 c.GoogleOAuthenticator.google_group_whitelist = {'example.com': ['somegroupwithaccess', 'othergroupwithaccess'] }
 ```
 ### You are done!
+
+## How to retrieve an `access_token` and `refresh_token` for all scopes at once
+
+In your `jupyterhub_config.py` do the following:
+
+```python
+from oauthenticator.google import GoogleOAuthenticator, GoogleLoginHandler
+c.JupyterHub.authenticator_class = GoogleOAuthenticator
+GoogleLoginHandler.retrieve_all_scopes_at_once = True
+c.GoogleOAuthenticator.login_handler = GoogleLoginHandler
+```

--- a/docs/source/google.md
+++ b/docs/source/google.md
@@ -69,7 +69,7 @@ c.GoogleOAuthenticator.google_group_whitelist = {'example.com': ['somegroupwitha
 In your `jupyterhub_config.py` do the following:
 
 ```python
-c.JupyterHub.authenticator_class.extra_authorize_params = {'access_type': 'offline', 'approval_prompt': 'force'}
+c.OAuthenticator.extra_authorize_params = {'access_type': 'offline', 'approval_prompt': 'force'}
 ```
 
 For more params you can use go [here](https://developers.google.com/identity/protocols/oauth2/web-server#creatingclient)

--- a/docs/source/google.md
+++ b/docs/source/google.md
@@ -69,10 +69,7 @@ c.GoogleOAuthenticator.google_group_whitelist = {'example.com': ['somegroupwitha
 In your `jupyterhub_config.py` do the following:
 
 ```python
-from oauthenticator.google import GoogleOAuthenticator, GoogleLoginHandler
-c.JupyterHub.authenticator_class = GoogleOAuthenticator
-GoogleLoginHandler.extra_params = {'access_type': 'offline', 'approval_prompt': 'force'}
-c.GoogleOAuthenticator.login_handler = GoogleLoginHandler
+c.JupyterHub.authenticator_class.extra_authorize_params = {'access_type': 'offline', 'approval_prompt': 'force'}
 ```
 
 For more params you can use go [here](https://developers.google.com/identity/protocols/oauth2/web-server#creatingclient)

--- a/docs/source/google.md
+++ b/docs/source/google.md
@@ -71,6 +71,6 @@ In your `jupyterhub_config.py` do the following:
 ```python
 from oauthenticator.google import GoogleOAuthenticator, GoogleLoginHandler
 c.JupyterHub.authenticator_class = GoogleOAuthenticator
-GoogleLoginHandler.retrieve_all_scopes_at_once = True
+GoogleLoginHandler.extra_params = {'access_type': 'offline', 'approval_prompt': 'force'}
 c.GoogleOAuthenticator.login_handler = GoogleLoginHandler
 ```

--- a/oauthenticator/google.py
+++ b/oauthenticator/google.py
@@ -13,7 +13,7 @@ from tornado.httpclient import HTTPRequest, AsyncHTTPClient
 from tornado.auth import GoogleOAuth2Mixin
 from tornado.web import HTTPError
 
-from traitlets import Bool, Dict, Unicode, List, default, validate
+from traitlets import Dict, Unicode, List, default, validate
 
 from jupyterhub.crypto import decrypt, EncryptionUnavailable, InvalidToken
 from jupyterhub.auth import LocalAuthenticator
@@ -31,17 +31,14 @@ def check_user_in_groups(member_groups, allowed_groups):
 class GoogleLoginHandler(OAuthLoginHandler):
     """See https://developers.google.com/identity/protocols/oauth2 for general information."""
 
-    retrieve_all_scopes_at_once = Bool(
-        os.environ.get('GOOGLE_LOGIN_ALL_SCOPES', 'False').lower() in {'true', '1'},
-        help="Set extra_params `access_type` to `offline` and `approval_prompt` to `force`"
+    extra_params = Dict(
+        Unicode(),
+        help="Add extra_params to authorize_redirect"
     ).tag(config=True)
 
     def authorize_redirect(self, *args, **kwargs):
-        """Add `access_type`, `approval_prompt` to redirect params"""
-        if self.retrieve_all_scopes_at_once:
-            extra_params = kwargs.setdefault('extra_params', {})
-            extra_params["access_type"] = 'offline'
-            extra_params["approval_prompt"] = 'force'
+        extra_params = kwargs.setdefault('extra_params', {})
+        extra_params.update(self.extra_params)
 
         return super().authorize_redirect(*args, **kwargs)
 

--- a/oauthenticator/google.py
+++ b/oauthenticator/google.py
@@ -13,7 +13,7 @@ from tornado.httpclient import HTTPRequest, AsyncHTTPClient
 from tornado.auth import GoogleOAuth2Mixin
 from tornado.web import HTTPError
 
-from traitlets import Dict, Unicode, List, default, validate
+from traitlets import Bool, Dict, Unicode, List, default, validate
 
 from jupyterhub.crypto import decrypt, EncryptionUnavailable, InvalidToken
 from jupyterhub.auth import LocalAuthenticator
@@ -31,11 +31,17 @@ def check_user_in_groups(member_groups, allowed_groups):
 class GoogleLoginHandler(OAuthLoginHandler):
     """See https://developers.google.com/identity/protocols/oauth2 for general information."""
 
+    retrieve_all_scopes_at_once = Bool(
+        os.environ.get('GOOGLE_LOGIN_ALL_SCOPES', 'False').lower() in {'true', '1'},
+        help="Set extra_params `access_type` to `offline` and `approval_prompt` to `force`"
+    ).tag(config=True)
+
     def authorize_redirect(self, *args, **kwargs):
         """Add `access_type`, `approval_prompt` to redirect params"""
-        extra_params = kwargs.setdefault('extra_params', {})
-        extra_params["access_type"] = 'offline'
-        extra_params["approval_prompt"] = 'force'
+        if self.retrieve_all_scopes_at_once:
+            extra_params = kwargs.setdefault('extra_params', {})
+            extra_params["access_type"] = 'offline'
+            extra_params["approval_prompt"] = 'force'
 
         return super().authorize_redirect(*args, **kwargs)
 

--- a/oauthenticator/google.py
+++ b/oauthenticator/google.py
@@ -19,7 +19,7 @@ from jupyterhub.crypto import decrypt, EncryptionUnavailable, InvalidToken
 from jupyterhub.auth import LocalAuthenticator
 from jupyterhub.utils import url_path_join
 
-from .oauth2 import OAuthCallbackHandler, OAuthenticator
+from .oauth2 import OAuthLoginHandler, OAuthCallbackHandler, OAuthenticator
 
 def check_user_in_groups(member_groups, allowed_groups):
     # Check if user is a member of any group in the allowed groups

--- a/oauthenticator/google.py
+++ b/oauthenticator/google.py
@@ -183,12 +183,12 @@ class GoogleOAuthenticator(OAuthenticator, GoogleOAuth2Mixin):
 
         if refresh_token == None:
             self.log.debug("Refresh token was empty, will try to pull refresh_token from previous auth_state")
-            user = handler.find_user(name=username)
-            encrypted = user.encrypted_auth_state
+            user = handler.find_user(username)
 
-            if encrypted:
+            if user:
                 self.log.debug("encrypted_auth_state was found, will try to decrypt and pull refresh_token from it")
                 try:
+                    encrypted = user.encrypted_auth_state
                     auth_state = await decrypt(encrypted)
                     refresh_token = auth_state.get('refresh_token')
                 except (ValueError, InvalidToken, EncryptionUnavailable) as e:

--- a/oauthenticator/google.py
+++ b/oauthenticator/google.py
@@ -181,7 +181,7 @@ class GoogleOAuthenticator(OAuthenticator, GoogleOAuth2Mixin):
                 # unambiguous domain, use only base name
                 username = user_email.split('@')[0]
 
-        if refresh_token == None:
+        if refresh_token is None:
             self.log.debug("Refresh token was empty, will try to pull refresh_token from previous auth_state")
             user = handler.find_user(username)
 

--- a/oauthenticator/google.py
+++ b/oauthenticator/google.py
@@ -28,6 +28,7 @@ def check_user_in_groups(member_groups, allowed_groups):
     else:
         return False
 
+
 class GoogleOAuthenticator(OAuthenticator, GoogleOAuth2Mixin):
     google_api_url = Unicode("https://www.googleapis.com", config=True)
 

--- a/oauthenticator/google.py
+++ b/oauthenticator/google.py
@@ -19,7 +19,7 @@ from jupyterhub.crypto import decrypt, EncryptionUnavailable, InvalidToken
 from jupyterhub.auth import LocalAuthenticator
 from jupyterhub.utils import url_path_join
 
-from .oauth2 import OAuthLoginHandler, OAuthCallbackHandler, OAuthenticator
+from .oauth2 import OAuthCallbackHandler, OAuthenticator
 
 def check_user_in_groups(member_groups, allowed_groups):
     # Check if user is a member of any group in the allowed groups
@@ -27,20 +27,6 @@ def check_user_in_groups(member_groups, allowed_groups):
         return True  # user _is_ in group
     else:
         return False
-
-class GoogleLoginHandler(OAuthLoginHandler):
-    """See https://developers.google.com/identity/protocols/oauth2 for general information."""
-
-    extra_params = Dict(
-        Unicode(),
-        help="Add extra_params to authorize_redirect"
-    ).tag(config=True)
-
-    def authorize_redirect(self, *args, **kwargs):
-        extra_params = kwargs.setdefault('extra_params', {})
-        extra_params.update(self.extra_params)
-
-        return super().authorize_redirect(*args, **kwargs)
 
 class GoogleOAuthenticator(OAuthenticator, GoogleOAuth2Mixin):
     google_api_url = Unicode("https://www.googleapis.com", config=True)
@@ -125,8 +111,6 @@ class GoogleOAuthenticator(OAuthenticator, GoogleOAuth2Mixin):
         config=True,
         help="""Google Apps hosted domain string, e.g. My College""",
     )
-
-    login_handler = GoogleLoginHandler
 
     async def authenticate(self, handler, data=None, google_groups=None):
         code = handler.get_argument("code")

--- a/oauthenticator/tests/mocks.py
+++ b/oauthenticator/tests/mocks.py
@@ -21,9 +21,9 @@ RegExpType = type(re.compile('.'))
 
 class MockAsyncHTTPClient(SimpleAsyncHTTPClient):
     """A mock AsyncHTTPClient that allows registering handlers for mocked requests
-    
+
     Call .add_host to mock requests made to a given host.
-    
+
     """
     def initialize(self, *args, **kwargs):
         super().initialize(*args, **kwargs)
@@ -31,13 +31,13 @@ class MockAsyncHTTPClient(SimpleAsyncHTTPClient):
 
     def add_host(self, host, paths):
         """Add a host whose requests should be mocked.
-        
+
         Args:
             host (str): the host to mock (e.g. 'api.github.com')
             paths (list(str|regex, callable)): a list of paths (or regexps for paths)
                 and callables to be called for those paths.
                 The mock handlers will receive the request as their only argument.
-        
+
         Mock handlers can return:
             - None
             - int (empty response with this status code)
@@ -46,7 +46,7 @@ class MockAsyncHTTPClient(SimpleAsyncHTTPClient):
             - HTTPResponse (passed unmodified)
 
         Example::
-        
+
             client.add_host('api.github.com', [
                 ('/user': lambda request: {'login': 'name'})
             ])
@@ -97,21 +97,21 @@ def setup_oauth_mock(client, host, access_token_path, user_path,
         token_request_style='post',
     ):
     """setup the mock client for OAuth
-    
+
     generates and registers two handlers common to OAuthenticators:
-    
+
     - create the access token (POST access_token_path)
     - get the user info (GET user_path)
-    
-    
+
+
     and adds a method for creating a new mock handler to pass to .authenticate():
-    
+
     client.handler_for_user(user)
-    
+
     where user is the user-model to be returned by the user request.
-    
+
     Args:
-    
+
         host (str): the host to mock (e.g. api.github.com)
         access_token_path (str): The path for the access token request (e.g. /access_token)
         user_path (str): The path for requesting  (e.g. /user)
@@ -192,16 +192,17 @@ def setup_oauth_mock(client, host, access_token_path, user_path,
             (access_token_path, access_token),
             (user_path, get_user),
         ])
-    
+
     def handler_for_user(user):
         """Return a new mock RequestHandler
-        
+
         user should be the JSONable model that will ultimately be returned
         from the get_user request.
         """
         code = uuid.uuid4().hex
         oauth_codes[code] = user
         handler = Mock(spec=web.RequestHandler)
+        handler.find_user = Mock(return_value=None)
         handler.get_argument = Mock(return_value=code)
         handler.request = HTTPServerRequest(
             method='GET',


### PR DESCRIPTION
I've been working on giving my users a unified experience using G Suite, we ran into a situation where we wanted to have access to files in Google Drive and most applications that interact with Google Drive (Example: https://github.com/astrada/google-drive-ocamlfuse) require a `refresh_token` in order to work.

Since users already authenticate to Google when they login to jupyterhub I thought it was best to do all at once. 

These are the changes and I made and I thought the rest of the community would benefit from them too.