### PR TITLE
Add GitHub teams check

### DIFF
--- a/oauthenticator/tests/test_github.py
+++ b/oauthenticator/tests/test_github.py
@@ -66,58 +66,58 @@ async def test_allowed_org_membership(github_client):
 
     ## Mock Github API
 
-    teams = {
+    orgs = {
         'red': ['grif', 'simmons', 'donut', 'sarge', 'lopez'],
         'blue': ['tucker', 'caboose', 'burns', 'sheila', 'texas'],
     }
 
     member_regex = re.compile(r'/orgs/(.*)/members')
 
-    def team_members(paginate, request):
+    def org_members(paginate, request):
         urlinfo = urlparse(request.url)
-        team = member_regex.match(urlinfo.path).group(1)
+        org = member_regex.match(urlinfo.path).group(1)
 
-        if team not in teams:
+        if org not in orgs:
             return HTTPResponse(request, 404)
 
         if not paginate:
-            return [user_model(m) for m in teams[team]]
+            return [user_model(m) for m in orgs[org]]
         else:
             page = parse_qs(urlinfo.query).get('page', ['1'])
             page = int(page[0])
-            return team_members_paginated(
-                team, page, urlinfo, functools.partial(HTTPResponse, request))
+            return org_members_paginated(
+                org, page, urlinfo, functools.partial(HTTPResponse, request))
 
-    def team_members_paginated(team, page, urlinfo, response):
-        if page < len(teams[team]):
+    def org_members_paginated(org, page, urlinfo, response):
+        if page < len(orgs[org]):
             headers = make_link_header(urlinfo, page + 1)
-        elif page == len(teams[team]):
+        elif page == len(orgs[org]):
             headers = {}
         else:
             return response(400)
 
         headers.update({'Content-Type': 'application/json'})
 
-        ret = [user_model(teams[team][page - 1])]
+        ret = [user_model(orgs[org][page - 1])]
 
         return response(200,
                         headers=HTTPHeaders(headers),
                         buffer=BytesIO(json.dumps(ret).encode('utf-8')))
 
 
-    membership_regex = re.compile(r'/orgs/(.*)/members/(.*)')
+    org_membership_regex = re.compile(r'/orgs/(.*)/members/(.*)')
 
-    def team_membership(request):
+    def org_membership(request):
         urlinfo = urlparse(request.url)
-        urlmatch = membership_regex.match(urlinfo.path)
-        team = urlmatch.group(1)
+        urlmatch = org_membership_regex.match(urlinfo.path)
+        org = urlmatch.group(1)
         username = urlmatch.group(2)
-        print('Request team = %s, username = %s' % (team, username))
-        if team not in teams:
-            print('Team not found: team = %s' %(team))
+        print('Request org = %s, username = %s' % (org, username))
+        if org not in orgs:
+            print('Org not found: org = %s' %(org))
             return HTTPResponse(request, 404)
-        if username not in teams[team]:
-            print('Member not found: team = %s, username = %s' %(team, username))
+        if username not in orgs[org]:
+            print('Member not found: org = %s, username = %s' %(org, username))
             return HTTPResponse(request, 404)
         return HTTPResponse(request, 204)
 
@@ -126,8 +126,8 @@ async def test_allowed_org_membership(github_client):
 
     for paginate in (False, True):
         client_hosts = client.hosts['api.github.com']
-        client_hosts.append((membership_regex, team_membership))
-        client_hosts.append((member_regex, functools.partial(team_members, paginate)))
+        client_hosts.append((org_membership_regex, org_membership))
+        client_hosts.append((member_regex, functools.partial(org_members, paginate)))
 
         authenticator.allowed_organizations = ['blue']
 


### PR DESCRIPTION
Currently it is only possible to specify 'allowed_organisations' and not teams within
those organisations. This PR allows specifying allowed teams in the format:
```
allowed_organisations = <organisation>:<team>
```
e.g.
```
allowed_organisations = octoenergy:data
```