### PR TITLE
Allow changing auth0 username key

### DIFF
--- a/oauthenticator/tests/test_auth0.py
+++ b/oauthenticator/tests/test_auth0.py
@@ -6,9 +6,13 @@ from .mocks import setup_oauth_mock
 auth0_subdomain = "jupyterhub-test"
 
 
-def user_model(username):
+def user_model(email, nickname=None):
     """Return a user model"""
-    return {'email': username}
+    return {
+        'email': email,
+        'nickname': nickname if nickname else email,
+        'name': 'Hoban Washburn',
+    }
 
 
 @fixture
@@ -33,3 +37,12 @@ async def test_auth0(auth0_client):
     auth_state = user_info['auth_state']
     assert 'access_token' in auth_state
     assert 'auth0_user' in auth_state
+
+
+async def test_username_key(auth0_client):
+    authenticator = Auth0OAuthenticator(auth0_subdomain=auth0_subdomain)
+    authenticator.username_key = 'nickname'
+    handler = auth0_client.handler_for_user(user_model('kaylee@serenity.now', 'kayle'))
+    user_info = await authenticator.authenticate(handler)
+
+    assert user_info['name'] == 'kayle'


### PR DESCRIPTION
Fixes https://github.com/jupyterhub/oauthenticator/issues/266

This should allow choosing what key in the authenticated user's profile to use as hub username.