### PR TITLE
Support pyjwt >= 2 in tests

### DIFF
--- a/oauthenticator/tests/test_azuread.py
+++ b/oauthenticator/tests/test_azuread.py
@@ -9,6 +9,7 @@ import jwt
 import pytest
 
 from ..azuread import AzureAdOAuthenticator
+from ..azuread import PYJWT_2
 from .mocks import setup_oauth_mock
 
 
@@ -40,7 +41,9 @@ def user_model(tenant_id, client_id, name):
             "aio": "Df2UVXL1ix!lMCWMSOJBcFatzcGfvFGhjKv8q5g0x732dR5MB5BisvGQO7YWByjd8iQDLq!eGbIDakyp5mnOrcdqHeYSnltepQmRp6AIZ8jY",
         },
         os.urandom(5),
-    ).decode("ascii")
+    )
+    if not PYJWT_2:
+        id_token = id_token.decode("ascii")
 
     return {
         "access_token": "abc123",

--- a/oauthenticator/tests/test_mediawiki.py
+++ b/oauthenticator/tests/test_mediawiki.py
@@ -8,6 +8,7 @@ import requests_mock
 from pytest import fixture
 from tornado import web
 
+from ..azuread import PYJWT_2
 from ..mediawiki import AUTH_REQUEST_COOKIE_NAME
 from ..mediawiki import MWOAuthenticator
 from .mocks import mock_handler
@@ -20,7 +21,7 @@ def mediawiki():
     def post_token(request, context):
         authorization_header = request.headers['Authorization'].decode('utf8')
         request_nonce = re.search(r'oauth_nonce="(.*?)"', authorization_header).group(1)
-        return jwt.encode(
+        content = jwt.encode(
             {
                 'username': 'wash',
                 'aud': 'client_id',
@@ -30,6 +31,10 @@ def mediawiki():
             },
             'client_secret',
         )
+        if PYJWT_2:
+            content = content.encode()
+
+        return content
 
     with requests_mock.Mocker() as mock:
         mock.post(


### PR DESCRIPTION
Allow the tests to be aware of the `pyjwt` version installed, converting the result of `jwt.encode()` from bytes to string and vice-versa accordingly as the return type changes between pyjwt versions.

### Details

It seems that `pyjwt` changed the return type between major versions, and running the tests with `pyjwt>=2.0` seems to result in #432 (I have been able to replicate the same errors). Even if `mwoauth` still pins `1.7.x` (although [might be able to use 2.x](https://github.com/mediawiki-utilities/python-mwoauth/pull/43) ) and as a result 2.x is never really installed in CI or a regular install, this PR tries to follow-up on the (guessed) rationale of #402 and #420 and allow running the test suite to support pyjwt 2.x.
