### PR TITLE
change to BaseHandler._set_cookie to do set cookie

### DIFF
--- a/oauthenticator/oauth2.py
+++ b/oauthenticator/oauth2.py
@@ -73,7 +73,7 @@ class OAuthLoginHandler(OAuth2Mixin, BaseHandler):
         return self.authenticator.userdata_url
 
     def set_state_cookie(self, state):
-        self.set_secure_cookie(STATE_COOKIE_NAME, state, expires_days=1, httponly=True)
+        self._set_cookie(STATE_COOKIE_NAME, state, expires_days=1, httponly=True)
 
     _state = None
 


### PR DESCRIPTION
fix #277
if you can't update, there is a way to fix it in config file 
```
from oauthenticator.generic import GenericOAuthenticator
from oauthenticator.oauth2 import OAuthLoginHandler, STATE_COOKIE_NAME
class SecureOAuthLoginHandler(OAuthLoginHandler):
      def set_state_cookie(self, state):
          self._set_cookie(STATE_COOKIE_NAME, state, expires_days=1, httponly=True)
class SecureOAuthenticator(GenericOAuthenticator):
      login_handler = SecureOAuthLoginHandler
c.JupyterHub.authenticator_class = SecureOAuthenticator
```