### PR TITLE
Update theme and fix autodoc

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,9 +1,9 @@
 # autodoc_traits needs to inspect the oauthenticator module, so we also install
 # oauthenticator itself.
 #
--e ./
 autodoc-traits
 myst-parser
-pydata-sphinx-theme
+sphinx-book-theme
 sphinx>=2
 sphinx-copybutton
+sphinx-autobuild

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,6 +1,8 @@
 # autodoc_traits needs to inspect the oauthenticator module, so we also install
 # oauthenticator itself.
-#
+# Note: the install command must be ran from the oauthenticator root directory
+-e ./
+
 autodoc-traits
 myst-parser
 sphinx-book-theme

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -114,6 +114,10 @@ extensions = [
     'sphinx_copybutton',
 ]
 
+# Disable autosummary otherwise it will overwrite the oauthenticators docs in the `gen` directory.
+# Reference: https://www.sphinx-doc.org/en/master/usage/extensions/autosummary.html
+autosummary_generate = False
+
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ['_templates']
 

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -128,7 +128,16 @@ exclude_patterns = []
 # The theme to use for HTML and HTML Help pages.  See the documentation for
 # a list of builtin themes.
 #
-html_theme = 'pydata_sphinx_theme'
+html_theme = 'sphinx_book_theme'
+html_title = 'OAuthenticator'
+
+html_theme_options = {
+    "repository_url": "https://github.com/jupyterhub/oauthenticator",
+    "use_issues_button": True,
+    "use_repository_button": True,
+    "use_edit_page_button": True,
+}
+
 
 html_logo = '_static/images/logo/logo.png'
 html_favicon = '_static/images/logo/favicon.ico'

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -115,7 +115,7 @@ extensions = [
 ]
 
 # Disable autosummary otherwise it will overwrite the oauthenticators docs in the `gen` directory.
-# Reference: https://www.sphinx-doc.org/en/master/usage/extensions/autosummary.html
+# Reference: https://www.sphinx-doc.org/en/master/usage/extensions/autosummary.html#confval-autosummary_generate
 autosummary_generate = False
 
 # Add any paths that contain templates here, relative to this directory.

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -46,7 +46,7 @@ Writing your own OAuthenticator
 API Reference
 -------------
 .. toctree::
-   :maxdepth: 1
+   :maxdepth: 2
 
    api/index
    changelog

--- a/oauthenticator/auth0.py
+++ b/oauthenticator/auth0.py
@@ -5,16 +5,16 @@ Derived using the Github and Google OAuthenticator implementations as examples.
 
 The following environment variables may be used for configuration:
 
-    AUTH0_SUBDOMAIN - The subdomain for your Auth0 account
-    OAUTH_CLIENT_ID - Your client id
-    OAUTH_CLIENT_SECRET - Your client secret
-    OAUTH_CALLBACK_URL - Your callback handler URL
+* AUTH0_SUBDOMAIN - The subdomain for your Auth0 account
+* OAUTH_CLIENT_ID - Your client id
+* OAUTH_CLIENT_SECRET - Your client secret
+* OAUTH_CALLBACK_URL - Your callback handler URL
 
 Additionally, if you are concerned about your secrets being exposed by
 an env dump(I know I am!) you can set the client_secret, client_id and
 oauth_callback_url directly on the config for Auth0OAuthenticator.
 
-One instance of this could be adding the following to your jupyterhub_config.py :
+One instance of this could be adding the following to your jupyterhub_config.py::
 
   c.Auth0OAuthenticator.client_id = 'YOUR_CLIENT_ID'
   c.Auth0OAuthenticator.client_secret = 'YOUR_CLIENT_SECRET'

--- a/oauthenticator/cilogon.py
+++ b/oauthenticator/cilogon.py
@@ -114,57 +114,52 @@ class CILogonOAuthenticator(OAuthenticator):
 
         It can be used to enable domain stripping, adding prefixes to the usernames and to specify an identity provider specific username claim.
 
-        For example:
+        For example::
 
-        ```python
-        allowed_idps = {
-            "https://idpz.utorauth.utoronto.ca/shibboleth": {
-                "username_derivation": {
-                    "username_claim": "email",
-                    "action": "strip_idp_domain",
-                    "domain": "utoronto.ca",
+            allowed_idps = {
+                "https://idpz.utorauth.utoronto.ca/shibboleth": {
+                    "username_derivation": {
+                        "username_claim": "email",
+                        "action": "strip_idp_domain",
+                        "domain": "utoronto.ca",
+                    }
+                },
+                "https://github.com/login/oauth/authorize": {
+                    "username_derivation": {
+                        "username_claim": "username",
+                        "action": "prefix",
+                        "prefix": "gh"
+                    }
                 }
-            },
-            "https://github.com/login/oauth/authorize": {
-                "username_derivation": {
-                    "username_claim": "username",
-                    "action": "prefix",
-                    "prefix": "gh"
+                "http://google.com/accounts/o8/id": {
+                    "username_derivation": {
+                        "username_claim": "username",
+                    }
+                    "allowed_domains": ["uni.edu", "something.org"]
                 }
             }
-            "http://google.com/accounts/o8/id": {
-                "username_derivation": {
-                    "username_claim": "username",
-                }
-                "allowed_domains": ["uni.edu", "something.org"]
-            }
-        }
-        ```
 
-        Where
-        - `username_derivation` defines:
-            - `username_claim`: string
-                The claim in the userinfo response from which to get the
-                JupyterHub username. Examples include: eppn, email.
-                What keys are available will depend on the scopes requested.
-                It will overwrite any value set through
-                CILogonOAuthenticator.username_claim for this identity provider.
-            - `action`: string
-                What action to perform on the username. Available options are
-                "strip_idp_domain", which will strip the domain from the username if specified and "prefix", which will prefix the hub username with "prefix:".
-            - `domain:` string
+        Where `username_derivation` defines:
+            * :attr:`username_claim`: string
+                The claim in the `userinfo` response from which to get the JupyterHub username.
+                Examples include: `eppn`, `email`. What keys are available will depend on the scopes requested.
+                It will overwrite any value set through CILogonOAuthenticator.username_claim for this identity provider.
+            * :attr:`action`: string
+                What action to perform on the username. Available options are "strip_idp_domain", which will strip the domain from the username if specified and "prefix", which will prefix the hub username with "prefix:".
+            * :attr:`domain:` string
                 The domain after "@" which will be stripped from the username if it exists and if the action is "strip_idp_domain".
-            - `prefix`: string
-                The prefix which will be added at the beginning of the username
-                followed by a semicolumn ":", if the action is "prefix".
-        - `allowed_domains` defines which domains will be allowed to login using the specific idp
+            * :attr:`prefix`: string
+                The prefix which will be added at the beginning of the username followed by a semi-column ":", if the action is "prefix".
+            * :attr:`allowed_domains`: string
+                It defines which domains will be allowed to login using the specific identity provider.
 
         Requirements:
-        - if `username_derivation.action` is `strip_idp_domain`, then
-          `username_derivation.domain` must also be specified
-        - if `username_derivation.action` is `prefix`, then
-          `username_derivation.prefix`must also be specified.
-        - `username_claim` must be provided for each idp in `allowed_idps`.
+            * if `username_derivation.action` is `strip_idp_domain`, then `username_derivation.domain` must also be specified
+            * if `username_derivation.action` is `prefix`, then `username_derivation.prefix` must also be specified.
+            * `username_claim` must be provided for each idp in `allowed_idps`
+
+        .. versionchanged:: 15.0.0
+            `CILogonOAuthenticaor.allowed_idps` changed type from list to dict
         """,
     )
 


### PR DESCRIPTION
- Closes https://github.com/jupyterhub/oauthenticator/issues/512
   The problem was that without `autosummary_generate = False` each oauthenticator doc file created by https://github.com/jupyterhub/oauthenticator/blob/2a9765e3d0dc901cd088a5b831ca1c057786c2ee/docs/source/conf.py#L41, was being overwritten by autosummary 
- Closes https://github.com/jupyterhub/oauthenticator/issues/501
- Fixes some docstring warnings and errors which came up after fixing the api docs generation