### PR TITLE
[Globus] Add config username_from_email

### DIFF
--- a/docs/source/getting-started.rst
+++ b/docs/source/getting-started.rst
@@ -399,6 +399,18 @@ to login, and will continue to be tied to that identity after changing this
 setting. Create a new Globus App with your preferred 'Required Identity Provider'
 to avoid this problem.
 
+Username from Email Address
+~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+By default, the JupyterHub ``username`` will be taken from the OIDC
+``preferred_username`` claim. In many cases, this is the same as the email
+address. However, some identity providers use an opaque string, e.g.,
+``046f34a240f0615e01420b3ff4350922@ucsd.edu``. You may set
+``username_from_email = True`` to get it from the user's email address. Setting
+this will automatically add ``email`` to the list of scopes. When
+``identity_provider`` is set, the email address domain must still match the
+identity provider domain.
+
 Globus Scopes and Transfer
 ~~~~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/oauthenticator/globus.py
+++ b/oauthenticator/globus.py
@@ -97,6 +97,16 @@ class GlobusOAuthenticator(OAuthenticator):
     def _identity_provider_default(self):
         return os.getenv('IDENTITY_PROVIDER', '')
 
+    username_from_email = Bool(
+        help="""Create username from email address, not preferred username. If
+        an identity provider is specified, email address must be from the same
+        domain. Email scope will be set automatically."""
+    ).tag(config=True)
+
+    @default("username_from_email")
+    def _username_from_email_default(self):
+        return False
+
     exclude_tokens = List(
         help="""Exclude tokens from being passed into user environments
         when they start notebooks, Terminals, etc."""
@@ -106,11 +116,14 @@ class GlobusOAuthenticator(OAuthenticator):
         return ['auth.globus.org']
 
     def _scope_default(self):
-        return [
+        scopes = [
             'openid',
             'profile',
             'urn:globus:auth:scope:transfer.api.globus.org:all',
         ]
+        if self.username_from_email:
+            scopes.append('email')
+        return scopes
 
     globus_local_endpoint = Unicode(
         help="""If Jupyterhub is also a Globus
@@ -210,7 +223,10 @@ class GlobusOAuthenticator(OAuthenticator):
     def get_username(self, user_data):
         # It's possible for identity provider domains to be namespaced
         # https://docs.globus.org/api/auth/specification/#identity_provider_namespaces # noqa
-        username, domain = user_data.get('preferred_username').split('@', 1)
+        username_field = 'preferred_username'
+        if self.username_from_email:
+            username_field = 'email'
+        username, domain = user_data.get(username_field).split('@', 1)
         if self.identity_provider and domain != self.identity_provider:
             raise HTTPError(
                 403,


### PR DESCRIPTION
By default, the Globus OAuthenticator takes the JupyterHub `username`  from the OIDC `preferred_username` claim. In many cases, this is the same as the emailaddress. However, some identity providers use an opaque string, e.g.,`046f34a240f0615e01420b3ff4350922@ucsd.edu`. This added the configuration `username_from_email = True` to get it from the user's email address. Setting this will automatically adds `email` to the list of scopes. When `identity_provider` is set, the email address domain must still match the identity provider domain.

Documentation and tests are included in this pull request.