### PR TITLE
Remove support for python 3.5

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -56,7 +56,6 @@ jobs:
       fail-fast: false
       matrix:
         python:
-          - "3.5"
           - "3.6"
           - "3.7"
           - "3.8"

--- a/setup.py
+++ b/setup.py
@@ -49,7 +49,7 @@ setup_args = dict(
     license             = "BSD",
     platforms           = "Linux, Mac OS X",
     keywords            = ['Interactive', 'Interpreter', 'Shell', 'Web'],
-    python_requires     = ">=3.5",
+    python_requires     = ">=3.6",
     entry_points={
         'jupyterhub.authenticators': [
             'auth0 = oauthenticator.auth0:Auth0OAuthenticator',


### PR DESCRIPTION
We can retain it, but I think it is a sensible policy to allow future releases to require a python version not passed end of life. By having this kind of policy, a person making a change doesn't have to ensure it remains compatible with Python 3.5 any more etc.
