### PR TITLE
[CILogon] Don't make action a required field of CILogonOAuthenticator.allowed_idps follow-up

### DIFF
--- a/docs/source/migrations.md
+++ b/docs/source/migrations.md
@@ -2,17 +2,17 @@
 
 The following section describes how to migrate your OAuthenticator to a newer version given some upgrade scenarios.
 
-## Migrating CILogonOAuthenticator to version 15.0.0
+## Migrating CILogonOAuthenticator to version 15.0.1
 
-OAuthenticator release of 15.0.0 version introduced some breaking changes for the CILogonOAuthenticator. This is a description of what breaking changes have been made and a step by step guide on how to update your JupyterHub CILogonOAuthenticator to this version.
+OAuthenticator release of 15.0.1 version introduced some breaking changes for the CILogonOAuthenticator. This is a description of what breaking changes have been made and a step by step guide on how to update your JupyterHub CILogonOAuthenticator to this version.
 
-The following configurations have been deprecated in oauthenticator 15.0.0
+The following configurations have been deprecated in oauthenticator 15.0.1
 
 1. `idp` -> **replaced**
 
-   The `idp` config refers to the SAML Entity ID of the user's selected identity provider and prior to 15.0.0 was used to set the [CILogon `selected_idp` optional authorization parameter](https://www.cilogon.org/oidc#h.p_IWGvXH0okDI_) in order to show only this identity provider in the CILogon IdP list.
+   The `idp` config refers to the SAML Entity ID of the user's selected identity provider and prior to 15.0.1 was used to set the [CILogon `selected_idp` optional authorization parameter](https://www.cilogon.org/oidc#h.p_IWGvXH0okDI_) in order to show only this identity provider in the CILogon IdP list.
 
-   Starting with oauthenticator 15.0.0, this config has been renamed to `shown_idps` and must now be a list of such SAML Entity IDs. Only the identity providers in this list will be shown in the CILogon IDP list, with the first one being considered the default.
+   Starting with oauthenticator 15.0.1, this config has been renamed to `shown_idps` and must now be a list of such SAML Entity IDs. Only the identity providers in this list will be shown in the CILogon IDP list, with the first one being considered the default.
 
    **Old config Example**
 
@@ -28,7 +28,7 @@ The following configurations have been deprecated in oauthenticator 15.0.0
 
 2. `strip_idp_domain` -> **removed**
 
-   The `strip_idp_domain` boolean config was previously used to enable stripping the domains listed in the `allowed_idps` from the hub usernames. In oauthenticator 15.0.0 this config option was removed and such behaviour can only be achieved using the `allowed_idps` dictionary config as documented in a section below.
+   The `strip_idp_domain` boolean config was previously used to enable stripping the domains listed in the `allowed_idps` from the hub usernames. In oauthenticator 15.0.1 this config option was removed and such behaviour can only be achieved using the `allowed_idps` dictionary config as documented in a section below.
 
    **Old config Example**
 
@@ -58,9 +58,9 @@ The following configurations have been deprecated in oauthenticator 15.0.0
 
 3. `allowed_idps` -> **changed type**
 
-   The `allowed_idps` config was used prior to oauthenticator version 15.0.0 to only allow access into the hub to usernames containing only these domains, after the @ sign. If `strip_idp_domain` was enabled, these domains would have been stripped from the hub username.
+   The `allowed_idps` config was used prior to oauthenticator version 15.0.1 to only allow access into the hub to usernames containing only these domains, after the @ sign. If `strip_idp_domain` was enabled, these domains would have been stripped from the hub username.
 
-   Starting with oauthenticator 15.0.0 this config option must now be a dictionary structured like below. More information about each configuration option that can go into the `username_derivation` can be found in the `allowed_idps` docstring.
+   Starting with oauthenticator 15.0.1 this config option must now be a dictionary structured like below. More information about each configuration option that can go into the `username_derivation` can be found in the `allowed_idps` docstring.
 
    **Stripping the domain from one IDP username, adding prefixes to another and leaving other unchanged**
 
@@ -77,7 +77,7 @@ The following configurations have been deprecated in oauthenticator 15.0.0
            'username_derivation': {
                'username_claim': 'nickname',
                'action': 'prefix',
-              'prefix': 'idp',
+               'prefix': 'idp',
            }
        },
        'https://yet-another-idp.com/login/oauth/authorize': {

--- a/docs/source/migrations.md
+++ b/docs/source/migrations.md
@@ -89,9 +89,10 @@ The following configurations have been deprecated in oauthenticator 15.0.0
    ```
 
    This config translates into:
-    - if you login using a `some-idp` provider, the hub username will be the email registered for that IdP, from which the domain `uni.edu` will be stripped (assuming this is domain in the email provided by `some-idp`).
-    - if you login using `another-idp` the hub username will be your `another-idp` provided `nickname` claim, username prefixed with `idp:`. This way, users from different identity providers can log in without username clashes.
-    - if you login using `yet-another-idp`, then the username will be left unchanged, i.e. the value corresponding to the `username_claim`.
+
+   - if you login using a `some-idp` provider, the hub username will be the email registered for that IdP, from which the domain `uni.edu` will be stripped (assuming this is domain in the email provided by `some-idp`).
+   - if you login using `another-idp` the hub username will be your `another-idp` provided `nickname` claim, username prefixed with `idp:`. This way, users from different identity providers can log in without username clashes.
+   - if you login using `yet-another-idp`, then the username will be left unchanged, i.e. the value corresponding to the `username_claim`.
 
    ```{note}
    If `allowed_idps` is specified, then each IdP in the dict must define the `username_derivation` dict, including `username_derivation.username_claim`. `CILogonOAuthenticator.username_claim` will only be used if `allowed_idps` is not specified!

--- a/docs/source/migrations.md
+++ b/docs/source/migrations.md
@@ -62,7 +62,7 @@ The following configurations have been deprecated in oauthenticator 15.0.0
 
    Starting with oauthenticator 15.0.0 this config option must now be a dictionary structured like below. More information about each configuration option that can go into the `username_derivation` can be found in the `allowed_idps` docstring.
 
-   **Stripping the domain from one IDP username and adding prefixes to another**
+   **Stripping the domain from one IDP username, adding prefixes to another and leaving other unchanged**
 
    ```python
    c.CILogonOAuthenticator.allowed_idps = {
@@ -80,11 +80,18 @@ The following configurations have been deprecated in oauthenticator 15.0.0
                'prefix': 'idp',
            }
        },
+       'https://yet-another-idp.com/login/oauth/authorize': {
+           'username_derivation': {
+               'username_claim': 'nickname',
+           }
+       },
    }
    ```
 
-   This config means that if you login using a `some-idp` provider, the hub username will be the email registered for that IdP, from which the domain `uni.edu` will be stripped (assuming this is domain in the email provided by `some-idp`).
-   But if you login using `another-idp` the hub username will be your `another-idp` provided `nickname` claim, username prefixed with `idp:`. This way, users from different identity providers can log in without username clashes.
+   This config translates into:
+    - if you login using a `some-idp` provider, the hub username will be the email registered for that IdP, from which the domain `uni.edu` will be stripped (assuming this is domain in the email provided by `some-idp`).
+    - if you login using `another-idp` the hub username will be your `another-idp` provided `nickname` claim, username prefixed with `idp:`. This way, users from different identity providers can log in without username clashes.
+    - if you login using `yet-another-idp`, then the username will be left unchanged, i.e. the value corresponding to the `username_claim`.
 
    ```{note}
    If `allowed_idps` is specified, then each IdP in the dict must define the `username_derivation` dict, including `username_derivation.username_claim`. `CILogonOAuthenticator.username_claim` will only be used if `allowed_idps` is not specified!

--- a/docs/source/migrations.md
+++ b/docs/source/migrations.md
@@ -77,7 +77,7 @@ The following configurations have been deprecated in oauthenticator 15.0.0
            'username_derivation': {
                'username_claim': 'nickname',
                'action': 'prefix',
-               'prefix': 'idp',
+              'prefix': 'idp',
            }
        },
        'https://yet-another-idp.com/login/oauth/authorize': {

--- a/oauthenticator/cilogon.py
+++ b/oauthenticator/cilogon.py
@@ -329,7 +329,7 @@ class CILogonOAuthenticator(OAuthenticator):
             username_derivation_config = self.allowed_idps[selected_idp][
                 "username_derivation"
             ]
-            action = username_derivation_config["action"]
+            action = username_derivation_config.get("action", None)
             if action == "strip_idp_domain":
                 gotten_name, gotten_domain = username.split('@')
                 if gotten_domain != username_derivation_config["domain"]:

--- a/oauthenticator/schemas/cilogon-schema.yaml
+++ b/oauthenticator/schemas/cilogon-schema.yaml
@@ -27,6 +27,8 @@ properties:
           properties:
             action:
               const: strip_idp_domain
+          required:
+            - action
         then:
           required:
             - domain
@@ -34,6 +36,8 @@ properties:
           properties:
             action:
               const: prefix
+          required:
+            - action
         then:
           required:
             - prefix

--- a/oauthenticator/tests/test_cilogon.py
+++ b/oauthenticator/tests/test_cilogon.py
@@ -300,3 +300,26 @@ async def test_strip_and_prefix_username(cilogon_client):
     print(json.dumps(user_info, sort_keys=True, indent=4))
     name = user_info['name']
     assert name == 'idp:jtkirk'
+
+
+async def test_no_action_specified(cilogon_client):
+    cfg = Config()
+    cfg.CILogonOAuthenticator.allowed_idps = {
+        'https://some-idp.com/login/oauth/authorize': {
+            'username_derivation': {
+                'username_claim': 'email',
+            }
+        },
+    }
+
+    authenticator = CILogonOAuthenticator(config=cfg)
+
+    # Test stripping domain
+    handler = cilogon_client.handler_for_user(
+        alternative_user_model(
+            'jtkirk@uni.edu', 'email', idp='https://some-idp.com/login/oauth/authorize'
+        )
+    )
+    user_info = await authenticator.authenticate(handler)
+    name = user_info['name']
+    assert name == 'jtkirk@uni.edu'


### PR DESCRIPTION
Follow-up to https://github.com/jupyterhub/oauthenticator/pull/516. Without this, it's still impossible to don't specify an `action`.

This also adds a test and documents this option.

Ref: https://github.com/jupyterhub/oauthenticator/issues/514