### PR TITLE
Implement MultiOAuthenticator

### DIFF
--- a/oauthenticator/multioauthenticator.py
+++ b/oauthenticator/multioauthenticator.py
@@ -1,0 +1,95 @@
+"""
+Custom Authenticator to use multiple OAuth providers with JupyterHub
+
+Example of configuration:
+
+    from oauthenticator.github import GitHubOAuthenticator
+    from oauthenticator.google import GoogleOAuthenticator
+
+    c.MultiOAuthenticator.authenticators = [
+        (GitHubOAuthenticator, '/github', {
+            'client_id': 'xxxx',
+            'client_secret': 'xxxx',
+            'oauth_callback_url': 'http://example.com/hub/github/oauth_callback'
+        }),
+        (GoogleOAuthenticator, '/google', {
+            'client_id': 'xxxx',
+            'client_secret': 'xxxx',
+            'oauth_callback_url': 'http://example.com/hub/google/oauth_callback'
+        })
+    ]
+
+    c.JupyterHub.authenticator_class = 'oauthenticator.multioauthenticator.MultiOAuthenticator'
+
+The same Authenticator class can be used several to support different providers.
+
+"""
+from jupyterhub.auth import Authenticator
+from jupyterhub.utils import url_path_join
+from traitlets import List
+
+
+class MultiOAuthenticator(Authenticator):
+    """Wrapper class that allows to use more than one authentication provider
+    for JupyterHub"""
+
+    authenticators = List(help="The subauthenticators to use", config=True)
+
+    def __init__(self, *arg, **kwargs):
+        super().__init__(*arg, **kwargs)
+        self._authenticators = []
+        for (
+            authenticator_klass,
+            url_scope,
+            authenticator_configuration,
+        ) in self.authenticators:
+            configuration = self.trait_values()
+            # Remove this one as it will overwrite the value if the authenticator_klass
+            # makes it configurable and the default value is used (take a look at
+            # GoogleOAuthenticator for example).
+            configuration.pop("login_service")
+            configuration.update(authenticator_configuration)
+            self._authenticators.append(
+                {
+                    "instance": authenticator_klass(**configuration),
+                    "url_scope": url_scope,
+                }
+            )
+
+    def get_custom_html(self, base_url):
+        """Re-implementation generating one login button per configured authenticator"""
+
+        html = []
+        for authenticator in self._authenticators:
+            login_service = authenticator["instance"].login_service
+            url = url_path_join(base_url, authenticator["url_scope"], "oauth_login")
+
+            html.append(
+                f"""
+                <div class="service-login">
+                  <a role="button" class='btn btn-jupyter btn-lg' href='{url}'>
+                    Sign in with {login_service}
+                  </a>
+                </div>
+                """
+            )
+        return "\n".join(html)
+
+    def get_handlers(self, app):
+        """Re-implementation that will return the handlers for all configured
+        authenticators"""
+
+        routes = []
+        for _authenticator in self._authenticators:
+            for path, handler in _authenticator["instance"].get_handlers(app):
+
+                class WrapperHandler(handler):
+                    """'Real' handler configured for each authenticator. This allows
+                    to reuse the same authenticator class configured for different
+                    services (for example GitLab.com, gitlab.example.com)
+                    """
+
+                    authenticator = _authenticator["instance"]
+
+                routes.append((f'{_authenticator["url_scope"]}{path}', WrapperHandler))
+        return routes

--- a/oauthenticator/tests/test_multioauthenticator.py
+++ b/oauthenticator/tests/test_multioauthenticator.py
@@ -1,0 +1,92 @@
+"""Test module for the MultiOAuthenticator class"""
+from pytest import fixture
+
+from ..github import GitHubOAuthenticator
+from ..gitlab import GitLabOAuthenticator
+from ..google import GoogleOAuthenticator
+from ..multioauthenticator import MultiOAuthenticator
+
+
+@fixture
+def different_authenticators():
+    return [
+        (
+            GitLabOAuthenticator,
+            "/gitlab",
+            {
+                "client_id": "xxxx",
+                "client_secret": "xxxx",
+                "oauth_callback_url": "http://example.com/hub/gitlab/oauth_callback",
+            },
+        ),
+        (
+            GitHubOAuthenticator,
+            "/github",
+            {
+                "client_id": "xxxx",
+                "client_secret": "xxxx",
+                "oauth_callback_url": "http://example.com/hub/github/oauth_callback",
+            },
+        ),
+    ]
+
+
+@fixture
+def same_authenticators():
+    return [
+        (
+            GoogleOAuthenticator,
+            "/mygoogle",
+            {
+                "login_service": "My Google",
+                "client_id": "yyyyy",
+                "client_secret": "yyyyy",
+                "oauth_callback_url": "http://example.com/hub/mygoogle/oauth_callback",
+            },
+        ),
+        (
+            GoogleOAuthenticator,
+            "/othergoogle",
+            {
+                "login_service": "Other Google",
+                "client_id": "xxxx",
+                "client_secret": "xxxx",
+                "oauth_callback_url": "http://example.com/hub/othergoogle/oauth_callback",
+            },
+        ),
+    ]
+
+
+def test_different_authenticators(different_authenticators):
+    MultiOAuthenticator.authenticators = different_authenticators
+
+    authenticator = MultiOAuthenticator()
+    assert len(authenticator._authenticators) == 2
+
+    handlers = authenticator.get_handlers("")
+    assert len(handlers) == 6
+    for path, handler in handlers:
+        if "gitlab" in path:
+            assert isinstance(handler.authenticator, GitLabOAuthenticator)
+        elif "github" in path:
+            assert isinstance(handler.authenticator, GitHubOAuthenticator)
+        else:
+            raise ValueError(f"Unknown path: {path}")
+
+
+def test_same_authenticators(same_authenticators):
+    MultiOAuthenticator.authenticators = same_authenticators
+
+    authenticator = MultiOAuthenticator()
+    assert len(authenticator._authenticators) == 2
+
+    handlers = authenticator.get_handlers("")
+    assert len(handlers) == 6
+    for path, handler in handlers:
+        assert isinstance(handler.authenticator, GoogleOAuthenticator)
+        if "mygoogle" in path:
+            assert handler.authenticator.login_service == "My Google"
+        elif "othergoogle" in path:
+            assert handler.authenticator.login_service == "Other Google"
+        else:
+            raise ValueError(f"Unknown path: {path}")


### PR DESCRIPTION
This authenticator allows to use several different services to authenticate to one instance of JupyterHub.

The code is based on the suggested implementation that can be found on #136 and more specifically https://github.com/jupyterhub/oauthenticator/issues/136#issuecomment-749931724.

Due to the merge of https://github.com/jupyterhub/jupyterhub/pull/3315, the support for showing multiple links is already supported.

This is the first step as discussed in this [JupyterHub discourse thread](https://discourse.jupyter.org/t/make-jupyterhub-authentication-pluggable/10122/2?u=sgaist).