### PR TITLE
[Google] Allow for checking of google_groups for admin only

### DIFF
--- a/docs/source/google.md
+++ b/docs/source/google.md
@@ -62,6 +62,15 @@ c.GoogleOAuthenticator.gsuite_administrator = {'example.com': 'someuser'}
 c.GoogleOAuthenticator.google_service_account_keys = {'example.com': '/path/to/service_account.json'}
 c.GoogleOAuthenticator.allowed_google_groups = {'example.com': ['somegroupwithaccess', 'othergroupwithaccess'] }
 ```
+
+#### if you want to manage admin users via google groups
+
+```python
+c.GoogleOAuthenticator.gsuite_administrator = {'example.com': 'someuser'}
+c.GoogleOAuthenticator.google_service_account_keys = {'example.com': '/path/to/service_account.json'}
+c.GoogleOAuthenticator.admin_google_groups = {'example.com': ['someadmingroup']}
+```
+
 ### You are done!
 
 ## How to retrieve an `access_token` and `refresh_token` for all scopes at once

--- a/oauthenticator/google.py
+++ b/oauthenticator/google.py
@@ -288,8 +288,19 @@ class GoogleOAuthenticator(OAuthenticator, GoogleOAuth2Mixin):
         # Check if user is a member of any admin groups.
         if self.admin_google_groups:
             is_admin = check_user_in_groups(google_groups, self.admin_google_groups[user_email_domain])
+
         # Check if user is a member of any allowed groups.
-        user_in_group = check_user_in_groups(google_groups, self.allowed_google_groups[user_email_domain])
+        allowed_groups = self.allowed_google_groups
+
+        if allowed_groups:
+            if user_email_domain in allowed_groups:
+                user_in_group = check_user_in_groups(
+                    google_groups, allowed_groups[user_email_domain]
+                )
+            else:
+                return None
+        else:
+            user_in_group = True
 
         if self.admin_google_groups and (is_admin or user_in_group):
             user_info['admin'] = is_admin

--- a/oauthenticator/tests/test_google.py
+++ b/oauthenticator/tests/test_google.py
@@ -121,6 +121,19 @@ async def test_allowed_google_groups(google_client):
     assert allowed_user_groups is None
 
 
+async def test_admin_only_google_groups(google_client):
+    authenticator = GoogleOAuthenticator(
+        hosted_domain=['email.com', 'mycollege.edu'],
+        admin_google_groups={'email.com': ['fakeadmingroup']},
+    )
+    handler = google_client.handler_for_user(user_model('fakeadmin@email.com'))
+    admin_user_info = await authenticator.authenticate(
+        handler, google_groups=['anotherone', 'fakeadmingroup']
+    )
+    admin_user = admin_user_info['admin']
+    assert admin_user is True
+
+
 def test_deprecated_config(caplog):
     cfg = Config()
     cfg.GoogleOAuthenticator.google_group_whitelist = {'email.com': ['group']}

--- a/oauthenticator/tests/test_google.py
+++ b/oauthenticator/tests/test_google.py
@@ -105,7 +105,7 @@ async def test_admin_google_groups(google_client):
 async def test_allowed_google_groups(google_client):
     authenticator = GoogleOAuthenticator(
         hosted_domain=['email.com', 'mycollege.edu'],
-        allowed_google_groups={'email.com': ['fakegroup']}
+        allowed_google_groups={'email.com': ['fakegroup'], ',mycollege.edu': []},
     )
     handler = google_client.handler_for_user(user_model('fakeadmin@email.com'))
     admin_user_info = await authenticator.authenticate(handler, google_groups=['anotherone', 'fakeadmingroup'])
@@ -118,6 +118,11 @@ async def test_allowed_google_groups(google_client):
     assert admin_field is None
     handler = google_client.handler_for_user(user_model('fakenonalloweduser@email.com'))
     allowed_user_groups = await authenticator.authenticate(handler, google_groups=['anotherone', 'fakenonallowedgroup'])
+    assert allowed_user_groups is None
+    handler = google_client.handler_for_user(user_model('fake@mycollege.edu'))
+    allowed_user_groups = await authenticator.authenticate(
+        handler, google_groups=['fakegroup']
+    )
     assert allowed_user_groups is None
 
 


### PR DESCRIPTION
I was testing the Google Group integration because I wanted to use it to specify a google group for JupyterHub admins, however the current implementation expects that you specify a list of groups for regular user access too.

This PR enables the user to either omit or specify an empty dict for google_group_whitelist:

```
c.GoogleOAuthenticator.admin_google_groups = {'example.com': ['admingroup']} 

c.GoogleOAuthenticator.google_group_whitelist = {}
```

providing admin group functionality without requiring a list of groups to be present.