### PR TITLE
[Generic] Support custom ca_certs bundle in GenericOAuthenticator

### DIFF
--- a/oauthenticator/generic.py
+++ b/oauthenticator/generic.py
@@ -84,10 +84,18 @@ class GenericOAuthenticator(OAuthenticator):
         help="Disable basic authentication for access token request",
     )
 
+    ca_certs = Unicode(
+        os.environ.get('OAUTH2_CA_CERTS', os.environ.get('SSL_CERT_FILE')),
+        allow_none=True,
+        config=True,
+        help="Custom trusted Certificate Authorities bundle in PEM format (ca_certs) or None to use defaults. Default: None",
+    )
+
     @default("http_client")
     def _default_http_client(self):
         return AsyncHTTPClient(
-            force_instance=True, defaults=dict(validate_cert=self.tls_verify)
+            force_instance=True,
+            defaults=dict(ca_certs=self.ca_certs, validate_cert=self.tls_verify),
         )
 
     def _get_headers(self):

--- a/oauthenticator/generic.py
+++ b/oauthenticator/generic.py
@@ -85,10 +85,14 @@ class GenericOAuthenticator(OAuthenticator):
     )
 
     ca_certs = Unicode(
-        os.environ.get('OAUTH2_CA_CERTS', os.environ.get('SSL_CERT_FILE')),
+        os.environ.get('OAUTH2_CA_CERTS', os.environ.get('SSL_CERT_FILE', None)),
         allow_none=True,
         config=True,
-        help="Custom trusted Certificate Authorities bundle in PEM format (ca_certs) or None to use defaults. Default: None",
+        help="""
+        Custom trusted Certificate Authorities bundle in PEM format (ca_certs). Default: None (to use system trusted CAs).
+
+        Can be overriden with OAUTH2_CA_CERTS (higher precedence) or SSL_CERT_FILE environment variable.
+        """,
     )
 
     @default("http_client")

--- a/oauthenticator/tests/test_generic.py
+++ b/oauthenticator/tests/test_generic.py
@@ -167,3 +167,14 @@ async def test_generic_callable_groups_claim_key_with_allowed_groups_and_admin_g
     user_info = await authenticator.authenticate(handler)
     assert user_info['name'] == 'zoe'
     assert user_info['admin'] is True
+
+
+def test_generic_ca_certs():
+    authenticator = GenericOAuthenticator()
+    assert authenticator.http_client.defaults.get('ca_certs') == None
+
+    ca_certs_bundle = '/test/ca.bundle'
+    authenticator = GenericOAuthenticator(
+        ca_certs=ca_certs_bundle,
+    )
+    assert authenticator.http_client.defaults.get('ca_certs') == ca_certs_bundle


### PR DESCRIPTION
Add support to use a custom certificate authority (CA) bundle for talking to GenericOAuthenticator (OAuth2) and overridable via `OAUTH2_CA_CERTS` environment variable without having to disable certificate validation with `OAUTH2_TLS_VERIFY=0` env.

Otherwise get the following error:
  - tornado.curl_httpclient.CurlError: HTTP 599: SSL certificate problem: unable to get local issuer certificate