### PR TITLE
[OpenShifAuthenticator] Enable cert verification for self-signed certs and auto-load auth api URL

### DIFF
--- a/oauthenticator/tests/test_openshift.py
+++ b/oauthenticator/tests/test_openshift.py
@@ -17,7 +17,7 @@ def user_model(username):
 @fixture
 def openshift_client(client):
     setup_oauth_mock(client,
-        host=['localhost'],
+        host=['openshift.default.svc.cluster.local'],
         access_token_path='/oauth/token',
         user_path='/apis/user.openshift.io/v1/users/~',
     )
@@ -26,6 +26,7 @@ def openshift_client(client):
 
 async def test_openshift(openshift_client):
     authenticator = OpenShiftOAuthenticator()
+    authenticator.openshift_auth_api_url = "https://openshift.default.svc.cluster.local"
     handler = openshift_client.handler_for_user(user_model('wash'))
     user_info = await authenticator.authenticate(handler)
     assert sorted(user_info) == ['auth_state', 'name']


### PR DESCRIPTION
The latest version of OpenShift OAuthenticator relies on user configuring `OPENSHIFT_URL` environment variable and then uses it for multiple kind of unrelated things, so it is not clear it `OPENSHIFT_URL` should be an API url, or OAuth API url.

Also, the default value `localhost:8443` would not work in OpenShift environment since in a container, localhost will not really do much.

This change sets more sensible default for `openshift_url` which actually represents internal URL for OpenShift API.

Next it automatically gathers the OpenShift OAuth URL, so that the user does not have to provide it externally via env vars.

Lastly it sets the OpenShift provided CA certs in a container by default, so that we don't have to turn off the verification on clusters using self-signed certs.

I had to use `requests` library to fetch the URLs for the OAuth issuer since the Async client did not work for me (event loop in an event loop error) - let me know if there is a better solution.