### PR TITLE
Add reference to external FeiShuAuthenticator

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ OAuthenticator overrides these handlers for the common OAuth2 identity providers
 plugged in and used with JupyterHub.
 
 The following authentication services are supported through their own authenticator: [Auth0](oauthenticator/auth0.py),
-[Azure AD](oauthenticator/azuread.py), [Bitbucket](oauthenticator/bitbucket.py), [CILogon](oauthenticator/cilogon.py),
+[Azure AD](oauthenticator/azuread.py), [Bitbucket](oauthenticator/bitbucket.py), [CILogon](oauthenticator/cilogon.py), [FeiShu](https://github.com/tezignlab/jupyterhub_feishu_authenticator), 
 [GitHub](oauthenticator/github.py), [GitLab](oauthenticator/gitlab.py), [Globus](oauthenticator/globus.py),
 [Google](oauthenticator/google.py), [MediaWiki](oauthenticator/mediawiki.py), [Okpy](oauthenticator/okpy.py),
 [OpenShift](oauthenticator/openshift.py).
@@ -30,6 +30,7 @@ The docs also provide example setups for different OAuth2 identity providers:
 
 * [General Setup](https://oauthenticator.readthedocs.io/en/latest/getting-started.html#general-setup)
 * [Azure AD](https://oauthenticator.readthedocs.io/en/latest/getting-started.html#azure-ad-setup)
+* [FeiShu](https://github.com/tezignlab/jupyterhub_feishu_authenticator)
 * [GitHub](https://oauthenticator.readthedocs.io/en/latest/getting-started.html#github-setup)
 * [GitLab](https://oauthenticator.readthedocs.io/en/latest/getting-started.html#gitlab-setup)
 * [Google](https://oauthenticator.readthedocs.io/en/latest/getting-started.html#google-setup)


### PR DESCRIPTION
FeiShu (https://www.feishu.cn/en/) is one of the most popular team collaboration tools developed by ByteDance (the company behind Tiktok). This PR enables OAuth authentication via FeiShu. We have tested this in our internal JupyterHub deployment at Tezign.com.