### PR TITLE
[Bitbucket] Fix for changes to bitbucket API - /teams removed and /workspaces to be used

### DIFF
--- a/oauthenticator/bitbucket.py
+++ b/oauthenticator/bitbucket.py
@@ -111,14 +111,14 @@ class BitbucketOAuthenticator(OAuthenticator):
         headers = _api_headers(access_token)
         # We verify the team membership by calling teams endpoint.
         next_page = url_concat(
-            "https://api.bitbucket.org/2.0/teams", {'role': 'member'}
+            "https://api.bitbucket.org/2.0/workspaces", {'role': 'member'}
         )
         while next_page:
             req = HTTPRequest(next_page, method="GET", headers=headers)
             resp_json = await self.fetch(req)
             next_page = resp_json.get('next', None)
 
-            user_teams = set([entry["username"] for entry in resp_json["values"]])
+            user_teams = set([entry["name"] for entry in resp_json["values"]])
             # check if any of the organizations seen thus far are in the allowed list
             if len(self.allowed_teams & user_teams) > 0:
                 return True

--- a/oauthenticator/tests/test_bitbucket.py
+++ b/oauthenticator/tests/test_bitbucket.py
@@ -53,10 +53,10 @@ async def test_allowed_teams(bitbucket_client):
         values = []
         for team, members in teams.items():
             if username in members:
-                values.append({'username': team})
+                values.append({'name': team})
         return {'values': values}
 
-    client.hosts['api.bitbucket.org'].append(('/2.0/teams', list_teams))
+    client.hosts['api.bitbucket.org'].append(('/2.0/workspaces', list_teams))
 
     handler = client.handler_for_user(user_model('caboose'))
     user_info = await authenticator.authenticate(handler)


### PR DESCRIPTION
Bitbucket Api Teams endpoint has been removed, use workspaces instead:
https://developer.atlassian.com/cloud/bitbucket/bitbucket-api-teams-deprecation/

https://github.com/jupyterhub/oauthenticator/issues/476

Changes to be committed:
	modified:   oauthenticator/bitbucket.py
	modified:   oauthenticator/tests/test_bitbucket.py