### PR TITLE
Fix broken link for OpenShift OAuth service accounts

### DIFF
--- a/docs/source/getting-started.rst
+++ b/docs/source/getting-started.rst
@@ -293,7 +293,7 @@ Service Accounts as OAuth Clients
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 As a project member, you can use the `Service Accounts as OAuth
-Clients <https://docs.openshift.org/latest/architecture/additional_concepts/authentication.html#service-accounts-as-oauth-clients>`__
+Clients <https://docs.openshift.com/container-platform/latest/authentication/using-service-accounts-as-oauth-client.html>`__
 scenario. This gives you the possibility of defining clients associated
 with service accounts. You just need to create the service account with
 the proper annotations:


### PR DESCRIPTION
Previous link was broken,(https://docs.openshift.org/latest/architecture/additional_concepts/authentication.html#service-accounts-as-oauth-clients)

So I'm suggesting replacing with this link:
https://docs.openshift.com/container-platform/latest/authentication/using-service-accounts-as-oauth-client.html