### PR TITLE
PyJWT 2.0 compliant

### DIFF
--- a/oauthenticator/azuread.py
+++ b/oauthenticator/azuread.py
@@ -79,7 +79,7 @@ class AzureAdOAuthenticator(OAuthenticator):
         access_token = resp_json['access_token']
 
         id_token = resp_json['id_token']
-        decoded = jwt.decode(id_token, verify=False)
+        decoded = jwt.decode(id_token, options={"verify_signature": False})
 
         userdict = {"name": decoded[self.username_claim]}
         userdict["auth_state"] = auth_state = {}


### PR DESCRIPTION
PyJWT deprecated the argument `verify` and made it part of options as `verify_signature`. This PR solves that bug, basically the same as this one: https://github.com/Clinical-Genomics/cgbeacon2/issues/116

you will get:
jwt.exceptions.DecodeError: It is required that you pass in a value for the "algorithms" argument when calling decode().