### PR TITLE
CI: Stop testing py35 and don't test on tagged commits

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,11 @@
 language: python
-sudo: false
-cache: pip
-dist: xenial
+dist: bionic
+
+stages:
+  - name: test
+    if: tag IS NOT present
+  - name: publish
+    if: tag IS present
 
 install:
   - pip install --upgrade pip
@@ -33,10 +37,12 @@ jobs:
     - python: 3.6
     - python: 3.5
     - python: nightly
-    # Only deploy if all test jobs passed
-    - stage: deploy
-      python: 3.7
-      if: tag IS present
+
+    - stage: publish
+      script:
+        - echo "Required dummy override of default 'script' in .travis.yml."
+      after_success:
+        - echo "Required dummy override of default 'after_success' in .travis.yml."
       deploy:
         provider: pypi
         user: __token__

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,8 @@
-language: python
+os: linux
 dist: bionic
+language: python
+python:
+  - 3.8
 
 stages:
   - name: test
@@ -7,13 +10,18 @@ stages:
   - name: publish
     if: tag IS present
 
+before_install:
+  # Exit immediately if a command exits with a non-zero status.
+  - set -e
+
 install:
   - pip install --upgrade pip
   - pip install --upgrade --pre -r test-requirements.txt .
   - pip freeze
+
 env:
-  OAUTH2_TOKEN_URL="token_url"
-  OAUTH2_USERDATA_URL="userdata_url"
+  - OAUTH2_TOKEN_URL="token_url" OAUTH2_USERDATA_URL="userdata_url"
+
 script:
   - |
     if [[ "$TEST_LINT" = 1 ]]; then
@@ -21,6 +29,7 @@ script:
     else
       py.test --cov oauthenticator oauthenticator
     fi
+
 after_success:
   - codecov
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -44,7 +44,6 @@ jobs:
     - python: 3.8
     - python: 3.7
     - python: 3.6
-    - python: 3.5
     - python: nightly
 
     - stage: publish


### PR DESCRIPTION
A tagged commit will trigger two jobs in TravisCI, one normal, and one tag job. When the normal branch based job run, test will run but not the publish part. When the tag based CI job run, the publishing step will run without running tests.

I also stop testing against python 3.5 as it has reached end of life. I wanted to add py39 but I don't think TravisCI supports it yet as something to specify with ease.

