### PR TITLE
Add CanvasOAuthenticator

### DIFF
--- a/oauthenticator/canvas.py
+++ b/oauthenticator/canvas.py
@@ -1,0 +1,204 @@
+import json
+import urllib
+
+from tornado.httpclient import HTTPRequest, AsyncHTTPClient, HTTPClientError
+from traitlets import List, Unicode, Set, Bool
+from jupyterhub.utils import maybe_future, url_path_join
+from jupyterhub.auth import LocalAuthenticator
+
+from .generic import GenericOAuthenticator
+
+class CanvasOAuthenticator(GenericOAuthenticator):
+    """
+    Canvas OAuth2 based authenticator for JupyterHub.
+
+    Collects info about user & enrolled courses from canvas,
+    puts them into auth_state. To refresh, user has to re-login.
+    """
+
+    strip_email_domain = Unicode(
+        '',
+        config=True,
+        help="""
+        Strip this domain from user emails when making their JupyterHub user name.
+
+        For example, if almost all your users have emails of form username@berkeley.edu,
+        you can set this to 'berkeley.edu'. A canvas user with email yuvipanda@berkeley.edu
+        will get a JupyterHub user name of 'yuvipanda', while a canvas user with email
+        yuvipanda@gmail.com will get a JupyterHub username of 'yuvipanda@gmail.com'.
+
+        By default, *no* domain stripping is performed, and the JupyterHub username
+        is the primary email of the canvas user.
+        """
+    )
+
+    canvas_url = Unicode(
+        '',
+        config=True,
+        help="""
+        URL to canvas installation to use for authentication.
+        """
+    )
+
+    allowed_courses = Set(
+        set(),
+        config=True,
+        help="""
+        Set of classes ids whose enrolees get access to this hub.
+
+        You can find the IDs from the URL of the course page on
+        canvas.
+
+        If left empty, all users are allowed.
+
+        Requires fetch_enrolled_courses to be set to True
+        """
+    )
+
+    inclusive_allow_list = Bool(
+        False,
+        config=True,
+        help="""
+        Allow users in allow_list in addition to those enrolled in courses.
+
+        By default, when allowed_list is specified, *only* those users
+        can login. However, often you want to grant access to additional
+        users who aren't in the courses - infrastructure admins, for example.
+
+        Setting this to True will allow both folks in the course *and*
+        those in the allowed_list.
+
+        If this is set to True, allowed_courses must *also* be set.
+        """
+    )
+
+    fetch_enrolled_courses = Bool(
+        False,
+        config=True,
+        help="""
+        Fetch list of courses user is enrolled in & put it in auth_state.
+
+        Having the list of courses a user is currently enrolled in can
+        help with access control, API access, etc. When set to True,
+        CanvasOAuthenticator will make a second request to get the
+        list of courses the user is enrolled in, so other actions (such as
+        only allowing some - see allowed_courses) can be performed.
+        """
+    )
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+
+        if not self.canvas_url:
+            raise ValueError('c.CanvasAuthenticator.canvas_url must be set')
+
+        self.token_url = url_path_join(self.canvas_url, 'login/oauth2/token')
+        self.userdata_url = url_path_join(self.canvas_url, 'api/v1/users/self/profile')
+
+        self.extra_params = {
+            'client_id': self.client_id,
+            'client_secret': self.client_secret
+        }
+
+    async def get_courses(self, username, token):
+        """
+        Get list of courses enrolled by the current user
+        """
+        headers = dict(Authorization = f"Bearer {token}")
+        url = url_path_join(self.canvas_url, '/api/v1/courses')
+        data = []
+
+        req = HTTPRequest(
+            url,
+            method='GET',
+            headers=headers,
+            body=urllib.parse.urlencode(self.extra_params)
+        )
+
+        http_client = self.http_client()
+
+        try:
+            resp = await http_client.fetch(req)
+        except HTTPClientError as e:
+            error_text = e.response.body.decode()
+            raise Exception(f"error fetching course info for {username}: {e.code} -- {error_text}")
+        return json.loads(resp.body.decode())
+
+    async def check_allowed(self, username, user_data):
+        """
+        Return true if user with current set of courses is allowed in.
+
+        If allowed_users is set and inclusive_allow_list is not True, we only
+        allow those users.
+
+        If allowed_users is set and inclusive_allow_list is True, we allow
+        allow users in allowed_list *in addition* to those who are in the
+        enrolled courses
+
+        If allowed_courses is not set, we allow everyone who has authenticated.
+
+        If allowed_courses is set, we only allow users who are in those courses.
+        """
+        if self.allowed_users:
+            if username in self.allowed_users:
+                # Always return true for users in allowed_list
+                return True
+            else:
+                # If user isn't explicitly in allowed_list, we go to the
+                # next phase of checking *only* if inclusive_allow_list is True.
+                # Else, we just return False here.
+                if not self.inclusive_allow_list:
+                    return False
+
+        if not self.allowed_courses:
+            return True
+
+        courses = user_data['auth_state']['oauth_user']['courses']
+
+        user_course_ids = set([c['id'] for c in courses])
+
+        for c in self.allowed_courses:
+            if c in user_course_ids:
+                return True
+
+        return False
+
+    async def authenticate(self, handler, data=None):
+        """
+        Augment base user auth info with course info
+        """
+        user = await super().authenticate(handler, data)
+        if self.fetch_enrolled_courses:
+            courses = await self.get_courses(user['name'], user['auth_state']['access_token'])
+            user['auth_state']['oauth_user']['courses'] = courses
+
+        return user
+
+    def normalize_username(self, username):
+        username = username.lower()
+        # To make life easier & match usernames with existing users who were
+        # created with google auth, we want to strip the domain name. If not,
+        # we use the full email as the official user name
+        if self.strip_email_domain and username.endswith('@' + self.strip_email_domain):
+            return username.split('@')[0]
+        return username
+
+    async def pre_spawn_start(self, user, spawner):
+        """Pass oauth data to spawner via OAUTH2_ prefixed env variables."""
+        auth_state = yield user.get_auth_state()
+        if not auth_state:
+            return
+        if 'access_token' in auth_state:
+            spawner.environment["OAUTH2_ACCESS_TOKEN"] = auth_state['access_token']
+        # others are lti_user_id, id, integration_id
+        if 'oauth_user' in auth_state:
+            for k in ['login_id', 'name', 'sortable_name', 'primary_email']:
+                if k in auth_state['oauth_user']:
+                    spawner.environment[f"OAUTH2_{k.upper()}"] = auth_state['oauth_user'][k]
+
+
+class LocalCanvasOAuthenticator(LocalAuthenticator, CanvasOAuthenticator):
+
+    """A version that mixes in local system user creation"""
+
+    pass

--- a/oauthenticator/canvas.py
+++ b/oauthenticator/canvas.py
@@ -2,6 +2,7 @@ import json
 import urllib
 
 from tornado.httpclient import HTTPRequest, AsyncHTTPClient, HTTPClientError
+from tornado.httputil import url_concat
 from traitlets import List, Unicode, Set, Bool
 from jupyterhub.utils import maybe_future, url_path_join
 from jupyterhub.auth import LocalAuthenticator
@@ -105,15 +106,12 @@ class CanvasOAuthenticator(GenericOAuthenticator):
         Get list of courses enrolled by the current user
         """
         headers = dict(Authorization = f"Bearer {token}")
-        url = url_path_join(self.canvas_url, '/api/v1/courses')
-        data = []
-
-        req = HTTPRequest(
-            url,
-            method='GET',
-            headers=headers,
-            body=urllib.parse.urlencode(self.extra_params)
+        url = url_concat(
+            url_path_join(self.canvas_url, '/api/v1/courses'),
+            self.extra_params
         )
+
+        req = HTTPRequest(url, headers=headers)
 
         http_client = self.http_client()
 

--- a/oauthenticator/tests/test_canvas.py
+++ b/oauthenticator/tests/test_canvas.py
@@ -1,0 +1,199 @@
+"""
+Unit tests for CanvasOAuthenticator
+"""
+import json
+from unittest.mock import patch
+from pytest import fixture
+
+from oauthenticator.canvas import CanvasOAuthenticator
+from .mocks import setup_oauth_mock
+
+CANVAS_HOST = 'example.com'
+
+def user_model(username):
+    return {
+        'username': username,
+    }
+
+@fixture
+def sample_courses():
+    """
+    Sample redacted structure of 'courses'.
+
+    See full spec here: https://canvas.instructure.com/doc/api/courses.html#Course
+
+    We'll mock the API call to return this, so *all* users, regardless
+    of name, will have this list of enrolled courses.
+    """
+    return [
+      {
+        "id": 1,
+        "name": "Computational Structures in Data Science (Fall 2018)",
+        "enrollments": [
+          {
+            "type": "designer",
+            "role": "DesignerEnrollment",
+            "role_id": 6312,
+            "user_id": 95341,
+            "enrollment_state": "active",
+          }
+        ],
+      },
+      {
+        "id": 2,
+        "name": "Human Contexts and Ethics of Data (Fall 2018)",
+        "enrollments": [
+          {
+            "type": "student",
+            "role": "StudentEnrollment",
+            "role_id": 6309,
+            "user_id": 95341,
+            "enrollment_state": "active",
+            "limit_privileges_to_course_section": False
+          }
+        ],
+      }
+    ]
+
+@fixture
+def canvas_client(client):
+    """
+    Http client mocking appropriate OAuth endpoints
+    """
+    setup_oauth_mock(
+        client,
+        host=CANVAS_HOST,
+        access_token_path='/login/oauth2/token',
+        user_path='/api/v1/users/self/profile'
+    )
+    return client
+
+async def test_simple_canvas(canvas_client):
+    """
+    Simple canvas authenticator test
+    """
+    with patch.object(CanvasOAuthenticator, 'http_client') as fake_client:
+        fake_client.return_value = canvas_client
+
+        authenticator = CanvasOAuthenticator(canvas_url=f'https://{CANVAS_HOST}/')
+
+        handler = canvas_client.handler_for_user(user_model('test'))
+        user_info = await authenticator.authenticate(handler)
+
+        assert user_info is not None
+        oauth_user = user_info['auth_state']['oauth_user']
+
+        # courses should be picked up only if allowed_courses is set
+        assert 'courses' not in oauth_user
+        assert 'username' in oauth_user
+
+async def test_get_courses(canvas_client, sample_courses):
+    """
+    Test retreiving course information from canvas API
+
+    We mock the API request, but make sure that authenticate fetches
+    it and passes it along properly
+    """
+
+    # Mock response to courses endpoint, return sample courses fixture
+    canvas_client.hosts[CANVAS_HOST].append(
+        ('/api/v1/courses', lambda req: json.dumps(sample_courses))
+    )
+
+    with patch.object(CanvasOAuthenticator, 'http_client') as fake_client:
+        fake_client.return_value = canvas_client
+
+        authenticator = CanvasOAuthenticator(
+            canvas_url=f'https://{CANVAS_HOST}/',
+            fetch_enrolled_courses=True
+        )
+
+        handler = canvas_client.handler_for_user(user_model(
+            'test'
+        ))
+
+        user_info = await authenticator.authenticate(handler)
+
+        assert user_info is not None
+        oauth_user = user_info['auth_state']['oauth_user']
+        assert oauth_user['courses'] == sample_courses
+
+async def test_allowed_courses(canvas_client, sample_courses):
+    """
+    Test that allowed_courses is respected
+    """
+    canvas_client.hosts[CANVAS_HOST].append(
+        ('/api/v1/courses', lambda req: json.dumps(sample_courses))
+    )
+    with patch.object(CanvasOAuthenticator, 'http_client') as fake_client:
+        fake_client.return_value = canvas_client
+
+        authenticator = CanvasOAuthenticator(
+            canvas_url=f'https://{CANVAS_HOST}/',
+            allowed_courses=[2, 3],
+            fetch_enrolled_courses=True
+        )
+
+        handler = canvas_client.handler_for_user(user_model(
+            'test'
+        ))
+
+        # All users are members of course 1, 2
+        user_info = await authenticator.authenticate(handler)
+        assert await authenticator.check_allowed('test', user_info)
+
+        # If only course 3 users are allowed, we should deny this user
+        authenticator.allowed_courses = [3]
+        assert not await authenticator.check_allowed('test', user_info)
+
+
+async def test_inclusive_allowed_list(canvas_client, sample_courses):
+    """
+    Test adding users with allowed_list, in addition to allowed_courses
+    """
+    canvas_client.hosts[CANVAS_HOST].append(
+        ('/api/v1/courses', lambda req: json.dumps(sample_courses))
+    )
+    with patch.object(CanvasOAuthenticator, 'http_client') as fake_client:
+        fake_client.return_value = canvas_client
+
+        authenticator = CanvasOAuthenticator(
+            canvas_url=f'https://{CANVAS_HOST}/',
+            allowed_users=[
+                'explicitly_allowed_user_1',
+                'explicitly_allowed_user_2'
+            ],
+            fetch_enrolled_courses=True
+        )
+
+        # An explicitly allowed user must be allowed in
+        handler = canvas_client.handler_for_user(user_model(
+            'explicitly_allowed_user_1'
+        ))
+
+        user_info = await authenticator.authenticate(handler)
+
+        assert await authenticator.check_allowed('explicitly_allowed_user_1', user_info)
+
+        # By default, a user who has just logged in via canvas,
+        # but isn't explicilty allowed, should not be allowed to login
+        handler = canvas_client.handler_for_user(user_model(
+            'implicitly_allowed_user_1'
+        ))
+
+        user_info = await authenticator.authenticate(handler)
+        assert not await authenticator.check_allowed('implicitly_allowed_user_1', user_info)
+
+        authenticator.allowed_courses = {2}
+        authenticator.inclusive_allow_list = True
+
+        handler = canvas_client.handler_for_user(user_model(
+            'implicitly_allowed_user_1'
+        ))
+        user_info = await authenticator.authenticate(handler)
+
+        assert await authenticator.check_allowed('implicitly_allowed_user_1', user_info)
+
+        authenticator.allowed_courses = {3}
+        assert not await authenticator.check_allowed('implicitly_allowed_user_1', user_info)
+

--- a/setup.py
+++ b/setup.py
@@ -86,6 +86,9 @@ setup_args = dict(
 
             'openshift = oauthenticator.openshift:OpenShiftOAuthenticator',
             'local-openshift = oauthenticator.openshift:LocalOpenShiftOAuthenticator',
+
+            'canvas = oauthenticator.canvas:CanvasOAuthenticator',
+            'localcanvas = oauthenticator.canvas:LocalCanvasOAuthenticator',
         ],
     },
     classifiers         = [


### PR DESCRIPTION
Canvas is a very popular educational tool used to manage
classes in universities across the world. It has a very
rich API (https://canvas.instructure.com/doc/api/), and
deep integration with it makes a lot of things possible.

This Authenticator builds on top of GenericOAuthenticator,
but adds a few new features:

- Strip domain names specific user emails to get userids. Works
  when all your Canvas users have an email for your educational
  institution.
- Fetch list of courses the user is enrolled in, and what kind
  (student, TA, instructor, etc). This allows for finer
  grained access control, and modifying the user environment
  based on the courses they are enrolled in.
- Ability to restrict user logins based on what courses they
  are enrolled in.

I've added some unit tests, and things seem to be working out
ok.