### PR TITLE
maint: remove deprecated distutils reference

### DIFF
--- a/oauthenticator/azuread.py
+++ b/oauthenticator/azuread.py
@@ -3,7 +3,6 @@ Custom Authenticator to use Azure AD with JupyterHub
 """
 import os
 import urllib
-from distutils.version import LooseVersion as V
 
 import jwt
 from jupyterhub.auth import LocalAuthenticator
@@ -14,7 +13,7 @@ from .oauth2 import OAuthenticator
 
 # pyjwt 2.0 has changed its signature,
 # but mwoauth pins to pyjwt 1.x
-PYJWT_2 = V(jwt.__version__) >= V("2.0")
+PYJWT_2 = int(jwt.__version__.split(".")[0]) >= 2
 
 
 class AzureAdOAuthenticator(OAuthenticator):


### PR DESCRIPTION
This is similar to what was done in https://github.com/jupyterhub/jupyterhub/pull/3562, but instead of declaring a dependency on `packaging` as is done in JupyterHub for this one-liner, I went for some basic string manipulation. I think this should be fine (robust) as we are not considering some patch or pre-release version etc, just checking if the major version is larger than 2.