### PR TITLE
added allowed_groups and admin_groups to generic.py

### DIFF
--- a/examples/generic/README.md
+++ b/examples/generic/README.md
@@ -1,0 +1,68 @@
+# OAuthenticator
+
+Example of `GenericOAuthenticator` using an IDM - identity and access management - solution (keycloak).
+
+## Keycloak
+
+`Keycloak` is an open source IDM solution. 
+In `Keycloak` one can map user roles or policies from a source, 
+e.g. Active Directory, configure the client scopes to include this information
+within the id token and access token as claims.
+
+This allows applications to obtain information that can be used to authorize
+access to functionality within that application.
+
+This functionality is supported by all major IDM tools, e.g. Auth0, Okta etc.
+
+## `GenericOAuthenticator` configuration
+
+The `GenericOAuthenticator` can be configured to provide authorization as well.
+
+### Example configuration 
+
+```python
+from oauthenticator.generic import GenericOAuthenticator
+
+c.Application.log_level = 'DEBUG'
+
+c.JupyterHub.authenticator_class = GenericOAuthenticator
+c.GenericOAuthenticator.client_id = 'client-id'
+c.GenericOAuthenticator.client_secret = 'some-long-secret-hash'
+c.GenericOAuthenticator.token_url = 'https://accounts.example.com/auth/realms/example/protocol/openid-connect/token'
+c.GenericOAuthenticator.userdata_url = 'https://accounts.example.com/auth/realms/example/protocol/openid-connect/userinfo'
+c.GenericOAuthenticator.userdata_method = 'GET'
+c.GenericOAuthenticator.userdata_params = {'state': 'state'}
+# the next can be a callable as well, e.g.: lambda t: t.get('complex').get('structure').get('username')
+c.GenericOAuthenticator.username_key = 'preferred_username'
+c.GenericOAuthenticator.login_service = 'EXAMPLE'
+c.GenericOAuthenticator.scope = ['openid', 'profile']
+```
+
+### Example configuration with authorization enabled
+
+In order to enable authorization, one needs to specify the at least one value for `allowed_groups`:
+
+```python
+from oauthenticator.generic import GenericOAuthenticator
+
+c.Application.log_level = 'DEBUG'
+
+c.JupyterHub.authenticator_class = GenericOAuthenticator
+c.GenericOAuthenticator.client_id = 'client-id'
+c.GenericOAuthenticator.client_secret = 'some-long-secret-hash'
+c.GenericOAuthenticator.token_url = 'https://accounts.example.com/auth/realms/example/protocol/openid-connect/token'
+c.GenericOAuthenticator.userdata_url = 'https://accounts.example.com/auth/realms/example/protocol/openid-connect/userinfo'
+c.GenericOAuthenticator.userdata_method = 'GET'
+c.GenericOAuthenticator.userdata_params = {'state': 'state'}
+# the next can be a callable as well, e.g.: lambda t: t.get('complex').get('structure').get('username')
+c.GenericOAuthenticator.username_key = 'preferred_username'
+c.GenericOAuthenticator.login_service = 'EXAMPLE'
+# The next settings are responsible for enabling authorization
+# the next can be a callable as well, e.g.: lambda t: t.get('complex').get('structure').get('roles')
+c.GenericOAuthenticator.claim_groups_key = 'roles'
+# users with `staff` role will be allowed
+c.GenericOAuthenticator.allowed_groups = ['staff']
+# users with `administrator` role will be marked as admin
+c.GenericOAuthenticator.admin_groups = ['administrator']
+c.GenericOAuthenticator.scope = ['openid', 'profile', 'roles']
+```

--- a/oauthenticator/tests/test_generic.py
+++ b/oauthenticator/tests/test_generic.py
@@ -1,4 +1,4 @@
-from pytest import fixture, mark
+from pytest import fixture
 
 from ..generic import GenericOAuthenticator
 
@@ -15,16 +15,23 @@ def user_model(username, **kwargs):
     user.update(kwargs)
     return user
 
-def Authenticator(**kwargs):
+
+def get_authenticator(**kwargs):
     return GenericOAuthenticator(
         token_url='https://generic.horse/oauth/access_token',
         userdata_url='https://generic.horse/oauth/userinfo',
         **kwargs
     )
 
+
+def get_simple_handler(generic_client):
+    return generic_client.handler_for_user(user_model('wash'))
+
+
 @fixture
 def generic_client(client):
-    setup_oauth_mock(client,
+    setup_oauth_mock(
+        client,
         host='generic.horse',
         access_token_path='/oauth/access_token',
         user_path='/oauth/userinfo',
@@ -35,9 +42,9 @@ def generic_client(client):
 async def test_generic(generic_client):
     with mock.patch.object(GenericOAuthenticator, 'http_client') as fake_client:
         fake_client.return_value = generic_client
-        authenticator = Authenticator()
+        authenticator = get_authenticator()
 
-        handler = generic_client.handler_for_user(user_model('wash'))
+        handler = get_simple_handler(generic_client)
         user_info = await authenticator.authenticate(handler)
         assert sorted(user_info) == ['auth_state', 'name']
         name = user_info['name']
@@ -52,7 +59,7 @@ async def test_generic(generic_client):
 async def test_generic_callable_username_key(generic_client):
     with mock.patch.object(GenericOAuthenticator, 'http_client') as fake_client:
         fake_client.return_value = generic_client
-        authenticator = Authenticator(
+        authenticator = get_authenticator(
             username_key=lambda r: r['alternate_username']
         )
         handler = generic_client.handler_for_user(
@@ -60,3 +67,100 @@ async def test_generic_callable_username_key(generic_client):
         )
         user_info = await authenticator.authenticate(handler)
         assert user_info['name'] == 'zoe'
+
+
+async def test_generic_callable_groups_claim_key_with_allowed_groups(generic_client):
+    with mock.patch.object(GenericOAuthenticator, 'http_client') as fake_client:
+        fake_client.return_value = generic_client
+        authenticator = get_authenticator(
+            scope=['openid', 'profile', 'roles'],
+            claim_groups_key=lambda r: r.get('policies').get('roles'),
+            allowed_groups=['super_user']
+        )
+        handler = generic_client.handler_for_user(
+            user_model('wash', alternate_username='zoe', policies={'roles': ['super_user']})
+        )
+        user_info = await authenticator.authenticate(handler)
+        assert user_info['name'] == 'wash'
+
+
+async def test_generic_groups_claim_key_with_allowed_groups(generic_client):
+    with mock.patch.object(GenericOAuthenticator, 'http_client') as fake_client:
+        fake_client.return_value = generic_client
+        authenticator = get_authenticator(
+            scope=['openid', 'profile', 'roles'],
+            claim_groups_key='groups',
+            allowed_groups=['super_user']
+        )
+        handler = generic_client.handler_for_user(
+            user_model('wash', alternate_username='zoe', groups=['super_user'])
+        )
+        user_info = await authenticator.authenticate(handler)
+        assert user_info['name'] == 'wash'
+
+
+async def test_generic_groups_claim_key_with_allowed_groups_unauthorized(generic_client):
+    with mock.patch.object(GenericOAuthenticator, 'http_client') as fake_client:
+        fake_client.return_value = generic_client
+        authenticator = get_authenticator(
+            scope=['openid', 'profile', 'roles'],
+            claim_groups_key='groups',
+            allowed_groups=['user']
+        )
+        handler = generic_client.handler_for_user(
+            user_model('wash', alternate_username='zoe', groups=['public'])
+        )
+        user_info = await authenticator.authenticate(handler)
+        assert user_info is None
+
+
+async def test_generic_groups_claim_key_with_allowed_groups_and_admin_groups(generic_client):
+    with mock.patch.object(GenericOAuthenticator, 'http_client') as fake_client:
+        fake_client.return_value = generic_client
+        authenticator = get_authenticator(
+            scope=['openid', 'profile', 'roles'],
+            claim_groups_key='groups',
+            allowed_groups=['user'],
+            admin_groups=['administrator'],
+        )
+        handler = generic_client.handler_for_user(
+            user_model('wash', alternate_username='zoe', groups=['user', 'administrator'])
+        )
+        user_info = await authenticator.authenticate(handler)
+        assert user_info['name'] == 'wash'
+        assert user_info['admin'] is True
+
+
+async def test_generic_groups_claim_key_with_allowed_groups_and_admin_groups_not_admin(generic_client):
+    with mock.patch.object(GenericOAuthenticator, 'http_client') as fake_client:
+        fake_client.return_value = generic_client
+        authenticator = get_authenticator(
+            scope=['openid', 'profile', 'roles'],
+            claim_groups_key='groups',
+            allowed_groups=['user'],
+            admin_groups=['administrator'],
+        )
+        handler = generic_client.handler_for_user(
+            user_model('wash', alternate_username='zoe', groups=['user'])
+        )
+        user_info = await authenticator.authenticate(handler)
+        assert user_info['name'] == 'wash'
+        assert user_info['admin'] is False
+
+
+async def test_generic_callable_groups_claim_key_with_allowed_groups_and_admin_groups(generic_client):
+    with mock.patch.object(GenericOAuthenticator, 'http_client') as fake_client:
+        fake_client.return_value = generic_client
+        authenticator = get_authenticator(
+            username_key=lambda r: r['alternate_username'],
+            scope=['openid', 'profile', 'roles'],
+            claim_groups_key=lambda r: r.get('policies').get('roles'),
+            allowed_groups=['user', 'public'],
+            admin_groups=['administrator'],
+        )
+        handler = generic_client.handler_for_user(
+            user_model('wash', alternate_username='zoe', policies={'roles': ['user', 'administrator']})
+        )
+        user_info = await authenticator.authenticate(handler)
+        assert user_info['name'] == 'zoe'
+        assert user_info['admin'] is True


### PR DESCRIPTION
Similarly to what is done for `gitlab` and `google` authenticators, this pull request introduces `allowed_groups` and `admin_groups` into the `generic` authenticator.

In `Keycloak` (this mention is solely because `Keycloak` is the IDM tool we use) one can map user roles or policies from a source, e.g. Active Directory, configure the client scopes to include this information within the id token and access token as claims. This allows applications to obtain information that can be used to authorize access to functionality within that application.

This functionality is supported by all major IDM tools, e.g. Auth0, Okta, ForgeRock, etc, and is quite common. I do believe this is useful functionality to be supported by this authenticator.

I tried to keep things generic, wrote some tests and some documentation on how to configure the `GenericOAuthenticator`. Plus everything works as before, if no `allowed_groups` are specified.

Thanks,
Manuel