### PR TITLE
Note that whitelist should be used if not in 1.2

### DIFF
--- a/docs/source/getting-started.rst
+++ b/docs/source/getting-started.rst
@@ -219,6 +219,9 @@ and
 but be aware that each entry incurs a separate API call, increasing the
 risk of rate limiting and timeouts.
 
+Note: if restriction to projects or groups does not work, you might not be using jupyterHub 1.2. In that case you can still you use whitelists as noted in this 
+`comment <https://github.com/jupyterhub/oauthenticator/pull/366#pullrequestreview-483095919>`__.
+
 Google Setup
 ------------
 


### PR DESCRIPTION
As commented in https://github.com/jupyterhub/oauthenticator/pull/366#pullrequestreview-483095919 it should be noted that whitelist for groups and projects works in gitlab if still on version 1.2.

I spend some hours because I did not realise the doc refers to a version which is not the standard version.