### PR TITLE
Ensure oauthenticator.tests is packaged

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ from __future__ import print_function
 import os
 import sys
 
-from setuptools import setup
+from setuptools import find_packages, setup
 from setuptools.command.bdist_egg import bdist_egg
 
 class bdist_egg_disabled(bdist_egg):
@@ -38,7 +38,7 @@ with open(pjoin(here, 'oauthenticator', '_version.py')) as f:
 
 setup_args = dict(
     name                = 'oauthenticator',
-    packages            = ['oauthenticator', 'oauthenticator.tests'],
+    packages            = find_packages(),
     version             = version_ns['__version__'],
     description         = "OAuthenticator: Authenticate JupyterHub users with common OAuth providers",
     long_description    = open("README.md").read(),

--- a/setup.py
+++ b/setup.py
@@ -38,7 +38,7 @@ with open(pjoin(here, 'oauthenticator', '_version.py')) as f:
 
 setup_args = dict(
     name                = 'oauthenticator',
-    packages            = ['oauthenticator'],
+    packages            = ['oauthenticator', 'oauthenticator.tests'],
     version             = version_ns['__version__'],
     description         = "OAuthenticator: Authenticate JupyterHub users with common OAuth providers",
     long_description    = open("README.md").read(),


### PR DESCRIPTION
This ensures you can import the test infrastructure when developing external authenticators that have this as a dependency.

See https://github.com/jupyterhub/oauthenticator/pull/406#issuecomment-769320126