### PR TITLE
Add `.fetch(req)` method to base OAuthenticator

### DIFF
--- a/oauthenticator/auth0.py
+++ b/oauthenticator/auth0.py
@@ -32,15 +32,11 @@ jupyterhub_config.py :
 import json
 import os
 
-from tornado.auth import OAuth2Mixin
-from tornado import web
-from tornado.httpclient import HTTPRequest, AsyncHTTPClient
-
+from jupyterhub.auth import LocalAuthenticator
+from tornado.httpclient import HTTPRequest
 from traitlets import Unicode, default
 
-from jupyterhub.auth import LocalAuthenticator
-
-from .oauth2 import OAuthLoginHandler, OAuthenticator
+from .oauth2 import OAuthenticator
 
 
 class Auth0OAuthenticator(OAuthenticator):
@@ -68,8 +64,6 @@ class Auth0OAuthenticator(OAuthenticator):
 
     async def authenticate(self, handler, data=None):
         code = handler.get_argument("code")
-        # TODO: Configure the curl_httpclient for tornado
-        http_client = AsyncHTTPClient()
 
         params = {
             'grant_type': 'authorization_code',
@@ -87,8 +81,7 @@ class Auth0OAuthenticator(OAuthenticator):
             body=json.dumps(params),
         )
 
-        resp = await http_client.fetch(req)
-        resp_json = json.loads(resp.body.decode('utf8', 'replace'))
+        resp_json = await self.fetch(req)
 
         access_token = resp_json['access_token']
 
@@ -106,8 +99,7 @@ class Auth0OAuthenticator(OAuthenticator):
             method="GET",
             headers=headers,
         )
-        resp = await http_client.fetch(req)
-        resp_json = json.loads(resp.body.decode('utf8', 'replace'))
+        resp_json = await self.fetch(req)
 
         return {
             'name': resp_json["email"],

--- a/oauthenticator/azuread.py
+++ b/oauthenticator/azuread.py
@@ -2,20 +2,15 @@
 Custom Authenticator to use Azure AD with JupyterHub
 """
 
-import json
-import jwt
 import os
 import urllib
 
-from tornado.auth import OAuth2Mixin
-from tornado.log import app_log
-from tornado.httpclient import HTTPRequest, AsyncHTTPClient
-
+import jwt
 from jupyterhub.auth import LocalAuthenticator
-
+from tornado.httpclient import HTTPRequest
 from traitlets import Unicode, default
 
-from .oauth2 import OAuthLoginHandler, OAuthenticator
+from .oauth2 import OAuthenticator
 
 
 class AzureAdOAuthenticator(OAuthenticator):
@@ -47,7 +42,6 @@ class AzureAdOAuthenticator(OAuthenticator):
 
     async def authenticate(self, handler, data=None):
         code = handler.get_argument("code")
-        http_client = AsyncHTTPClient()
 
         params = dict(
             client_id=self.client_id,
@@ -72,10 +66,8 @@ class AzureAdOAuthenticator(OAuthenticator):
             body=data  # Body is required for a POST...
         )
 
-        resp = await http_client.fetch(req)
-        resp_json = json.loads(resp.body.decode('utf8', 'replace'))
+        resp_json = await self.fetch(req)
 
-        # app_log.info("Response %s", resp_json)
         access_token = resp_json['access_token']
 
         id_token = resp_json['id_token']

--- a/oauthenticator/globus.py
+++ b/oauthenticator/globus.py
@@ -1,20 +1,17 @@
 """
 Custom Authenticator to use Globus OAuth2 with JupyterHub
 """
+import base64
 import os
 import pickle
-import json
-import base64
 import urllib
 
-from tornado.web import HTTPError
-from tornado.httpclient import HTTPRequest, AsyncHTTPClient
-
-from traitlets import List, Unicode, Bool, default
-
+from jupyterhub.auth import LocalAuthenticator
 from jupyterhub.handlers import LogoutHandler
 from jupyterhub.utils import url_path_join
-from jupyterhub.auth import LocalAuthenticator
+from tornado.httpclient import HTTPRequest
+from tornado.web import HTTPError
+from traitlets import Bool, List, Unicode, default
 
 from .oauth2 import OAuthenticator
 
@@ -153,7 +150,6 @@ class GlobusOAuthenticator(OAuthenticator):
         will have the 'foouser' account in Jupyterhub.
         """
         # Complete login and exchange the code for tokens.
-        http_client = AsyncHTTPClient()
         params = dict(
             redirect_uri=self.get_callback_url(handler),
             code=handler.get_argument("code"),
@@ -163,15 +159,14 @@ class GlobusOAuthenticator(OAuthenticator):
             headers=self.get_client_credential_headers(),
             body=urllib.parse.urlencode(params),
         )
-        token_response = await http_client.fetch(req)
-        token_json = json.loads(token_response.body.decode('utf8', 'replace'))
+        token_json = await self.fetch(req)
 
         # Fetch user info at Globus's oauth2/userinfo/ HTTP endpoint to get the username
         user_headers = self.get_default_headers()
         user_headers['Authorization'] = 'Bearer {}'.format(token_json['access_token'])
         req = HTTPRequest(self.userdata_url, method='GET', headers=user_headers)
-        user_resp = await http_client.fetch(req)
-        username = self.get_username(json.loads(user_resp.body.decode('utf8', 'replace')))
+        user_resp = await self.fetch(req)
+        username = self.get_username(user_resp)
 
         # Each token should have these attributes. Resource server is optional,
         # and likely won't be present.
@@ -241,14 +236,14 @@ class GlobusOAuthenticator(OAuthenticator):
         access_tokens = [token_dict.get('access_token') for token_dict in services.values()]
         refresh_tokens = [token_dict.get('refresh_token') for token_dict in services.values()]
         all_tokens = [tok for tok in access_tokens + refresh_tokens if tok is not None]
-        http_client = AsyncHTTPClient()
+
         for token in all_tokens:
             req = HTTPRequest(self.revocation_url,
                               method="POST",
                               headers=self.get_client_credential_headers(),
                               body=urllib.parse.urlencode({'token': token}),
                               )
-            await http_client.fetch(req)
+            await self.fetch(req)
 
     def logout_url(self, base_url):
         return url_path_join(base_url, 'logout')

--- a/oauthenticator/mediawiki.py
+++ b/oauthenticator/mediawiki.py
@@ -4,24 +4,18 @@ Custom Authenticator to use MediaWiki OAuth with JupyterHub
 Requires `mwoauth` package.
 """
 
-import os
 import json
+import os
 from asyncio import wrap_future
 from concurrent.futures import ThreadPoolExecutor
 
-from tornado import web
-
 from jupyterhub.handlers import BaseHandler
 from jupyterhub.utils import url_path_join
-from jupyterhub import orm
-
 from mwoauth import ConsumerToken, Handshaker
 from mwoauth.tokens import RequestToken
-
 from traitlets import Any, Integer, Unicode
 
-from oauthenticator import OAuthenticator, OAuthCallbackHandler
-
+from oauthenticator import OAuthCallbackHandler, OAuthenticator
 
 # Name of cookie used to pass auth token between the oauth
 # login and authentication phase
@@ -141,4 +135,3 @@ class MWOAuthenticator(OAuthenticator):
             }
         else:
             self.log.error("No username found in %s", identity)
-

--- a/oauthenticator/oauth2.py
+++ b/oauthenticator/oauth2.py
@@ -7,18 +7,17 @@ Most of the code c/o Kyle Kelley (@rgbkrk)
 import base64
 import json
 import os
-from urllib.parse import quote, urlparse
 import uuid
+from urllib.parse import quote, urlparse, urlunparse
 
+from jupyterhub.auth import Authenticator
+from jupyterhub.handlers import BaseHandler
+from jupyterhub.utils import url_path_join
 from tornado import web
 from tornado.auth import OAuth2Mixin
+from tornado.httpclient import AsyncHTTPClient, HTTPClientError
 from tornado.log import app_log
-
-from jupyterhub.handlers import BaseHandler
-from jupyterhub.auth import Authenticator
-from jupyterhub.utils import url_path_join
-
-from traitlets import Unicode, Bool, List, Dict, default, observe
+from traitlets import Any, Bool, Dict, List, Unicode, default
 
 
 def guess_callback_uri(protocol, host, hub_server_url):
@@ -316,9 +315,61 @@ class OAuthenticator(Authenticator):
         else:
             return True
 
+    http_client = Any()
+
+    @default("http_client")
+    def _default_http_client(self):
+        return AsyncHTTPClient()
+
+    async def fetch(self, req, label="fetching", parse_json=True, **kwargs):
+        """Wrapper for http requests
+
+        logs error responses, parses successful JSON responses
+
+        Args:
+            req: tornado HTTPRequest
+            label (str): label describing what is happening,
+                used in log message when the request fails.
+            **kwargs: remaining keyword args
+                passed to underlying `client.fetch(req, **kwargs)`
+        Returns:
+            r: parsed JSON response
+        """
+        try:
+            resp = await self.http_client.fetch(req, **kwargs)
+        except HTTPClientError as e:
+            if e.response:
+                # Log failed response message for debugging purposes
+                message = e.response.body.decode("utf8", "replace")
+                try:
+                    # guess json, reformat for readability
+                    json_message = json.loads(message)
+                except ValueError:
+                    # not json
+                    pass
+                else:
+                    # reformat json log message for readability
+                    message = json.dumps(json_message, sort_keys=True, indent=1)
+            else:
+                # didn't get a response, e.g. connection error
+                message = str(e)
+
+            # log url without query params
+            url = urlunparse(urlparse(req.url)._replace(query=""))
+            app_log.error(f"Error {label} {e.code} {req.method} {url}: {message}")
+            raise e
+        else:
+            if parse_json:
+                if resp.body:
+                    return json.loads(resp.body.decode('utf8', 'replace'))
+                else:
+                    # empty body is None
+                    return None
+            else:
+                return resp
+
     def login_url(self, base_url):
         return url_path_join(base_url, 'oauth_login')
-
 
     def get_callback_url(self, handler=None):
         """Get my OAuth redirect URL

--- a/oauthenticator/tests/test_generic.py
+++ b/oauthenticator/tests/test_generic.py
@@ -1,9 +1,9 @@
+from functools import partial
+
 from pytest import fixture
 
 from ..generic import GenericOAuthenticator
-
 from .mocks import setup_oauth_mock
-from unittest import mock
 
 
 def user_model(username, **kwargs):
@@ -16,7 +16,7 @@ def user_model(username, **kwargs):
     return user
 
 
-def get_authenticator(**kwargs):
+def _get_authenticator(**kwargs):
     return GenericOAuthenticator(
         token_url='https://generic.horse/oauth/access_token',
         userdata_url='https://generic.horse/oauth/userinfo',
@@ -39,128 +39,131 @@ def generic_client(client):
     return client
 
 
-async def test_generic(generic_client):
-    with mock.patch.object(GenericOAuthenticator, 'http_client') as fake_client:
-        fake_client.return_value = generic_client
-        authenticator = get_authenticator()
-
-        handler = get_simple_handler(generic_client)
-        user_info = await authenticator.authenticate(handler)
-        assert sorted(user_info) == ['auth_state', 'name']
-        name = user_info['name']
-        assert name == 'wash'
-        auth_state = user_info['auth_state']
-        assert 'access_token' in auth_state
-        assert 'oauth_user' in auth_state
-        assert 'refresh_token' in auth_state
-        assert 'scope' in auth_state
+@fixture
+def get_authenticator(generic_client, **kwargs):
+    return partial(_get_authenticator, http_client=generic_client)
 
 
-async def test_generic_callable_username_key(generic_client):
-    with mock.patch.object(GenericOAuthenticator, 'http_client') as fake_client:
-        fake_client.return_value = generic_client
-        authenticator = get_authenticator(
-            username_key=lambda r: r['alternate_username']
+async def test_generic(get_authenticator, generic_client):
+    authenticator = get_authenticator()
+
+    handler = get_simple_handler(generic_client)
+    user_info = await authenticator.authenticate(handler)
+    assert sorted(user_info) == ['auth_state', 'name']
+    name = user_info['name']
+    assert name == 'wash'
+    auth_state = user_info['auth_state']
+    assert 'access_token' in auth_state
+    assert 'oauth_user' in auth_state
+    assert 'refresh_token' in auth_state
+    assert 'scope' in auth_state
+
+
+async def test_generic_callable_username_key(get_authenticator, generic_client):
+    authenticator = get_authenticator(username_key=lambda r: r['alternate_username'])
+    handler = generic_client.handler_for_user(
+        user_model('wash', alternate_username='zoe')
+    )
+    user_info = await authenticator.authenticate(handler)
+    assert user_info['name'] == 'zoe'
+
+
+async def test_generic_callable_groups_claim_key_with_allowed_groups(
+    get_authenticator, generic_client
+):
+    authenticator = get_authenticator(
+        scope=['openid', 'profile', 'roles'],
+        claim_groups_key=lambda r: r.get('policies').get('roles'),
+        allowed_groups=['super_user'],
+    )
+    handler = generic_client.handler_for_user(
+        user_model('wash', alternate_username='zoe', policies={'roles': ['super_user']})
+    )
+    user_info = await authenticator.authenticate(handler)
+    assert user_info['name'] == 'wash'
+
+
+async def test_generic_groups_claim_key_with_allowed_groups(
+    get_authenticator, generic_client
+):
+    authenticator = get_authenticator(
+        scope=['openid', 'profile', 'roles'],
+        claim_groups_key='groups',
+        allowed_groups=['super_user'],
+    )
+    handler = generic_client.handler_for_user(
+        user_model('wash', alternate_username='zoe', groups=['super_user'])
+    )
+    user_info = await authenticator.authenticate(handler)
+    assert user_info['name'] == 'wash'
+
+
+async def test_generic_groups_claim_key_with_allowed_groups_unauthorized(
+    get_authenticator, generic_client
+):
+    authenticator = get_authenticator(
+        scope=['openid', 'profile', 'roles'],
+        claim_groups_key='groups',
+        allowed_groups=['user'],
+    )
+    handler = generic_client.handler_for_user(
+        user_model('wash', alternate_username='zoe', groups=['public'])
+    )
+    user_info = await authenticator.authenticate(handler)
+    assert user_info is None
+
+
+async def test_generic_groups_claim_key_with_allowed_groups_and_admin_groups(
+    get_authenticator, generic_client
+):
+    authenticator = get_authenticator(
+        scope=['openid', 'profile', 'roles'],
+        claim_groups_key='groups',
+        allowed_groups=['user'],
+        admin_groups=['administrator'],
+    )
+    handler = generic_client.handler_for_user(
+        user_model('wash', alternate_username='zoe', groups=['user', 'administrator'])
+    )
+    user_info = await authenticator.authenticate(handler)
+    assert user_info['name'] == 'wash'
+    assert user_info['admin'] is True
+
+
+async def test_generic_groups_claim_key_with_allowed_groups_and_admin_groups_not_admin(
+    get_authenticator, generic_client
+):
+    authenticator = get_authenticator(
+        scope=['openid', 'profile', 'roles'],
+        claim_groups_key='groups',
+        allowed_groups=['user'],
+        admin_groups=['administrator'],
+    )
+    handler = generic_client.handler_for_user(
+        user_model('wash', alternate_username='zoe', groups=['user'])
+    )
+    user_info = await authenticator.authenticate(handler)
+    assert user_info['name'] == 'wash'
+    assert user_info['admin'] is False
+
+
+async def test_generic_callable_groups_claim_key_with_allowed_groups_and_admin_groups(
+    get_authenticator, generic_client
+):
+    authenticator = get_authenticator(
+        username_key=lambda r: r['alternate_username'],
+        scope=['openid', 'profile', 'roles'],
+        claim_groups_key=lambda r: r.get('policies').get('roles'),
+        allowed_groups=['user', 'public'],
+        admin_groups=['administrator'],
+    )
+    handler = generic_client.handler_for_user(
+        user_model(
+            'wash',
+            alternate_username='zoe',
+            policies={'roles': ['user', 'administrator']},
         )
-        handler = generic_client.handler_for_user(
-            user_model('wash', alternate_username='zoe')
-        )
-        user_info = await authenticator.authenticate(handler)
-        assert user_info['name'] == 'zoe'
-
-
-async def test_generic_callable_groups_claim_key_with_allowed_groups(generic_client):
-    with mock.patch.object(GenericOAuthenticator, 'http_client') as fake_client:
-        fake_client.return_value = generic_client
-        authenticator = get_authenticator(
-            scope=['openid', 'profile', 'roles'],
-            claim_groups_key=lambda r: r.get('policies').get('roles'),
-            allowed_groups=['super_user']
-        )
-        handler = generic_client.handler_for_user(
-            user_model('wash', alternate_username='zoe', policies={'roles': ['super_user']})
-        )
-        user_info = await authenticator.authenticate(handler)
-        assert user_info['name'] == 'wash'
-
-
-async def test_generic_groups_claim_key_with_allowed_groups(generic_client):
-    with mock.patch.object(GenericOAuthenticator, 'http_client') as fake_client:
-        fake_client.return_value = generic_client
-        authenticator = get_authenticator(
-            scope=['openid', 'profile', 'roles'],
-            claim_groups_key='groups',
-            allowed_groups=['super_user']
-        )
-        handler = generic_client.handler_for_user(
-            user_model('wash', alternate_username='zoe', groups=['super_user'])
-        )
-        user_info = await authenticator.authenticate(handler)
-        assert user_info['name'] == 'wash'
-
-
-async def test_generic_groups_claim_key_with_allowed_groups_unauthorized(generic_client):
-    with mock.patch.object(GenericOAuthenticator, 'http_client') as fake_client:
-        fake_client.return_value = generic_client
-        authenticator = get_authenticator(
-            scope=['openid', 'profile', 'roles'],
-            claim_groups_key='groups',
-            allowed_groups=['user']
-        )
-        handler = generic_client.handler_for_user(
-            user_model('wash', alternate_username='zoe', groups=['public'])
-        )
-        user_info = await authenticator.authenticate(handler)
-        assert user_info is None
-
-
-async def test_generic_groups_claim_key_with_allowed_groups_and_admin_groups(generic_client):
-    with mock.patch.object(GenericOAuthenticator, 'http_client') as fake_client:
-        fake_client.return_value = generic_client
-        authenticator = get_authenticator(
-            scope=['openid', 'profile', 'roles'],
-            claim_groups_key='groups',
-            allowed_groups=['user'],
-            admin_groups=['administrator'],
-        )
-        handler = generic_client.handler_for_user(
-            user_model('wash', alternate_username='zoe', groups=['user', 'administrator'])
-        )
-        user_info = await authenticator.authenticate(handler)
-        assert user_info['name'] == 'wash'
-        assert user_info['admin'] is True
-
-
-async def test_generic_groups_claim_key_with_allowed_groups_and_admin_groups_not_admin(generic_client):
-    with mock.patch.object(GenericOAuthenticator, 'http_client') as fake_client:
-        fake_client.return_value = generic_client
-        authenticator = get_authenticator(
-            scope=['openid', 'profile', 'roles'],
-            claim_groups_key='groups',
-            allowed_groups=['user'],
-            admin_groups=['administrator'],
-        )
-        handler = generic_client.handler_for_user(
-            user_model('wash', alternate_username='zoe', groups=['user'])
-        )
-        user_info = await authenticator.authenticate(handler)
-        assert user_info['name'] == 'wash'
-        assert user_info['admin'] is False
-
-
-async def test_generic_callable_groups_claim_key_with_allowed_groups_and_admin_groups(generic_client):
-    with mock.patch.object(GenericOAuthenticator, 'http_client') as fake_client:
-        fake_client.return_value = generic_client
-        authenticator = get_authenticator(
-            username_key=lambda r: r['alternate_username'],
-            scope=['openid', 'profile', 'roles'],
-            claim_groups_key=lambda r: r.get('policies').get('roles'),
-            allowed_groups=['user', 'public'],
-            admin_groups=['administrator'],
-        )
-        handler = generic_client.handler_for_user(
-            user_model('wash', alternate_username='zoe', policies={'roles': ['user', 'administrator']})
-        )
-        user_info = await authenticator.authenticate(handler)
-        assert user_info['name'] == 'zoe'
-        assert user_info['admin'] is True
+    )
+    user_info = await authenticator.authenticate(handler)
+    assert user_info['name'] == 'zoe'
+    assert user_info['admin'] is True


### PR DESCRIPTION
consolidates:

- http client instantiation
- error handling and logging (many failed upstream requests are hard to debug because the upstream error message is not logged)
- JSON response parsing