### PR TITLE
Azure AD auth needs audience specified to validate

### DIFF
--- a/oauthenticator/azuread.py
+++ b/oauthenticator/azuread.py
@@ -71,7 +71,7 @@ class AzureAdOAuthenticator(OAuthenticator):
         access_token = resp_json['access_token']
 
         id_token = resp_json['id_token']
-        decoded = jwt.decode(id_token, options={"verify_signature": False})
+        decoded = jwt.decode(id_token, options={"verify_signature": False}, audience=self.client_id)
 
         userdict = {"name": decoded[self.username_claim]}
         userdict["auth_state"] = auth_state = {}


### PR DESCRIPTION
Using helm chart: 11.1-n340.h85c73557 azure ad authentication does not work properly. You get an invalid audience exception below. You need to pass the client id in as the audience for authentication to be successful. 

https://github.com/jpadilla/pyjwt/blob/master/jwt/api_jwt.py#L191

```
    Traceback (most recent call last):
      File "/usr/local/lib/python3.8/dist-packages/tornado/web.py", line 1704, in _execute
        result = await result
      File "/usr/local/lib/python3.8/dist-packages/oauthenticator/oauth2.py", line 224, in get
        user = await self.login_user()
      File "/usr/local/lib/python3.8/dist-packages/jupyterhub/handlers/base.py", line 749, in login_user
        authenticated = await self.authenticate(data)
      File "/usr/local/lib/python3.8/dist-packages/jupyterhub/auth.py", line 462, in get_authenticated_user
        authenticated = await maybe_future(self.authenticate(handler, data))
      File "/usr/local/lib/python3.8/dist-packages/oauthenticator/azuread.py", line 82, in authenticate
        decoded = jwt.decode(id_token, options={"verify_signature": False, "audience": self.client_id})
      File "/usr/local/lib/python3.8/dist-packages/jwt/api_jwt.py", line 106, in decode
        self._validate_claims(payload, merged_options, **kwargs)
      File "/usr/local/lib/python3.8/dist-packages/jwt/api_jwt.py", line 142, in _validate_claims
        self._validate_aud(payload, audience)
      File "/usr/local/lib/python3.8/dist-packages/jwt/api_jwt.py", line 191, in _validate_aud
        raise InvalidAudienceError('Invalid audience')
```