### PR TITLE
[GitLab] Implement refresh_user() to keep `auth_state` updated

### DIFF
--- a/oauthenticator/gitlab.py
+++ b/oauthenticator/gitlab.py
@@ -128,7 +128,9 @@ class GitLabOAuthenticator(OAuthenticator):
             grant_type="authorization_code",
             redirect_uri=self.get_callback_url(handler),
         )
+        return await self._oauth_call(handler, params, data)
 
+    async def _oauth_call(self, handler, params, data=None):
         validate_server_cert = self.validate_server_cert
 
         url = url_concat("%s/oauth/token" % self.gitlab_url, params)

--- a/oauthenticator/gitlab.py
+++ b/oauthenticator/gitlab.py
@@ -2,6 +2,7 @@
 Custom Authenticator to use GitLab OAuth with JupyterHub
 """
 import os
+import time
 import warnings
 from urllib.parse import quote
 
@@ -131,9 +132,11 @@ class GitLabOAuthenticator(OAuthenticator):
         return await self._oauth_call(handler, params, data)
 
     async def refresh_user(self, user, handler=None):
+
         # Renew the Access Token with a valid Refresh Token
         #
         # See: https://github.com/gitlabhq/gitlabhq/blob/HEAD/doc/api/oauth2.md
+
         auth_state = await user.get_auth_state()
         if not auth_state:
             self.log.info(
@@ -141,6 +144,7 @@ class GitLabOAuthenticator(OAuthenticator):
                 user,
             )
             return False
+
         # In seconds, ex : 1607635748
         created_at = auth_state.get('created_at', 0)
         # In seconds, ex : 7200
@@ -153,6 +157,7 @@ class GitLabOAuthenticator(OAuthenticator):
                 user,
             )
             return True
+
         # GitLab specifies a POST request yet requires URL parameters
         params = dict(
             client_id=self.client_id,

--- a/oauthenticator/gitlab.py
+++ b/oauthenticator/gitlab.py
@@ -135,7 +135,13 @@ class GitLabOAuthenticator(OAuthenticator):
 
         # Renew the Access Token with a valid Refresh Token
         #
-        # See: https://github.com/gitlabhq/gitlabhq/blob/HEAD/doc/api/oauth2.md
+        # Without that custom configuration, the Gitlab access token gets
+        # outdated while the user can still connect to JupyterHub, that leads to
+        # forbidden Git interactions with Gitlab within Notebook.
+        #
+        # See:
+        # - https://github.com/gitlabhq/gitlabhq/blob/HEAD/doc/api/oauth2.md
+        # - https://github.com/jupyterhub/oauthenticator/pull/490
 
         auth_state = await user.get_auth_state()
         if not auth_state:


### PR DESCRIPTION
## Background to help review this PR added by Erik

[Authenticator.refresh_user](https://jupyterhub.readthedocs.io/en/stable/api/auth.html#jupyterhub.auth.Authenticator.refresh_user) is part of the Authenticator base class. By overriding it, the Authenticator can make sure `auth_state` is updated.

- `[Authenticator.refresh_pre_spawn](https://jupyterhub.readthedocs.io/en/stable/api/auth.html#jupyterhub.auth.Authenticator.refresh_pre_spawn) set to True, the authentication state can be ensured to be freshly updated.
- [Authenticator.auth_refresh_age](https://jupyterhub.readthedocs.io/en/stable/api/auth.html#jupyterhub.auth.Authenticator.auth_refresh_age) is set to 300 seconds by default, and JupyterHub will ensure that the state isn't older than that when the user makes requests to JupyterHub itself (not `/user/...` but `/hub/...`).

### Misc notes

- It seems that `refresh_user`, by returning `None` can force a user to re-login. This is perhaps not relevant in this PR.
- It seems that by implementing `refresh_user`, anything done in the authentication flow could be done multiple times again. Because the default value of `Authenticator.auth_refresh_age` is 300 for the base authenticator class, it means that by implementing `refresh_user()`, users of the GitLab authenticator may experience a performance hit if they don't end up needing this unless that it set to `0` to disable refreshing by default.

## Original PR description

- Shared logic exists between `authenticate()` and `refresh_user()`, it has been split into a separate method.
- Not sure about whole OAuth2 content being put into `auth_state`
- Didn't read contributing guide yet, I'll have a look tonight sorry