### PR TITLE
ci: unpin pyjwt in test-requirements.txt

### DIFF
--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -2,7 +2,7 @@
 .[googlegroups]
 codecov
 flake8
-pyjwt>=1.7,<2.0
+pyjwt
 mwoauth >= 0.3.7
 pytest >= 2.8
 pytest-cov


### PR DESCRIPTION
I think there is support for pyjwt in OAUthenticator since of #420, so we can unpin the test-requirements.txt and close #430 which mentions the test-requirements.txt file.
