### PR TITLE
[GitHub] Set JH user's email with non-public email if needed and granted scope to do so

### DIFF
--- a/oauthenticator/github.py
+++ b/oauthenticator/github.py
@@ -195,8 +195,9 @@ class GitHubOAuthenticator(OAuthenticator):
         # store the whole user model in auth_state.github_user
         auth_state['github_user'] = resp_json
         # If a public email is not available, an extra API call has to be made
-        # to a secondary endpoint using the access token.
-        # see https://github.com/jupyterhub/oauthenticator/issues/438
+        # to a /user/emails using the access token to retrieve emails. The
+        # scopes relevant for this are checked based on this documentation:
+        # https://docs.github.com/en/developers/apps/building-oauth-apps/scopes-for-oauth-apps#normalized-scopes
         if not auth_state['github_user']['email'] and (
             'user' in scopes or 'user:email' in scopes
         ):

--- a/oauthenticator/github.py
+++ b/oauthenticator/github.py
@@ -191,8 +191,19 @@ class GitHubOAuthenticator(OAuthenticator):
         auth_state['access_token'] = access_token
         # store the whole user model in auth_state.github_user
         auth_state['github_user'] = resp_json
-        # A public email will return in the initial query (assuming default scope).
-        # Private will not.
+        # To retrieve emails an extra call has to be made to a secondary endpoint
+        # using the access token. see https://github.com/jupyterhub/oauthenticator/issues/438
+        if 'user:email' in self.scope:
+            req = HTTPRequest(
+                      self.github_api + "/user/emails",
+                      method="GET",
+                      headers=_api_headers(access_token),
+                      validate_cert=self.validate_server_cert,
+                 )
+            resp_json = await self.fetch(req, "fetching user emails")
+            for val in resp_json:
+              if val["primary"]:
+                  auth_state['github_user']['email'] = val['email']
 
         return userdict
 

--- a/oauthenticator/github.py
+++ b/oauthenticator/github.py
@@ -155,6 +155,8 @@ class GitHubOAuthenticator(OAuthenticator):
         else:
             raise web.HTTPError(500, "Bad response: {}".format(resp_json))
 
+        scopes = resp_json['scope'].split(',')
+
         # Determine who the logged-in user is
         req = HTTPRequest(
             self.github_api + "/user",
@@ -195,7 +197,9 @@ class GitHubOAuthenticator(OAuthenticator):
         # If a public email is not available, an extra API call has to be made
         # to a secondary endpoint using the access token.
         # see https://github.com/jupyterhub/oauthenticator/issues/438
-        if not auth_state['github_user']['email']:
+        if not auth_state['github_user']['email'] and (
+            'user' in scopes or 'user:email' in scopes
+        ):
             req = HTTPRequest(
                 self.github_api + "/user/emails",
                 method="GET",

--- a/oauthenticator/github.py
+++ b/oauthenticator/github.py
@@ -196,7 +196,10 @@ class GitHubOAuthenticator(OAuthenticator):
         # If a public email is not available, an extra API call has to be made
         # to a /user/emails using the access token to retrieve emails. The
         # scopes relevant for this are checked based on this documentation:
-        # https://docs.github.com/en/developers/apps/building-oauth-apps/scopes-for-oauth-apps#normalized-scopes
+        # - about scopes: https://docs.github.com/en/developers/apps/building-oauth-apps/scopes-for-oauth-apps#available-scopes
+        # - about /user/emails: https://docs.github.com/en/rest/reference/users#list-email-addresses-for-the-authenticated-user
+        #
+        # Note that the read:user scope does not imply the user:emails scope!
         if not auth_state['github_user']['email'] and (
             'user' in granted_scopes or 'user:email' in granted_scopes
         ):
@@ -210,6 +213,7 @@ class GitHubOAuthenticator(OAuthenticator):
             for val in resp_json:
                 if val["primary"]:
                     auth_state['github_user']['email'] = val['email']
+                    break
 
         return userdict
 

--- a/oauthenticator/github.py
+++ b/oauthenticator/github.py
@@ -192,22 +192,24 @@ class GitHubOAuthenticator(OAuthenticator):
         auth_state['access_token'] = access_token
         # store the whole user model in auth_state.github_user
         auth_state['github_user'] = resp_json
-        # To retrieve emails an extra call has to be made to a secondary endpoint
-        # using the access token. see https://github.com/jupyterhub/oauthenticator/issues/438
-        req = HTTPRequest(
-            self.github_api + "/user/emails",
-            method="GET",
-            headers=_api_headers(access_token),
-            validate_cert=self.validate_server_cert,
-        )
-        try:
-            resp_json = await self.fetch(req, "fetching user emails")
-        except HTTPClientError:
-            pass
-        else:
-            for val in resp_json:
-                if val["primary"]:
-                    auth_state['github_user']['email'] = val['email']
+        # If a public email is not available, an extra API call has to be made
+        # to a secondary endpoint using the access token.
+        # see https://github.com/jupyterhub/oauthenticator/issues/438
+        if not auth_state['github_user']['email']:
+            req = HTTPRequest(
+                self.github_api + "/user/emails",
+                method="GET",
+                headers=_api_headers(access_token),
+                validate_cert=self.validate_server_cert,
+            )
+            try:
+                resp_json = await self.fetch(req, "fetching user emails")
+            except HTTPClientError:
+                pass
+            else:
+                for val in resp_json:
+                    if val["primary"]:
+                        auth_state['github_user']['email'] = val['email']
 
         return userdict
 

--- a/oauthenticator/github.py
+++ b/oauthenticator/github.py
@@ -154,7 +154,9 @@ class GitHubOAuthenticator(OAuthenticator):
         else:
             raise web.HTTPError(500, "Bad response: {}".format(resp_json))
 
-        granted_scopes = resp_json['scope'].split(',')
+        granted_scopes = []
+        if resp_json.get("scope"):
+            granted_scopes = resp_json["scope"].split(",")
 
         # Determine who the logged-in user is
         req = HTTPRequest(


### PR DESCRIPTION
This allows emails to be read and set in the state dictionary when scope is authorized.

closes #438

### Related references
- https://docs.github.com/en/developers/apps/building-oauth-apps/scopes-for-oauth-apps#available-scopes
- https://docs.github.com/en/rest/guides/basics-of-authentication#checking-granted-scopes
- https://docs.github.com/en/rest/reference/users#list-email-addresses-for-the-authenticated-user
- https://docs.github.com/en/developers/apps/building-oauth-apps/authorizing-oauth-apps#response
  The `scope` field in the JSON response when acquiring the access token is not always present it seems.