### PR TITLE
[AzureAD] Add (optional) additional request to get username attribute

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -68,3 +68,5 @@ jupyterhub_cookie_secret
 
 .vscode/
 .idea/
+
+Pipfile*

--- a/examples/azuread/sample_jupyter_config.py
+++ b/examples/azuread/sample_jupyter_config.py
@@ -1,5 +1,7 @@
 import os
+
 from oauthenticator.azuread import AzureAdOAuthenticator
+
 c.JupyterHub.authenticator_class = AzureAdOAuthenticator
 
 c.Application.log_level = 'DEBUG'
@@ -14,3 +16,8 @@ c.AzureAdOAuthenticator.client_secret = '{AAD-APP-CLIENT-SECRET}'
 # uncomment the line below to use 'unique_name' rather than the default 'name'. Consult the Azure
 # documentation for other field names.
 #c.AzureAdOAuthenticator.username_claim = 'unique_name'
+#
+# If the alternate field defined by username_claim is not part of the default OAuth request,
+# we can do an additional lookup request to the Microsoft Graph API to fetch it. You can enable it
+# by uncommenting the settings below (if needed)
+#c.AzureAdOAuthenticator.username_claim_request = True

--- a/oauthenticator/azuread.py
+++ b/oauthenticator/azuread.py
@@ -2,17 +2,20 @@
 Custom Authenticator to use Azure AD with JupyterHub
 """
 
+import json
 import os
 import urllib
 from distutils.version import LooseVersion as V
 
 import jwt
 from jupyterhub.auth import LocalAuthenticator
-from tornado.httpclient import HTTPRequest
+from tornado.httpclient import AsyncHTTPClient, HTTPRequest
+from tornado.log import app_log
+
 from traitlets import Unicode, default
+from traitlets.traitlets import Bool
 
 from .oauth2 import OAuthenticator
-
 
 # pyjwt 2.0 has changed its signature,
 # but mwoauth pins to pyjwt 1.x
@@ -32,11 +35,17 @@ class AzureAdOAuthenticator(OAuthenticator):
     def _tenant_id_default(self):
         return os.environ.get('AAD_TENANT_ID', '')
 
-    username_claim = Unicode(config=True)
+    username_claim = Unicode(config=True, help="User's attribute to return as username")
 
     @default('username_claim')
     def _username_claim_default(self):
         return 'name'
+
+    username_claim_request = Bool(config=True, help="Allow an additional user attribute request if username_claim is not in the initial response")
+
+    @default('username_claim_request')
+    def _username_claim_request_default(self):
+        return False
 
     @default("authorize_url")
     def _authorize_url_default(self):
@@ -45,6 +54,63 @@ class AzureAdOAuthenticator(OAuthenticator):
     @default("token_url")
     def _token_url_default(self):
         return 'https://login.microsoftonline.com/{0}/oauth2/token'.format(self.tenant_id)
+
+    graph_url = Unicode(config=True, help="URL of the Microsoft Graph Endpoint")
+
+    @default('graph_url')
+    def _graph_url_default(self):
+        return 'https://graph.microsoft.com/v1.0'
+
+    async def get_user_attribute(self, oid, attr):
+
+        http_client = AsyncHTTPClient()
+
+        params = dict(
+            scope=["https://graph.microsoft.com/.default"],
+            client_secret=self.client_secret,
+            grant_type="client_credentials",
+            client_id=self.client_id,
+        )
+
+        data = urllib.parse.urlencode(
+            params, doseq=True, encoding='utf-8', safe='=')
+
+        url = self.token_url
+
+        headers = {
+            'Content-Type':
+            'application/x-www-form-urlencoded; charset=UTF-8'
+        }
+        req = HTTPRequest(
+            url,
+            method="POST",
+            headers=headers,
+            body=data  # Body is required for a POST...
+        )
+
+        resp = await http_client.fetch(req)
+        resp_json = json.loads(resp.body.decode('utf8', 'replace'))
+
+        access_token = resp_json["access_token"]
+
+        url = '{0}/users/{1}?$select={2}'.format(self.graph_url, oid, attr)
+
+        headers = {
+            'Authorization':
+            'Bearer {0}'.format(access_token)
+        }
+        req = HTTPRequest(
+            url,
+            method="GET",
+            headers=headers,
+        )
+
+        resp = await http_client.fetch(req)
+        resp_json = json.loads(resp.body.decode('utf8', 'replace'))
+
+        # app_log.debug("[GetUserAttribute] Response %s", resp_json)
+
+        return resp_json[attr]
 
     async def authenticate(self, handler, data=None):
         code = handler.get_argument("code")
@@ -87,7 +153,18 @@ class AzureAdOAuthenticator(OAuthenticator):
             # pyjwt 1.x
             decoded = jwt.decode(id_token, verify=False)
 
-        userdict = {"name": decoded[self.username_claim]}
+        # try to set the name using the username_claim attribute
+        # if this fails, try to get it from a specific Microsoft Graph Query (if enabled)
+        try:
+            userdict = {"name": decoded[self.username_claim]}
+        except KeyError as e:
+            if self.username_claim_request:
+                app_log.debug("Trying to get username_claim attribute '{0}' for user '{1}'".format(self.username_claim, decoded['oid']))
+                userdict = {"name": await self.get_user_attribute(decoded['oid'], self.username_claim)}
+            else:
+                app_log.debug("Failed to get username_claim '{0}' for user '{1}' and additional request is not enabled".format(self.username_claim, decoded['oid']))
+                raise KeyError("Failed to get username_claim '{0}' for user '{1}'".format(self.username_claim, decoded['oid']))
+
         userdict["auth_state"] = auth_state = {}
         auth_state['access_token'] = access_token
         # results in a decoded JWT for the user data

--- a/oauthenticator/tests/test_azuread.py
+++ b/oauthenticator/tests/test_azuread.py
@@ -9,7 +9,6 @@ import jwt
 import pytest
 
 from ..azuread import AzureAdOAuthenticator
-
 from .mocks import setup_oauth_mock
 
 


### PR DESCRIPTION
Hi there,
this PR adds the ability to do an additional second request against AzureAD (more specifically, the Microsoft Graph API) to fetch the username attribute defined by `username_claim`, if it isn't present in the default OAuth reply.

Example use case that we hit: 
- We're syncing an on-premises AD with AzureAD and heavily rely on the (old) short usernames, which are in the `sAMAccountName` field in AD and in the `onPremisesSamAccountName` in AzureAD.
- The field `onPremisesSamAccountName` is not present in the small default reply of the Login requests (/authorize and /token on login.microsoftonline.com).
- This results in a 500 error on JupyterHub (`KeyError` in the OAuthenticator)

I guess there's still room for improvement (or you prefer to rather drop this in a GenericOAuthenticator), but I'd like to get some feedback on my first iteration :)