### PR TITLE
Fix exception when enable_auth_state is enabled but user.encrypted_auth_state is None

### DIFF
--- a/oauthenticator/google.py
+++ b/oauthenticator/google.py
@@ -180,7 +180,7 @@ class GoogleOAuthenticator(OAuthenticator, GoogleOAuth2Mixin):
             self.log.debug("Refresh token was empty, will try to pull refresh_token from previous auth_state")
             user = handler.find_user(username)
 
-            if user:
+            if user and user.encrypted_auth_state:
                 self.log.debug("encrypted_auth_state was found, will try to decrypt and pull refresh_token from it")
                 try:
                     encrypted = user.encrypted_auth_state


### PR DESCRIPTION
This can happen if you have a hub database with `enable_auth_state` disabled, but it's turned on afterwards. Some preexisting entries in the database would not have a saved auth state.
https://github.com/jupyterhub/oauthenticator/blob/11a18e8b5c4a35a8248f4f2a4dc81965af3d3da5/oauthenticator/google.py#L183-L194

In that case, `user` would exist, but `user.encrypted_auth_state` would be None. This causes `decrypt` to throw out a `TypeError`, which is not caught and causes a 500 on login.

Full exception stack trace (with some details removed):
```
    Traceback (most recent call last):
      File "/home/jovyan/.local/lib/python3.8/site-packages/tornado/web.py", line 1704, in _execute
        result = await result
      File "/home/jovyan/.local/lib/python3.8/site-packages/oauthenticator/oauth2.py", line 224, in get
        user = await self.login_user()
      File "/home/jovyan/.local/lib/python3.8/site-packages/jupyterhub/handlers/base.py", line 747, in login_user
        authenticated = await self.authenticate(data)
      File "/home/jovyan/.local/lib/python3.8/site-packages/jupyterhub/auth.py", line 459, in get_authenticated_user
        authenticated = await maybe_future(self.authenticate(handler, data))
      File "/home/jovyan/.local/lib/python3.8/site-packages/oauthenticator/google.py", line 192, in authenticate
        auth_state = await decrypt(encrypted)
      File "/usr/lib/python3.8/concurrent/futures/thread.py", line 57, in run
        result = self.fn(*self.args, **self.kwargs)
      File "/home/jovyan/.local/lib/python3.8/site-packages/jupyterhub/crypto.py", line 155, in _decrypt
        decrypted = self.fernet.decrypt(encrypted)
      File "/home/jovyan/.local/lib/python3.8/site-packages/cryptography/fernet.py", line 179, in decrypt
        return f.decrypt(msg, ttl)
      File "/home/jovyan/.local/lib/python3.8/site-packages/cryptography/fernet.py", line 75, in decrypt
        timestamp, data = Fernet._get_unverified_token_data(token)
      File "/home/jovyan/.local/lib/python3.8/site-packages/cryptography/fernet.py", line 94, in _get_unverified_token_data
        utils._check_bytes("token", token)
      File "/home/jovyan/.local/lib/python3.8/site-packages/cryptography/utils.py", line 29, in _check_bytes
        raise TypeError("{} must be bytes".format(name))
    TypeError: token must be bytes
```