### PR TITLE
[Generic] Implement refresh_user to periodically refresh OAuth tokens

### DIFF
--- a/oauthenticator/generic.py
+++ b/oauthenticator/generic.py
@@ -146,7 +146,7 @@ class GenericOAuthenticator(OAuthenticator):
 
         try:
             expires_in = int(token_response.get('expires_in'))
-            expires_at = time.time() + expires_in # seconds
+            expires_at = time.time() + expires_in  # seconds
         except (KeyError, TypeError):
             expires_at = None
 
@@ -240,7 +240,7 @@ class GenericOAuthenticator(OAuthenticator):
             return True
 
         # If over 2x auth_refresh_age intervals from expiration, return success
-        if (time.time() + 2*self.auth_refresh_age) < expires_at:
+        if (time.time() + 2 * self.auth_refresh_age) < expires_at:
             return True
 
         self.log.info('Refreshing tokens for user %s', user.name)


### PR DESCRIPTION
An attempt at OAuth token refresh, following the pattern in PR https://github.com/jupyterhub/oauthenticator/pull/287, without relying on tokens to be JWTs. This should address at least some of issue https://github.com/jupyterhub/oauthenticator/issues/398.

Requirements for token refresh:

- OAuth server response includes `expires_in` and `refresh_token`
- State is persisted on hub with `c.Authenticator.enable_auth_state = True` (to store the `refresh_token`)