### PR TITLE
[Generic] Remove userdata_method configuration supposedly not relevant

### DIFF
--- a/docs/source/getting-started.rst
+++ b/docs/source/getting-started.rst
@@ -103,7 +103,6 @@ Set the above settings in your ``jupyterhub_config.py``:
    c.GenericOAuthenticator.authorize_url = "https://your-AWSCognito-domain/oauth2/authorize"
    c.GenericOAuthenticator.token_url = ""https://your-AWSCognito-domain/oauth2/token"
    c.GenericOAuthenticator.userdata_url = "https://your-AWSCognito-domain/oauth2/userInfo"
-   c.GenericOAuthenticator.userdata_method = 'POST'
 
 Azure AD Setup
 --------------
@@ -463,11 +462,11 @@ Use the ``GenericOAuthenticator`` for Jupyterhub by editing your
    c.GenericOAuthenticator.login_service = 'NAME-OF-SERVICE'
    c.GenericOAuthenticator.userdata_url = 'http://YOUR-MOODLE-DOMAIN.com/local/oauth/user_info.php'
    c.GenericOAuthenticator.token_url = 'http://YOUR-MOODLE-DOMAIN.com/local/oauth/token.php'
-   c.GenericOAuthenticator.userdata_method = 'POST'
    c.GenericOAuthenticator.extra_params = {
        'scope': 'user_info',
        'client_id': 'MOODLE-CLIENT-ID',
-       'client_secret': 'MOODLE-CLIENT-SECRET-KEY'}
+       'client_secret': 'MOODLE-CLIENT-SECRET-KEY',
+   }
 
 And set your environmental variable ``OAUTH2_AUTHORIZE_URL`` to:
 

--- a/oauthenticator/generic.py
+++ b/oauthenticator/generic.py
@@ -61,12 +61,6 @@ class GenericOAuthenticator(OAuthenticator):
         help="Userdata params to get user data login information"
     ).tag(config=True)
 
-    userdata_method = Unicode(
-        os.environ.get('OAUTH2_USERDATA_METHOD', 'GET'),
-        config=True,
-        help="Userdata method to get user data login information",
-    )
-
     userdata_token_method = Unicode(
         os.environ.get('OAUTH2_USERDATA_REQUEST_TYPE', 'header'),
         config=True,
@@ -131,11 +125,7 @@ class GenericOAuthenticator(OAuthenticator):
         if self.userdata_token_method == "url":
             url = url_concat(self.userdata_url, dict(access_token=access_token))
 
-        req = HTTPRequest(
-            url,
-            method=self.userdata_method,
-            headers=headers,
-        )
+        req = HTTPRequest(url, headers=headers)
         return self.fetch(req, "fetching user data")
 
     @staticmethod


### PR DESCRIPTION
A final piece discussed to be deprecated in #197 which I think should be closed no matter what though.

The idea is that the `userdata_method` is always going to be `GET`, but I'm not 100% that is true. I'm not sure how to get knowledge if this is a relevant configuration option any more though, it is like needing to proove there is no black sheeps, its hard.
