### PR TITLE
[GitHub] fix implementation of populate_teams_in_auth_state

### DIFF
--- a/oauthenticator/github.py
+++ b/oauthenticator/github.py
@@ -270,7 +270,6 @@ class GitHubOAuthenticator(OAuthenticator):
             )
             resp = await self.fetch(req, "fetching user teams", parse_json=False)
 
-            resp.raise_for_status()
             resp_json = json.loads(resp.body.decode())
             content += resp_json
 


### PR DESCRIPTION
When using tornado's HTTPClient, there will be an error thrown by default as documented in [tornado.httpclient.HTTPClient](https://www.tornadoweb.org/en/stable/httpclient.html#tornado.httpclient.HTTPClient).

---

Fixes broken implementation of `GitHubOAuthenticator.populate_teams_in_auth_state` in #498 as caused by my code suggestion adding `resp.raise_for_status()`.