### PR TITLE
Don't make action a required field of CILogonOAuthenticator.allowed_idps

### DIFF
--- a/oauthenticator/schemas/cilogon-schema.yaml
+++ b/oauthenticator/schemas/cilogon-schema.yaml
@@ -22,7 +22,6 @@ properties:
         type: string
     required:
       - username_claim
-      - action
     allOf:
       - if:
           properties:


### PR DESCRIPTION
Fixes https://github.com/jupyterhub/oauthenticator/issues/514