### PR TITLE
[OpenShift] add allowed_groups and admin_groups

### DIFF
--- a/oauthenticator/openshift.py
+++ b/oauthenticator/openshift.py
@@ -162,6 +162,7 @@ class OpenShiftOAuthenticator(OAuthenticator):
         is authenticated based on groups, an admin, or both.
         """
         user_groups = set(user_info['auth_state']['openshift_user']['groups'])
+        username = user_info['name']
 
         if self.admin_groups:
             is_admin = self.user_in_groups(user_groups, self.admin_groups)
@@ -175,7 +176,7 @@ class OpenShiftOAuthenticator(OAuthenticator):
             return user_info
         else:
             msg = f"username:{username} User not in any of the allowed/admin groups"
-            self.log.warning(msg.format(username=user_info['name']))
+            self.log.warning(msg)
             return None
 
 

--- a/oauthenticator/openshift.py
+++ b/oauthenticator/openshift.py
@@ -28,18 +28,21 @@ class OpenShiftOAuthenticator(OAuthenticator):
     scope = ['user:info']
 
     openshift_url = Unicode(
-        os.environ.get('OPENSHIFT_URL') or 'https://openshift.default.svc.cluster.local', config=True
+        os.environ.get('OPENSHIFT_URL')
+        or 'https://openshift.default.svc.cluster.local',
+        config=True,
     )
 
     validate_cert = Bool(
         True, config=True, help="Set to False to disable certificate validation"
     )
 
-    ca_certs = Unicode(
-        config=True
-    )
+    ca_certs = Unicode(config=True)
 
-    allowed_groups = List(config=True, help="List of OpenShift groups that should be allowed to access the hub.")
+    allowed_groups = List(
+        config=True,
+        help="List of OpenShift groups that should be allowed to access the hub.",
+    )
 
     @default("ca_certs")
     def _ca_certs_default(self):
@@ -61,7 +64,9 @@ class OpenShiftOAuthenticator(OAuthenticator):
         return resp_json.get('issuer')
 
     openshift_rest_api_url = Unicode(
-        os.environ.get('OPENSHIFT_REST_API_URL') or 'https://openshift.default.svc.cluster.local', config=True
+        os.environ.get('OPENSHIFT_REST_API_URL')
+        or 'https://openshift.default.svc.cluster.local',
+        config=True,
     )
 
     @default("openshift_rest_api_url")
@@ -138,13 +143,11 @@ class OpenShiftOAuthenticator(OAuthenticator):
             'auth_state': {'access_token': access_token, 'openshift_user': ocp_user},
         }
 
-
         if self.allowed_groups:
             if not any(set(ocp_user['groups']).intersection(set(self.allowed_groups))):
                 msg = "username:{username} User not in any of the allowed groups"
                 self.log.warning(msg.format(username=username))
                 return None
-
 
         return auth_data
 

--- a/oauthenticator/openshift.py
+++ b/oauthenticator/openshift.py
@@ -138,18 +138,16 @@ class OpenShiftOAuthenticator(OAuthenticator):
 
         username = ocp_user['metadata']['name']
 
-        auth_data = {
-            'name': username,
-            'auth_state': {'access_token': access_token, 'openshift_user': ocp_user},
-        }
-
         if self.allowed_groups:
             if not any(set(ocp_user['groups']).intersection(set(self.allowed_groups))):
                 msg = "username:{username} User not in any of the allowed groups"
                 self.log.warning(msg.format(username=username))
                 return None
 
-        return auth_data
+        return {
+            'name': username,
+            'auth_state': {'access_token': access_token, 'openshift_user': ocp_user},
+        }
 
 
 class LocalOpenShiftOAuthenticator(LocalAuthenticator, OpenShiftOAuthenticator):

--- a/oauthenticator/openshift.py
+++ b/oauthenticator/openshift.py
@@ -174,7 +174,7 @@ class OpenShiftOAuthenticator(OAuthenticator):
         elif user_in_allowed_group:
             return user_info
         else:
-            msg = "username:{username} User not in any of the allowed/admin groups"
+            msg = f"username:{username} User not in any of the allowed/admin groups"
             self.log.warning(msg.format(username=user_info['name']))
             return None
 

--- a/oauthenticator/openshift.py
+++ b/oauthenticator/openshift.py
@@ -7,7 +7,6 @@ Derived from the GitHub OAuth authenticator.
 
 import json
 import os
-import warnings
 
 import requests
 from jupyterhub.auth import LocalAuthenticator
@@ -18,12 +17,6 @@ from tornado.httputil import url_concat
 
 from oauthenticator.oauth2 import OAuthenticator
 from traitlets import Bool, Set, Unicode, default
-
-try:
-    import pycurl
-    AsyncHTTPClient.configure("tornado.curl_httpclient.CurlAsyncHTTPClient")
-except ModuleNotFoundError:
-    warnings.warn('pycurl not installed. defaulting to simple_httpclient')
 
 
 class OpenShiftOAuthenticator(OAuthenticator):

--- a/oauthenticator/tests/test_openshift.py
+++ b/oauthenticator/tests/test_openshift.py
@@ -8,15 +8,15 @@ from .mocks import setup_oauth_mock
 def user_model(username):
     """Return a user model"""
     return {
-        'metadata': {
-            'name': username,
-        }
+        'metadata': {'name': username},
+        "groups": ["group1", "group2"],
     }
 
 
 @fixture
 def openshift_client(client):
-    setup_oauth_mock(client,
+    setup_oauth_mock(
+        client,
         host=['openshift.default.svc.cluster.local'],
         access_token_path='/oauth/token',
         user_path='/apis/user.openshift.io/v1/users/~',
@@ -36,3 +36,27 @@ async def test_openshift(openshift_client):
     assert 'access_token' in auth_state
     assert 'openshift_user' in auth_state
 
+
+async def test_openshift_allowed_groups(openshift_client):
+    authenticator = OpenShiftOAuthenticator()
+    authenticator.allowed_groups = ['group1']
+    authenticator.openshift_auth_api_url = "https://openshift.default.svc.cluster.local"
+    handler = openshift_client.handler_for_user(user_model('wash'))
+    user_info = await authenticator.authenticate(handler)
+    assert sorted(user_info) == ['auth_state', 'name']
+    name = user_info['name']
+    assert name == 'wash'
+    auth_state = user_info['auth_state']
+    assert 'access_token' in auth_state
+    assert 'openshift_user' in auth_state
+    groups = auth_state['openshift_user']['groups']
+    assert 'group1' in groups
+
+
+async def test_openshift_not_in_allowed_groups(openshift_client):
+    authenticator = OpenShiftOAuthenticator()
+    authenticator.allowed_groups = ['group3']
+    authenticator.openshift_auth_api_url = "https://openshift.default.svc.cluster.local"
+    handler = openshift_client.handler_for_user(user_model('wash'))
+    user_info = await authenticator.authenticate(handler)
+    assert user_info == None

--- a/oauthenticator/tests/test_openshift.py
+++ b/oauthenticator/tests/test_openshift.py
@@ -39,7 +39,7 @@ async def test_openshift(openshift_client):
 
 async def test_openshift_allowed_groups(openshift_client):
     authenticator = OpenShiftOAuthenticator()
-    authenticator.allowed_groups = ['group1']
+    authenticator.allowed_groups = {'group1'}
     authenticator.openshift_auth_api_url = "https://openshift.default.svc.cluster.local"
     handler = openshift_client.handler_for_user(user_model('wash'))
     user_info = await authenticator.authenticate(handler)
@@ -55,8 +55,41 @@ async def test_openshift_allowed_groups(openshift_client):
 
 async def test_openshift_not_in_allowed_groups(openshift_client):
     authenticator = OpenShiftOAuthenticator()
-    authenticator.allowed_groups = ['group3']
+    authenticator.allowed_groups = {'group3'}
     authenticator.openshift_auth_api_url = "https://openshift.default.svc.cluster.local"
     handler = openshift_client.handler_for_user(user_model('wash'))
     user_info = await authenticator.authenticate(handler)
     assert user_info == None
+
+
+async def test_openshift_not_in_allowed_groups_but_is_admin(openshift_client):
+    authenticator = OpenShiftOAuthenticator()
+    authenticator.allowed_groups = {'group3'}
+    authenticator.admin_groups = {'group1'}
+    authenticator.openshift_auth_api_url = "https://openshift.default.svc.cluster.local"
+    handler = openshift_client.handler_for_user(user_model('wash'))
+    user_info = await authenticator.authenticate(handler)
+    assert sorted(user_info) == ['admin', 'auth_state', 'name']
+    assert user_info['admin'] == True
+
+
+async def test_openshift_in_allowed_groups_and_is_admin(openshift_client):
+    authenticator = OpenShiftOAuthenticator()
+    authenticator.allowed_groups = {'group2'}
+    authenticator.admin_groups = {'group1'}
+    authenticator.openshift_auth_api_url = "https://openshift.default.svc.cluster.local"
+    handler = openshift_client.handler_for_user(user_model('wash'))
+    user_info = await authenticator.authenticate(handler)
+    assert sorted(user_info) == ['admin', 'auth_state', 'name']
+    assert user_info['admin'] == True
+
+
+async def test_openshift_in_allowed_groups_and_is_not_admin(openshift_client):
+    authenticator = OpenShiftOAuthenticator()
+    authenticator.allowed_groups = {'group2'}
+    authenticator.admin_groups = {'group3'}
+    authenticator.openshift_auth_api_url = "https://openshift.default.svc.cluster.local"
+    handler = openshift_client.handler_for_user(user_model('wash'))
+    user_info = await authenticator.authenticate(handler)
+    assert sorted(user_info) == ['admin', 'auth_state', 'name']
+    assert user_info['admin'] == False


### PR DESCRIPTION
What this PR does is add both `allowed_groups` and `admin_groups` configuration options similar to that of the other oauthenticators.

Since OpenShift now allows you to sync groups from other IdP such as LDAP it is useful to be able to leverage group based authentication, but have the hub still point to the built-in OAuth provider. 

Example: In a multi-namespace deployment it might be helpful to feature-gate a hub based on the type of hardware attached to it (ie. the GPU cluster should only be available to those in the `datascience` cluster group).

@vpavlin do you know if this should be feature-gated to a particular OCP version? I tested it personally on OCP 4.6 and don't have access to any other clusters.