### PR TITLE
Support custom logout url (logout_redirect_url)

### DIFF
--- a/oauthenticator/auth0.py
+++ b/oauthenticator/auth0.py
@@ -35,7 +35,6 @@ from jupyterhub.auth import LocalAuthenticator
 from tornado.httpclient import HTTPRequest
 from traitlets import default
 from traitlets import Unicode
-from traitlets import Bool
 
 from .oauth2 import OAuthenticator
 from .oauth2 import OAuthLogoutHandler

--- a/oauthenticator/auth0.py
+++ b/oauthenticator/auth0.py
@@ -76,7 +76,7 @@ class Auth0OAuthenticator(OAuthenticator):
 
     @default("logout_redirect_url")
     def _logout_redirect_url_default(self):
-        return os.getenv('LOGOUT_REDIRECT_URL', '')
+        return 'https://%s.auth0.com/v2/logout' % self.auth0_subdomain
 
     @default("authorize_url")
     def _authorize_url_default(self):

--- a/oauthenticator/auth0.py
+++ b/oauthenticator/auth0.py
@@ -58,12 +58,6 @@ class Auth0OAuthenticator(OAuthenticator):
 
     auth0_subdomain = Unicode(config=True)
 
-    return_to_login = Bool(
-        False,
-        help="""Whether or not to return to the hub main page after auth0 logout endpoint redirect.""",
-        config=True,
-    )
-
     logout_redirect_url = Unicode(help="""URL for logging out of Auth0""", config=True)
 
     @default("auth0_subdomain")

--- a/oauthenticator/auth0.py
+++ b/oauthenticator/auth0.py
@@ -57,8 +57,6 @@ class Auth0OAuthenticator(OAuthenticator):
 
     auth0_subdomain = Unicode(config=True)
 
-    logout_redirect_url = Unicode(help="""URL for logging out of Auth0""", config=True)
-
     @default("auth0_subdomain")
     def _auth0_subdomain_default(self):
         subdomain = os.getenv("AUTH0_SUBDOMAIN")

--- a/oauthenticator/auth0.py
+++ b/oauthenticator/auth0.py
@@ -37,23 +37,11 @@ from traitlets import default
 from traitlets import Unicode
 
 from .oauth2 import OAuthenticator
-from .oauth2 import OAuthLogoutHandler
-
-
-class Auth0LogoutHandler(OAuthLogoutHandler):
-    async def render_logout_page(self):
-        if self.authenticator.logout_redirect_url:
-            self.redirect(self.authenticator.logout_redirect_url)
-            return
-
-        super().render_logout_page()
 
 
 class Auth0OAuthenticator(OAuthenticator):
 
     login_service = "Auth0"
-
-    logout_handler = Auth0LogoutHandler
 
     auth0_subdomain = Unicode(config=True)
 

--- a/oauthenticator/globus.py
+++ b/oauthenticator/globus.py
@@ -120,11 +120,6 @@ class GlobusOAuthenticator(OAuthenticator):
     def _globus_local_endpoint_default(self):
         return os.getenv('GLOBUS_LOCAL_ENDPOINT', '')
 
-    logout_redirect_url = Unicode(help="""URL for logging out.""").tag(config=True)
-
-    def _logout_redirect_url_default(self):
-        return os.getenv('LOGOUT_REDIRECT_URL', '')
-
     revoke_tokens_on_logout = Bool(
         help="""Revoke tokens so they cannot be used again. Single-user servers
         MUST be restarted after logout in order to get a fresh working set of

--- a/oauthenticator/oauth2.py
+++ b/oauthenticator/oauth2.py
@@ -239,7 +239,7 @@ class OAuthLogoutHandler(LogoutHandler):
     async def handle_logout(self):
         self.clear_cookie(STATE_COOKIE_NAME)
 
-   def render_logout_page(self):
+    def render_logout_page(self):
         if self.authenticator.logout_redirect_url:
             self.redirect(self.authenticator.logout_redirect_url)
             return

--- a/oauthenticator/oauth2.py
+++ b/oauthenticator/oauth2.py
@@ -239,12 +239,12 @@ class OAuthLogoutHandler(LogoutHandler):
     async def handle_logout(self):
         self.clear_cookie(STATE_COOKIE_NAME)
 
-    def render_logout_page(self):
+    async def render_logout_page(self):
         if self.authenticator.logout_redirect_url:
             self.redirect(self.authenticator.logout_redirect_url)
             return
 
-        return super().render_logout_page()
+        return await super().render_logout_page()
 
 
 class OAuthenticator(Authenticator):

--- a/oauthenticator/oauth2.py
+++ b/oauthenticator/oauth2.py
@@ -239,6 +239,13 @@ class OAuthLogoutHandler(LogoutHandler):
     async def handle_logout(self):
         self.clear_cookie(STATE_COOKIE_NAME)
 
+    async def render_logout_page(self):
+        if self.authenticator.logout_redirect_url:
+            self.redirect(self.authenticator.logout_redirect_url)
+            return
+
+        super().render_logout_page()
+
 
 class OAuthenticator(Authenticator):
     """Base class for OAuthenticators

--- a/oauthenticator/oauth2.py
+++ b/oauthenticator/oauth2.py
@@ -239,12 +239,12 @@ class OAuthLogoutHandler(LogoutHandler):
     async def handle_logout(self):
         self.clear_cookie(STATE_COOKIE_NAME)
 
-    async def render_logout_page(self):
+   def render_logout_page(self):
         if self.authenticator.logout_redirect_url:
             self.redirect(self.authenticator.logout_redirect_url)
             return
 
-        super().render_logout_page()
+        return super().render_logout_page()
 
 
 class OAuthenticator(Authenticator):

--- a/oauthenticator/oauth2.py
+++ b/oauthenticator/oauth2.py
@@ -279,6 +279,13 @@ class OAuthenticator(Authenticator):
     def _userdata_url_default(self):
         return os.environ.get("OAUTH2_USERDATA_URL", "")
 
+
+    logout_redirect_url = Unicode(config=True, help="""URL for logging out of Auth0""")
+
+    @default("logout_redirect_url")
+    def _logout_redirect_url_default(self):
+        return os.getenv("OAUTH_LOGOUT_REDIRECT_URL", "")
+
     scope = List(
         Unicode(),
         config=True,

--- a/oauthenticator/oauth2.py
+++ b/oauthenticator/oauth2.py
@@ -279,7 +279,6 @@ class OAuthenticator(Authenticator):
     def _userdata_url_default(self):
         return os.environ.get("OAUTH2_USERDATA_URL", "")
 
-
     logout_redirect_url = Unicode(config=True, help="""URL for logging out of Auth0""")
 
     @default("logout_redirect_url")

--- a/oauthenticator/tests/test_auth0.py
+++ b/oauthenticator/tests/test_auth0.py
@@ -3,10 +3,10 @@ from unittest.mock import Mock
 from pytest import fixture
 from tornado import web
 
-from ..auth0 import Auth0LogoutHandler
 from ..auth0 import Auth0OAuthenticator
 from .mocks import mock_handler
 from .mocks import setup_oauth_mock
+from ..oauth2 import OAuthLogoutHandler
 
 auth0_subdomain = "jupyterhub-test"
 
@@ -56,7 +56,7 @@ async def test_username_key(auth0_client):
 async def test_custom_logout(monkeypatch):
     auth0_subdomain = 'auth0-domain.org'
     authenticator = Auth0OAuthenticator()
-    logout_handler = mock_handler(Auth0LogoutHandler, authenticator=authenticator)
+    logout_handler = mock_handler(OAuthLogoutHandler, authenticator=authenticator)
     monkeypatch.setattr(web.RequestHandler, 'redirect', Mock())
 
     logout_handler.clear_login_cookie = Mock()
@@ -66,7 +66,7 @@ async def test_custom_logout(monkeypatch):
 
     # Sanity check: Ensure the logout handler and url are set on the hub
     handlers = [handler for _, handler in authenticator.get_handlers(None)]
-    assert any([h == Auth0LogoutHandler for h in handlers])
+    assert any([h == OAuthLogoutHandler for h in handlers])
     assert authenticator.logout_url('http://myhost') == 'http://myhost/logout'
 
     # Check redirection to the custom logout url

--- a/oauthenticator/tests/test_auth0.py
+++ b/oauthenticator/tests/test_auth0.py
@@ -1,11 +1,12 @@
-from pytest import fixture
-from tornado import web
 from unittest.mock import Mock
 
-from ..auth0 import Auth0OAuthenticator
+from pytest import fixture
+from tornado import web
+
 from ..auth0 import Auth0LogoutHandler
-from .mocks import setup_oauth_mock
+from ..auth0 import Auth0OAuthenticator
 from .mocks import mock_handler
+from .mocks import setup_oauth_mock
 
 auth0_subdomain = "jupyterhub-test"
 

--- a/oauthenticator/tests/test_auth0.py
+++ b/oauthenticator/tests/test_auth0.py
@@ -54,7 +54,7 @@ async def test_username_key(auth0_client):
 
 
 async def test_custom_logout(monkeypatch):
-    custom_logout_url = 'https://auth0-domain.org/logout'
+    auth0_subdomain = 'auth0-domain.org'
     authenticator = Auth0OAuthenticator()
     logout_handler = mock_handler(Auth0LogoutHandler, authenticator=authenticator)
     monkeypatch.setattr(web.RequestHandler, 'redirect', Mock())
@@ -70,6 +70,7 @@ async def test_custom_logout(monkeypatch):
     assert authenticator.logout_url('http://myhost') == 'http://myhost/logout'
 
     # Check redirection to the custom logout url
-    authenticator.logout_redirect_url = custom_logout_url
+    authenticator.auth0_subdomain = auth0_subdomain
     await logout_handler.get()
+    custom_logout_url = f'https://{auth0_subdomain}.auth0.com/v2/logout'
     logout_handler.redirect.assert_called_with(custom_logout_url)

--- a/oauthenticator/tests/test_auth0.py
+++ b/oauthenticator/tests/test_auth0.py
@@ -4,9 +4,9 @@ from pytest import fixture
 from tornado import web
 
 from ..auth0 import Auth0OAuthenticator
+from ..oauth2 import OAuthLogoutHandler
 from .mocks import mock_handler
 from .mocks import setup_oauth_mock
-from ..oauth2 import OAuthLogoutHandler
 
 auth0_subdomain = "jupyterhub-test"
 


### PR DESCRIPTION
Fixes https://github.com/jupyterhub/oauthenticator/issues/436

This should allow setting `OAuthenticator.logout_redirect_url` to be a logout endpoint, such as the [Auth0 logout endpoint](https://auth0.com/docs/api/authentication#logout)  to log users out of the Auth0 session and potentially out of their identity providers as well if the `federated` query string parameter is passed.

Edit by Erik: updated to be non Auth0 specific