### PR TITLE
Support username_claim in Google OAuth

### DIFF
--- a/oauthenticator/google.py
+++ b/oauthenticator/google.py
@@ -117,6 +117,12 @@ class GoogleOAuthenticator(OAuthenticator, GoogleOAuth2Mixin):
         help="""Google Apps hosted domain string, e.g. My College""",
     )
 
+    username_claim = Unicode(config=True)
+
+    @default('username_claim')
+    def _username_claim_default(self):
+        return 'email'
+
     async def authenticate(self, handler, data=None, google_groups=None):
         code = handler.get_argument("code")
         body = urllib.parse.urlencode(
@@ -146,8 +152,9 @@ class GoogleOAuthenticator(OAuthenticator, GoogleOAuth2Mixin):
             )
         )
         bodyjs = await self.fetch(req, "fetching user info")
-        user_email = username = bodyjs['email']
+        user_email = bodyjs['email']
         user_email_domain = user_email.split('@')[1]
+        username = bodyjs[self.username_claim]
 
         if not bodyjs['verified_email']:
             self.log.warning("Google OAuth unverified email attempt: %s", user_email)
@@ -164,7 +171,7 @@ class GoogleOAuthenticator(OAuthenticator, GoogleOAuth2Mixin):
                         user_email_domain
                     ),
                 )
-            if len(self.hosted_domain) == 1:
+            if len(self.hosted_domain) == 1 and user_email == username:
                 # unambiguous domain, use only base name
                 username = user_email.split('@')[0]
 

--- a/oauthenticator/google.py
+++ b/oauthenticator/google.py
@@ -117,7 +117,15 @@ class GoogleOAuthenticator(OAuthenticator, GoogleOAuth2Mixin):
         help="""Google Apps hosted domain string, e.g. My College""",
     )
 
-    username_claim = Unicode(config=True)
+    username_claim = Unicode(
+        "email",
+        help="""Field in userinfo reply to use for username
+
+        Default: 'email'
+        Also reasonable: 'sub' for the opaque unique id
+        """,
+        config=True,
+    )
 
     @default('username_claim')
     def _username_claim_default(self):


### PR DESCRIPTION
I'd like to use unique ID instead of email for Google OAuth because it contains `@` and `.` which can be non-unique even w/ https://github.com/jupyterhub/jupyterhub/pull/3316.

Here's the payload of the Google OAuth token: https://developers.google.com/identity/protocols/oauth2/openid-connect