### PR TITLE
Fix AUTH0_SUBDOMAIN default setting

### DIFF
--- a/oauthenticator/auth0.py
+++ b/oauthenticator/auth0.py
@@ -52,6 +52,7 @@ class Auth0OAuthenticator(OAuthenticator):
                 "Please specify $AUTH0_SUBDOMAIN env or %s.auth0_subdomain config"
                 % self.__class__.__name__
             )
+        return subdomain
 
     username_key = Unicode(
         os.environ.get("OAUTH2_USERNAME_KEY", "email"),


### PR DESCRIPTION
The decorated function `_auth0_subdomain_default` always sets the subdomain value to an empty value due to a missing return. This PR fixes that issue.