### PR TITLE
Allow and document custom 403 messages and pages

### DIFF
--- a/docs/source/getting-started.rst
+++ b/docs/source/getting-started.rst
@@ -83,6 +83,36 @@ You can also set these values in your **configuration file**,
    c.MyOAuthenticator.client_id = 'your-client-id'
    c.MyOAuthenticator.client_secret = 'your-client-secret'
 
+Use a custom 403 error
+~~~~~~~~~~~~~~~~~~~~~~
+
+1. Custom message
+   When a user successfully logins at an OAuth provider but is forbidden access based on the config,
+   e.g. the ``allowed_users`` list or the ``blocked_users`` list, it is whoen the following message
+   by default:
+
+   *"Looks like you have not been added to the list of allowed users for this hub. Please contact the hub administrator."*
+
+   You can show a customized 403 error message by changing the OAuthenticator config:
+
+   .. code:: python
+
+      # Replace MyOAuthenticator with your selected OAuthenticator class (e.g. c.GithubOAuthenticator).
+      c.MyOAuthenticator.custom_403_message = "Your message for the user"
+
+2. Custom html page
+   You can also show a customized 403 HTML page message by creating a
+   `custom HTML template <https://jupyterhub.readthedocs.io/en/stable/reference/templates.html>`_ and
+   point JupyterHub to it.
+
+   An example custom 403 html page can be found in the
+   `examples directory <https://github.com/jupyterhub/oauthenticator/tree/main/examples/templates>`_
+
+   .. code:: python
+
+      # Replace MyOAuthenticator with your selected OAuthenticator class (e.g. c.GithubOAuthenticator).
+      c.JupyterHub.template_paths = ["examples/templates"]
+
 AWS Cognito Setup
 -----------------
 First visit

--- a/examples/templates/403.html
+++ b/examples/templates/403.html
@@ -1,0 +1,33 @@
+{% extends "templates/error.html" %}
+
+{% block error_detail %}
+{% if status_code == 403 %}
+<style>
+	.info {
+  		color: #fc8703;
+  		background-color: #f2f2f3;
+		
+		max-width: 640px;
+		padding: 30px;
+		margin: 0 auto;
+		margin-bottom: 30px;
+		overflow: hidden;
+		font-size: 17px;
+	}
+</style>
+<div class="error">
+	<div class="info">
+		<i class="fa fa-info-circle"></i>
+		{{ message | safe }}
+	</div>
+	<div class="text-center">
+		<a role="button" class='btn btn-jupyter' href='{{base_url}}/logout'>
+		Tap to try a different account
+		</a>
+	</div>
+</div>
+{% else %}
+{{ super() }}
+{% endif %}
+
+{% endblock error_detail %}

--- a/examples/templates/403.html
+++ b/examples/templates/403.html
@@ -1,33 +1,27 @@
-{% extends "templates/error.html" %}
-
-{% block error_detail %}
-{% if status_code == 403 %}
+{% extends "templates/error.html" %} {% block error_detail %} {% if status_code
+== 403 %}
 <style>
-	.info {
-  		color: #fc8703;
-  		background-color: #f2f2f3;
-		
-		max-width: 640px;
-		padding: 30px;
-		margin: 0 auto;
-		margin-bottom: 30px;
-		overflow: hidden;
-		font-size: 17px;
-	}
+  .info {
+    color: #fc8703;
+    background-color: #f2f2f3;
+
+    max-width: 640px;
+    padding: 30px;
+    margin: 0 auto;
+    margin-bottom: 30px;
+    overflow: hidden;
+    font-size: 17px;
+  }
 </style>
 <div class="error">
-	<div class="info">
-		<i class="fa fa-info-circle"></i>
-		{{ message | safe }}
-	</div>
-	<div class="text-center">
-		<a role="button" class='btn btn-jupyter' href='{{logout_url}}'>
-		Tap to try a different account
-		</a>
-	</div>
+  <div class="info">
+    <i class="fa fa-info-circle"></i>
+    {{ message | safe }}
+  </div>
+  <div class="text-center">
+    <a role="button" class="btn btn-jupyter" href="{{logout_url}}">
+      Tap to try a different account
+    </a>
+  </div>
 </div>
-{% else %}
-{{ super() }}
-{% endif %}
-
-{% endblock error_detail %}
+{% else %} {{ super() }} {% endif %} {% endblock error_detail %}

--- a/examples/templates/403.html
+++ b/examples/templates/403.html
@@ -21,7 +21,7 @@
 		{{ message | safe }}
 	</div>
 	<div class="text-center">
-		<a role="button" class='btn btn-jupyter' href='{{base_url}}/logout'>
+		<a role="button" class='btn btn-jupyter' href='{{logout_url}}'>
 		Tap to try a different account
 		</a>
 	</div>

--- a/oauthenticator/oauth2.py
+++ b/oauthenticator/oauth2.py
@@ -230,8 +230,8 @@ class OAuthCallbackHandler(BaseHandler):
         self.check_arguments()
         user = await self.login_user()
         if user is None:
-            # todo: custom error page?
-            raise web.HTTPError(403)
+            raise web.HTTPError(403, self.authenticator.custom_403_message)
+
         self.redirect(self.get_next_url(user))
 
 
@@ -291,6 +291,14 @@ class OAuthenticator(Authenticator):
     @default("logout_redirect_url")
     def _logout_redirect_url_default(self):
         return os.getenv("OAUTH_LOGOUT_REDIRECT_URL", "")
+
+    custom_403_message = Unicode(
+        config=True, help="""The message to be shown when user was not allowed"""
+    )
+
+    @default("custom_403_message")
+    def _custom_403_message(self):
+        return "Looks like you have not been added to the list of allowed users for this hub. Please contact the hub administrator."
 
     scope = List(
         Unicode(),

--- a/oauthenticator/oauth2.py
+++ b/oauthenticator/oauth2.py
@@ -293,12 +293,10 @@ class OAuthenticator(Authenticator):
         return os.getenv("OAUTH_LOGOUT_REDIRECT_URL", "")
 
     custom_403_message = Unicode(
-        config=True, help="""The message to be shown when user was not allowed"""
+        "Sorry, you are not currently authorized to use this hub. Please contact the hub administrator.",
+        config=True,
+        help="""The message to be shown when user was not allowed"""
     )
-
-    @default("custom_403_message")
-    def _custom_403_message(self):
-        return "Looks like you have not been added to the list of allowed users for this hub. Please contact the hub administrator."
 
     scope = List(
         Unicode(),

--- a/oauthenticator/oauth2.py
+++ b/oauthenticator/oauth2.py
@@ -295,7 +295,7 @@ class OAuthenticator(Authenticator):
     custom_403_message = Unicode(
         "Sorry, you are not currently authorized to use this hub. Please contact the hub administrator.",
         config=True,
-        help="""The message to be shown when user was not allowed"""
+        help="""The message to be shown when user was not allowed""",
     )
 
     scope = List(


### PR DESCRIPTION
This PR:

- adds a config option that allows modifying the message that is shown to the user when a 403 error is raised
![403-default-appearance](https://user-images.githubusercontent.com/7579677/152642858-e19613c9-85a2-44bc-88a5-935ae5cf5350.png)
- documents this custom message option
- shows an example `403.html` that can extend the default hub templates. This example template uses the nw custom 403 message and also adds a button that redirects users to the hub logout endpoint. It looks like this rendered:
![403-message](https://user-images.githubusercontent.com/7579677/152642771-b86a7423-78a2-4109-9560-34d3d7d47794.png)
- exemplifies extending hub templates and links to the appropriate hub docs

Fixes https://github.com/jupyterhub/oauthenticator/issues/414
Ref: https://github.com/2i2c-org/pilot-homepage/pull/8