### PR TITLE
[AzureAD] Added configuration: admin_role_ids, allowed_user_role_ids, role_claim

### DIFF
--- a/oauthenticator/azuread.py
+++ b/oauthenticator/azuread.py
@@ -9,8 +9,8 @@ import jwt
 from jupyterhub.auth import LocalAuthenticator
 from tornado.httpclient import HTTPRequest
 from traitlets import default
-from traitlets import Unicode
 from traitlets import List
+from traitlets import Unicode
 
 from .oauth2 import OAuthenticator
 
@@ -32,15 +32,15 @@ class AzureAdOAuthenticator(OAuthenticator):
     admin_role_ids = List(
         Unicode(),
         default_value=[],
-        config=True, 
-        help="The GUIDs of the Azure Active Directory Groups or Application Roles containing admin users"
+        config=True,
+        help="The GUIDs of the Azure Active Directory Groups or Application Roles containing admin users",
     )
 
     allowed_user_role_ids = List(
         Unicode(),
         default_value=[],
-        config=True, 
-        help="The GUIDs of the Azure Active Direcetory Groups or Application Roles containing allowed users"
+        config=True,
+        help="The GUIDs of the Azure Active Direcetory Groups or Application Roles containing allowed users",
     )
 
     @default('tenant_id')
@@ -81,7 +81,6 @@ class AzureAdOAuthenticator(OAuthenticator):
                 if role_id in token[self.role_claim]:
                     return True
         return False
-        
 
     async def authenticate(self, handler, data=None):
         code = handler.get_argument("code")
@@ -135,10 +134,14 @@ class AzureAdOAuthenticator(OAuthenticator):
             self.log.debug("Access to Azure AD User %s is permitted.", userdict["name"])
             if self._claim_has_role(decoded, self.admin_role_ids):
                 userdict["admin"] = True
-                self.log.debug("Azure AD User %s has been granted admin privileges", userdict["name"])
-            return userdict          
-        
+                self.log.debug(
+                    "Azure AD User %s has been granted admin privileges",
+                    userdict["name"],
+                )
+            return userdict
+
         return None
+
 
 class LocalAzureAdOAuthenticator(LocalAuthenticator, AzureAdOAuthenticator):
     """A version that mixes in local system user creation"""


### PR DESCRIPTION
Enhanced azuread provider to include functionality for "admin" and "allowed user" roles.

Setup:
- Add and grant use privileges to the following API Permissions to the Azure AD App Registration:
  - Directory.AccessAsUser.All
  - Directory.Read.All
  - Group.Read.All
  - User.Read
  - User.Read.All
  - User.ReadBasic.All
- Create Azure AD Security Groups for Allowed Users and Admin Users
  - Assign Security Groups to App Roles in the app registration (not required)
  **-OR-**
  - Configure the optional group claims as described in the next section
- Add the following Token Configurations to the Azure AD App Registration:
  - Optional Claim: preferred_username
  - Optional Group Claim: groups
    - Set `c.AzureADOAuthenticator.role_claim = 'groups'` 
    **-OR-**
    - Leave `c.AzureADOAuthenticator.role_claim` unchanged and check 'Emit groups as role claims' for ID, Access, and SAML when adding the group claim configuration.
- Set role parameter lists for AzureAdOAuthenticator:
```
c.AzureAdOAuthenticator.admin_role_ids = [<List of AAD Object IDs for Admin Groups or App Roles>]
c.AzureAdOAuthenticator.allowed_user_role_ids = [<List of AAD Object IDs for Allowed Users Groups or App Roles>]
```
Group ID is the default setting in when configuring group claims in the app registration token configuration (most secure).  You can use any other available option instead of Group ID (sAMAccountName, NetBIOSDomain\sAMAccountName, DNSDomain\sAMAccountName or On Premises Group Security Identifier) and substitute the Object IDs in `admin_role_ids` and `allowed_user_role_ids` with expected values for your specific configuration.

Tip:  If you have an adequate plan for Azure Active Directory, you can further limit the groups that will be returned by the group claims by adding the groups to the Enterprise Application registration through the 'Manage > Users and Groups' configuration.  You will also need to check the 'Groups assigned to the application' checkbox when adding the optional group claim.  This is only required if the number of groups pulled for a given user is greater than 200.  This is not available for the free plan Azure AD offering, as groups cannot be assigned to enterprise applications at this plan level.