### PR TITLE
[AzureAD] Add an implementation for Authenticator.authenticator_managed_groups=true

### DIFF
--- a/oauthenticator/azuread.py
+++ b/oauthenticator/azuread.py
@@ -33,13 +33,13 @@ class AzureAdOAuthenticator(OAuthenticator):
     def _tenant_id_default(self):
         return os.environ.get('AAD_TENANT_ID', '')
 
-    username_claim = Unicode(config=True)
+    username_claim = Unicode(config=True, help="Name of claim containing username")
 
     @default('username_claim')
     def _username_claim_default(self):
         return 'name'
 
-    user_groups_claim = Unicode(config=True)
+    user_groups_claim = Unicode(config=True, help="Name of claim containing user group memberships")
 
     @default('user_groups_claim')
     def _user_groups_claim_default(self):

--- a/oauthenticator/azuread.py
+++ b/oauthenticator/azuread.py
@@ -10,7 +10,6 @@ from jupyterhub.auth import LocalAuthenticator
 from tornado.httpclient import HTTPRequest
 from traitlets import default
 from traitlets import Unicode
-from traitlets import Bool
 
 from .oauth2 import OAuthenticator
 
@@ -39,7 +38,9 @@ class AzureAdOAuthenticator(OAuthenticator):
     def _username_claim_default(self):
         return 'name'
 
-    user_groups_claim = Unicode(config=True, help="Name of claim containing user group memberships")
+    user_groups_claim = Unicode(
+        config=True, help="Name of claim containing user group memberships"
+    )
 
     @default('user_groups_claim')
     def _user_groups_claim_default(self):
@@ -106,7 +107,6 @@ class AzureAdOAuthenticator(OAuthenticator):
     def load_user_groups(self, auth_state):
         auth_user_state = auth_state["auth_state"]["user"]
         return auth_user_state[self.user_groups_claim]
-
 
 
 class LocalAzureAdOAuthenticator(LocalAuthenticator, AzureAdOAuthenticator):

--- a/oauthenticator/azuread.py
+++ b/oauthenticator/azuread.py
@@ -10,6 +10,7 @@ from jupyterhub.auth import LocalAuthenticator
 from tornado.httpclient import HTTPRequest
 from traitlets import default
 from traitlets import Unicode
+from traitlets import Bool
 
 from .oauth2 import OAuthenticator
 
@@ -37,6 +38,12 @@ class AzureAdOAuthenticator(OAuthenticator):
     @default('username_claim')
     def _username_claim_default(self):
         return 'name'
+
+    user_groups_claim = Unicode(config=True)
+
+    @default('user_groups_claim')
+    def _user_groups_claim_default(self):
+        return 'groups'
 
     @default("authorize_url")
     def _authorize_url_default(self):
@@ -95,6 +102,11 @@ class AzureAdOAuthenticator(OAuthenticator):
         auth_state['user'] = decoded
 
         return userdict
+
+    def load_user_groups(self, auth_state):
+        auth_user_state = auth_state["auth_state"]["user"]
+        return auth_user_state[self.user_groups_claim]
+
 
 
 class LocalAzureAdOAuthenticator(LocalAuthenticator, AzureAdOAuthenticator):


### PR DESCRIPTION
See [this](https://github.com/jupyterhub/jupyterhub/pull/3548) related PR in jupyterhub/jupyterhub-repo.

Added support for external user group management to Azure AD authenticator.

Usage example:

```python
"""sample jupyterhub config file for testing

configures jupyterhub with dummyauthenticator and simplespawner
to enable testing without administrative privileges.
"""

c = get_config()  # noqa
c.Application.log_level = 'DEBUG'

from oauthenticator.azuread import AzureAdOAuthenticator
import os

c.JupyterHub.authenticator_class = AzureAdOAuthenticator

c.AzureAdOAuthenticator.client_id = os.getenv("AAD_CLIENT_ID")
c.AzureAdOAuthenticator.client_secret = os.getenv("AAD_CLIENT_SECRET")
c.AzureAdOAuthenticator.oauth_callback_url = os.getenv("AAD_CALLBACK_URL")
c.AzureAdOAuthenticator.tenant_id = os.getenv("AAD_TENANT_ID")
c.AzureAdOAuthenticator.username_claim = "email"
c.AzureAdOAuthenticator.authorize_url = os.getenv("AAD_AUTHORIZE_URL")
c.AzureAdOAuthenticator.token_url = os.getenv("AAD_TOKEN_URL")
c.Authenticator.authenticator_managed_groups = True
c.Authenticator.refresh_pre_spawn = True

from jupyterhub.spawner import SimpleLocalProcessSpawner

c.JupyterHub.spawner_class = SimpleLocalProcessSpawner
```