### PR TITLE
[CILogon] Use `get_callback_url` to determine the OAuth callback URL

### DIFF
--- a/oauthenticator/cilogon.py
+++ b/oauthenticator/cilogon.py
@@ -143,7 +143,7 @@ class CILogonOAuthenticator(OAuthenticator):
         params = dict(
             client_id=self.client_id,
             client_secret=self.client_secret,
-            redirect_uri=self.oauth_callback_url,
+            redirect_uri=self.get_callback_url(handler),
             code=code,
             grant_type='authorization_code',
         )


### PR DESCRIPTION
When `oauth_callback_url` is not configured, this function will fallback on guessing based on the request URL, which is desirable when the JupyterHub instance is serving multiple domains.