### PR TITLE
Respect validate_server_cert attribute for GitHub

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,4 +1,8 @@
 [flake8]
 select = F
 ignore = E,W,C,F401,F841
-exclude = __init__.py
+builtins =
+    c
+    get_config
+exclude =
+    __init__.py

--- a/docs/source/example-oauthenticator.py
+++ b/docs/source/example-oauthenticator.py
@@ -64,7 +64,7 @@ class GitHubOAuthenticator(OAuthenticator):
                 ),
             )
         else:
-            raise HTTPError(500, "Bad response: %s".format(resp))
+            raise HTTPError(500, "Bad response: {}".format(resp))
 
         # Determine who the logged in user is
         # by using the new access token to make a request

--- a/oauthenticator/github.py
+++ b/oauthenticator/github.py
@@ -136,7 +136,7 @@ class GitHubOAuthenticator(OAuthenticator):
             method="POST",
             headers={"Accept": "application/json"},
             body='',  # Body is required for a POST...
-            validate_cert=self.validate_server_cert
+            validate_cert=self.validate_server_cert,
         )
 
         resp = await http_client.fetch(req)
@@ -159,7 +159,7 @@ class GitHubOAuthenticator(OAuthenticator):
             self.github_api + "/user",
             method="GET",
             headers=_api_headers(access_token),
-            validate_cert=self.validate_server_cert
+            validate_cert=self.validate_server_cert,
         )
         resp = await http_client.fetch(req)
         resp_json = json.loads(resp.body.decode('utf8', 'replace'))
@@ -213,7 +213,8 @@ class GitHubOAuthenticator(OAuthenticator):
             check_membership_url,
             method="GET",
             headers=headers,
-            validate_cert=self.validate_server_cert)
+            validate_cert=self.validate_server_cert,
+        )
         self.log.debug(
             "Checking GitHub organization membership: %s in %s?", username, org
         )

--- a/oauthenticator/github.py
+++ b/oauthenticator/github.py
@@ -136,6 +136,7 @@ class GitHubOAuthenticator(OAuthenticator):
             method="POST",
             headers={"Accept": "application/json"},
             body='',  # Body is required for a POST...
+            validate_cert=self.validate_server_cert
         )
 
         resp = await http_client.fetch(req)
@@ -155,7 +156,10 @@ class GitHubOAuthenticator(OAuthenticator):
 
         # Determine who the logged in user is
         req = HTTPRequest(
-            self.github_api + "/user", method="GET", headers=_api_headers(access_token)
+            self.github_api + "/user",
+            method="GET",
+            headers=_api_headers(access_token),
+            validate_cert=self.validate_server_cert
         )
         resp = await http_client.fetch(req)
         resp_json = json.loads(resp.body.decode('utf8', 'replace'))
@@ -205,7 +209,11 @@ class GitHubOAuthenticator(OAuthenticator):
             org,
             username,
         )
-        req = HTTPRequest(check_membership_url, method="GET", headers=headers)
+        req = HTTPRequest(
+            check_membership_url,
+            method="GET",
+            headers=headers,
+            validate_cert=self.validate_server_cert)
         self.log.debug(
             "Checking GitHub organization membership: %s in %s?", username, org
         )

--- a/oauthenticator/github.py
+++ b/oauthenticator/github.py
@@ -152,7 +152,7 @@ class GitHubOAuthenticator(OAuthenticator):
                 ),
             )
         else:
-            raise HTTPError(500, "Bad response: %s".format(resp))
+            raise HTTPError(500, "Bad response: {}".format(resp))
 
         # Determine who the logged in user is
         req = HTTPRequest(


### PR DESCRIPTION
Setting up `OAUTH_TLS_VERIFY` to `0` was not working for GitHub Enterprise instances with Self-Signed Certificate.

This was because the `HTTPRequest` was called without passing the `self.validate_server_cert` attribute for `validate_cert` argument.

This PR fixes issue #253 