### PR TITLE
Refactor oauthenticators

### DIFF
--- a/docs/source/getting-started.rst
+++ b/docs/source/getting-started.rst
@@ -549,7 +549,7 @@ Use the ``GenericOAuthenticator`` for Jupyterhub by editing your
    c.GenericOAuthenticator.login_service = 'NAME-OF-SERVICE'
    c.GenericOAuthenticator.userdata_url = 'http://YOUR-MOODLE-DOMAIN.com/local/oauth/user_info.php'
    c.GenericOAuthenticator.token_url = 'http://YOUR-MOODLE-DOMAIN.com/local/oauth/token.php'
-   c.GenericOAuthenticator.extra_params = {
+   c.GenericOAuthenticator.token_params = {
        'scope': 'user_info',
        'client_id': 'MOODLE-CLIENT-ID',
        'client_secret': 'MOODLE-CLIENT-SECRET-KEY',

--- a/oauthenticator/auth0.py
+++ b/oauthenticator/auth0.py
@@ -44,7 +44,7 @@ from .oauth2 import OAuthenticator
 class Auth0OAuthenticator(OAuthenticator):
 
     _deprecated_oauth_aliases = {
-        "username_key": ("username_claim", "15.1.0"),
+        "username_key": ("username_claim", "16.0.0"),
         **OAuthenticator._deprecated_oauth_aliases,
     }
 

--- a/oauthenticator/azuread.py
+++ b/oauthenticator/azuread.py
@@ -43,9 +43,9 @@ class AzureAdOAuthenticator(OAuthenticator):
             self.tenant_id
         )
 
-    async def token_to_user(self, tokens_info):
-        access_token = tokens_info['access_token']
-        id_token = tokens_info['id_token']
+    async def token_to_user(self, token_info):
+        access_token = token_info['access_token']
+        id_token = token_info['id_token']
         decoded = jwt.decode(
             id_token,
             options={"verify_signature": False},

--- a/oauthenticator/azuread.py
+++ b/oauthenticator/azuread.py
@@ -2,11 +2,9 @@
 Custom Authenticator to use Azure AD with JupyterHub
 """
 import os
-import urllib
 
 import jwt
 from jupyterhub.auth import LocalAuthenticator
-from tornado.httpclient import HTTPRequest
 from traitlets import Unicode, default
 
 from .oauth2 import OAuthenticator
@@ -21,11 +19,13 @@ class AzureAdOAuthenticator(OAuthenticator):
 
     tenant_id = Unicode(config=True, help="The Azure Active Directory Tenant ID")
 
+    @default("user_auth_state_key")
+    def _user_auth_state_key_default(self):
+        return "user"
+
     @default('tenant_id')
     def _tenant_id_default(self):
         return os.environ.get('AAD_TENANT_ID', '')
-
-    username_claim = Unicode(config=True)
 
     @default('username_claim')
     def _username_claim_default(self):
@@ -43,47 +43,16 @@ class AzureAdOAuthenticator(OAuthenticator):
             self.tenant_id
         )
 
-    async def authenticate(self, handler, data=None):
-        code = handler.get_argument("code")
-
-        params = dict(
-            client_id=self.client_id,
-            client_secret=self.client_secret,
-            grant_type='authorization_code',
-            code=code,
-            redirect_uri=self.get_callback_url(handler),
-        )
-
-        data = urllib.parse.urlencode(params, doseq=True, encoding='utf-8', safe='=')
-
-        url = self.token_url
-
-        headers = {'Content-Type': 'application/x-www-form-urlencoded; charset=UTF-8'}
-        req = HTTPRequest(
-            url,
-            method="POST",
-            headers=headers,
-            body=data,  # Body is required for a POST...
-        )
-
-        resp_json = await self.fetch(req)
-
-        access_token = resp_json['access_token']
-        id_token = resp_json['id_token']
-
+    async def token_to_user(self, tokens_info):
+        access_token = tokens_info['access_token']
+        id_token = tokens_info['id_token']
         decoded = jwt.decode(
             id_token,
             options={"verify_signature": False},
             audience=self.client_id,
         )
 
-        userdict = {"name": decoded[self.username_claim]}
-        userdict["auth_state"] = auth_state = {}
-        auth_state['access_token'] = access_token
-        # results in a decoded JWT for the user data
-        auth_state['user'] = decoded
-
-        return userdict
+        return decoded
 
 
 class LocalAzureAdOAuthenticator(LocalAuthenticator, AzureAdOAuthenticator):

--- a/oauthenticator/bitbucket.py
+++ b/oauthenticator/bitbucket.py
@@ -1,22 +1,12 @@
 """
 Custom Authenticator to use Bitbucket OAuth with JupyterHub
 """
-import urllib
-
 from jupyterhub.auth import LocalAuthenticator
 from tornado.httpclient import HTTPRequest
 from tornado.httputil import url_concat
 from traitlets import Set, default
 
 from .oauth2 import OAuthenticator
-
-
-def _api_headers(access_token):
-    return {
-        "Accept": "application/json",
-        "User-Agent": "JupyterHub",
-        "Authorization": "Bearer {}".format(access_token),
-    }
 
 
 class BitbucketOAuthenticator(OAuthenticator):
@@ -30,6 +20,10 @@ class BitbucketOAuthenticator(OAuthenticator):
     client_id_env = 'BITBUCKET_CLIENT_ID'
     client_secret_env = 'BITBUCKET_CLIENT_SECRET'
 
+    @default("user_auth_state_key")
+    def _user_auth_state_key_default(self):
+        return "bitbucket_user"
+
     @default("authorize_url")
     def _authorize_url_default(self):
         return "https://bitbucket.org/site/oauth2/authorize"
@@ -37,6 +31,10 @@ class BitbucketOAuthenticator(OAuthenticator):
     @default("token_url")
     def _token_url_default(self):
         return "https://bitbucket.org/site/oauth2/access_token"
+
+    @default("userdata_url")
+    def _userdata_url_default(self):
+        return "https://api.bitbucket.org/2.0/user"
 
     team_whitelist = Set(
         help="Deprecated, use `BitbucketOAuthenticator.allowed_teams`",
@@ -47,67 +45,25 @@ class BitbucketOAuthenticator(OAuthenticator):
         config=True, help="Automatically allow members of selected teams"
     )
 
-    headers = {
-        "Accept": "application/json",
-        "User-Agent": "JupyterHub",
-        "Authorization": "Bearer {}",
-    }
-
-    async def authenticate(self, handler, data=None):
-        code = handler.get_argument("code")
-
-        params = dict(
-            client_id=self.client_id,
-            client_secret=self.client_secret,
-            grant_type="authorization_code",
-            code=code,
-            redirect_uri=self.get_callback_url(handler),
-        )
-
-        url = url_concat("https://bitbucket.org/site/oauth2/access_token", params)
-
-        bb_header = {"Content-Type": "application/x-www-form-urlencoded;charset=utf-8"}
-        req = HTTPRequest(
-            url,
-            method="POST",
-            auth_username=self.client_id,
-            auth_password=self.client_secret,
-            body=urllib.parse.urlencode(params).encode('utf-8'),
-            headers=bb_header,
-        )
-
-        resp_json = await self.fetch(req)
-
-        access_token = resp_json['access_token']
-
-        # Determine who the logged in user is
-        req = HTTPRequest(
-            "https://api.bitbucket.org/2.0/user",
-            method="GET",
-            headers=_api_headers(access_token),
-        )
-        resp_json = await self.fetch(req)
-
-        username = resp_json["username"]
+    async def user_is_authorized(self, auth_model):
+        access_token = auth_model["auth_state"]["token_response"]["access_token"]
+        token_type = auth_model["auth_state"]["token_response"]["token_type"]
+        username = auth_model["name"]
 
         # Check if user is a member of any allowed teams.
         # This check is performed here, as the check requires `access_token`.
         if self.allowed_teams:
             user_in_team = await self._check_membership_allowed_teams(
-                username, access_token
+                username, access_token, token_type
             )
             if not user_in_team:
                 self.log.warning("%s not in team allowed list of users", username)
-                return None
+                return False
 
-        return {
-            'name': username,
-            'auth_state': {'access_token': access_token, 'bitbucket_user': resp_json},
-        }
+        return True
 
-    async def _check_membership_allowed_teams(self, username, access_token):
-
-        headers = _api_headers(access_token)
+    async def _check_membership_allowed_teams(self, username, access_token, token_type):
+        headers = self.build_userdata_request_headers(access_token, token_type)
         # We verify the team membership by calling teams endpoint.
         next_page = url_concat(
             "https://api.bitbucket.org/2.0/workspaces", {'role': 'member'}

--- a/oauthenticator/cilogon.py
+++ b/oauthenticator/cilogon.py
@@ -31,14 +31,14 @@ class CILogonLoginHandler(OAuthLoginHandler):
 
     def authorize_redirect(self, *args, **kwargs):
         """Add idp, skin to redirect params"""
-        extra_params = kwargs.setdefault('extra_params', {})
+        token_params = kwargs.setdefault('token_params', {})
         if self.authenticator.shown_idps:
             # selected_idp must be a string where idps are separated by commas, with no space between, otherwise it will get escaped
             # example: https://accounts.google.com/o/oauth2/auth,https://github.com/login/oauth/authorize
             idps = ",".join(self.authenticator.shown_idps)
-            extra_params["selected_idp"] = idps
+            token_params["selected_idp"] = idps
         if self.authenticator.skin:
-            extra_params["skin"] = self.authenticator.skin
+            token_params["skin"] = self.authenticator.skin
 
         return super().authorize_redirect(*args, **kwargs)
 

--- a/oauthenticator/generic.py
+++ b/oauthenticator/generic.py
@@ -90,7 +90,7 @@ class GenericOAuthenticator(OAuthenticator):
         else:
             username = user_info.get(self.username_claim, None)
             if not username:
-                message = "No %s found in %s", self.username_claim, user_info
+                message = f"No {self.username_claim} found in {user_info}",
                 self.log.error(message)
                 raise ValueError(message)
 

--- a/oauthenticator/generic.py
+++ b/oauthenticator/generic.py
@@ -90,7 +90,7 @@ class GenericOAuthenticator(OAuthenticator):
         else:
             username = user_info.get(self.username_claim, None)
             if not username:
-                message = f"No {self.username_claim} found in {user_info}",
+                message = (f"No {self.username_claim} found in {user_info}",)
                 self.log.error(message)
                 raise ValueError(message)
 

--- a/oauthenticator/generic.py
+++ b/oauthenticator/generic.py
@@ -15,8 +15,8 @@ from .traitlets import Callable
 class GenericOAuthenticator(OAuthenticator):
 
     _deprecated_oauth_aliases = {
-        "username_key": ("username_claim", "15.1.0"),
-        "extra_params": ("token_params", "15.1.0"),
+        "username_key": ("username_claim", "16.0.0"),
+        "extra_params": ("token_params", "16.0.0"),
         **OAuthenticator._deprecated_oauth_aliases,
     }
 

--- a/oauthenticator/generic.py
+++ b/oauthenticator/generic.py
@@ -16,6 +16,7 @@ class GenericOAuthenticator(OAuthenticator):
 
     _deprecated_oauth_aliases = {
         "username_key": ("username_claim", "15.1.0"),
+        "extra_params": ("token_params", "15.1.0"),
         **OAuthenticator._deprecated_oauth_aliases,
     }
 

--- a/oauthenticator/generic.py
+++ b/oauthenticator/generic.py
@@ -1,24 +1,25 @@
 """
 Custom Authenticator to use generic OAuth2 with JupyterHub
 """
-import base64
 import os
 from functools import reduce
-from urllib.parse import urlencode
 
 from jupyterhub.auth import LocalAuthenticator
-from tornado.httpclient import AsyncHTTPClient, HTTPRequest
-from tornado.httputil import url_concat
-from traitlets import Bool, Dict, List, Unicode, Union, default
+from tornado.httpclient import AsyncHTTPClient
+from traitlets import Bool, List, Unicode, Union, default
 
 from .oauth2 import OAuthenticator
 from .traitlets import Callable
 
 
 class GenericOAuthenticator(OAuthenticator):
-    login_service = Unicode("OAuth 2.0", config=True)
 
-    extra_params = Dict(help="Extra parameters for first POST request").tag(config=True)
+    _deprecated_oauth_aliases = {
+        "username_key": ("username_claim", "15.1.0"),
+        **OAuthenticator._deprecated_oauth_aliases,
+    }
+
+    login_service = Unicode("OAuth 2.0", config=True)
 
     claim_groups_key = Union(
         [Unicode(os.environ.get('OAUTH2_GROUPS_KEY', 'groups')), Callable()],
@@ -46,6 +47,12 @@ class GenericOAuthenticator(OAuthenticator):
     username_key = Union(
         [Unicode(os.environ.get('OAUTH2_USERNAME_KEY', 'username')), Callable()],
         config=True,
+        help="""Deprecated, use `GenericOAuthenticator.username_claim`""",
+    )
+
+    username_claim = Union(
+        [Unicode(os.environ.get('OAUTH2_USERNAME_KEY', 'username')), Callable()],
+        config=True,
         help="""
         Userdata username key from returned json for USERDATA_URL.
 
@@ -56,27 +63,15 @@ class GenericOAuthenticator(OAuthenticator):
         """,
     )
 
-    userdata_params = Dict(
-        help="Userdata params to get user data login information"
-    ).tag(config=True)
-
-    userdata_token_method = Unicode(
-        os.environ.get('OAUTH2_USERDATA_REQUEST_TYPE', 'header'),
-        config=True,
-        help="Method for sending access token in userdata request. Supported methods: header, url. Default: header",
-    )
-
     tls_verify = Bool(
         os.environ.get('OAUTH2_TLS_VERIFY', 'True').lower() in {'true', '1'},
         config=True,
         help="Disable TLS verification on http request",
     )
 
-    basic_auth = Bool(
-        os.environ.get('OAUTH2_BASIC_AUTH', 'True').lower() in {'true', '1'},
-        config=True,
-        help="Disable basic authentication for access token request",
-    )
+    @default("basic_auth")
+    def _basic_auth_default(self):
+        return os.environ.get('OAUTH2_BASIC_AUTH', 'True').lower() in {'true', '1'}
 
     @default("http_client")
     def _default_http_client(self):
@@ -84,103 +79,24 @@ class GenericOAuthenticator(OAuthenticator):
             force_instance=True, defaults=dict(validate_cert=self.tls_verify)
         )
 
-    def _get_headers(self):
-        headers = {"Accept": "application/json", "User-Agent": "JupyterHub"}
-
-        if self.basic_auth:
-            b64key = base64.b64encode(
-                bytes("{}:{}".format(self.client_id, self.client_secret), "utf8")
-            )
-            headers.update({"Authorization": "Basic {}".format(b64key.decode("utf8"))})
-        return headers
-
-    def _get_token(self, headers, params):
-        if self.token_url:
-            url = self.token_url
-        else:
-            raise ValueError("Please set the $OAUTH2_TOKEN_URL environment variable")
-
-        req = HTTPRequest(
-            url,
-            method="POST",
-            headers=headers,
-            body=urlencode(params),
-        )
-        return self.fetch(req, "fetching access token")
-
-    def _get_user_data(self, token_response):
-        access_token = token_response['access_token']
-        token_type = token_response['token_type']
-
-        # Determine who the logged in user is
-        headers = {
-            "Accept": "application/json",
-            "User-Agent": "JupyterHub",
-            "Authorization": "{} {}".format(token_type, access_token),
-        }
-        if self.userdata_url:
-            url = url_concat(self.userdata_url, self.userdata_params)
-        else:
-            raise ValueError("Please set the OAUTH2_USERDATA_URL environment variable")
-
-        if self.userdata_token_method == "url":
-            url = url_concat(self.userdata_url, dict(access_token=access_token))
-
-        req = HTTPRequest(url, headers=headers)
-        return self.fetch(req, "fetching user data")
-
-    @staticmethod
-    def _create_auth_state(token_response, user_data_response):
-        access_token = token_response['access_token']
-        refresh_token = token_response.get('refresh_token', None)
-        scope = token_response.get('scope', '')
-        if isinstance(scope, str):
-            scope = scope.split(' ')
-
-        return {
-            'access_token': access_token,
-            'refresh_token': refresh_token,
-            'oauth_user': user_data_response,
-            'scope': scope,
-        }
-
     @staticmethod
     def check_user_in_groups(member_groups, allowed_groups):
         return bool(set(member_groups) & set(allowed_groups))
 
-    async def authenticate(self, handler, data=None):
-        code = handler.get_argument("code")
-
-        params = dict(
-            redirect_uri=self.get_callback_url(handler),
-            code=code,
-            grant_type='authorization_code',
-        )
-        params.update(self.extra_params)
-
-        headers = self._get_headers()
-
-        token_resp_json = await self._get_token(headers, params)
-
-        user_data_resp_json = await self._get_user_data(token_resp_json)
-
-        if callable(self.username_key):
-            name = self.username_key(user_data_resp_json)
+    def user_info_to_username(self, user_info):
+        if callable(self.username_claim):
+            username = self.username_claim(user_info)
         else:
-            name = user_data_resp_json.get(self.username_key)
-            if not name:
-                self.log.error(
-                    "OAuth user contains no key %s: %s",
-                    self.username_key,
-                    user_data_resp_json,
-                )
-                return
+            username = user_info.get(self.username_claim, None)
+            if not username:
+                message = "No %s found in %s", self.username_claim, user_info
+                self.log.error(message)
+                raise ValueError(message)
 
-        user_info = {
-            'name': name,
-            'auth_state': self._create_auth_state(token_resp_json, user_data_resp_json),
-        }
+        return username
 
+    async def user_is_authorized(self, auth_model):
+        user_info = auth_model["auth_state"][self.user_auth_state_key]
         if self.allowed_groups:
             self.log.info(
                 'Validating if user claim groups match any of {}'.format(
@@ -189,11 +105,11 @@ class GenericOAuthenticator(OAuthenticator):
             )
 
             if callable(self.claim_groups_key):
-                groups = self.claim_groups_key(user_data_resp_json)
+                groups = self.claim_groups_key(user_info)
             else:
                 try:
                     groups = reduce(
-                        dict.get, self.claim_groups_key.split("."), user_data_resp_json
+                        dict.get, self.claim_groups_key.split("."), user_info
                     )
                 except TypeError:
                     # This happens if a nested key does not exist (reduce trying to call None.get)
@@ -206,19 +122,30 @@ class GenericOAuthenticator(OAuthenticator):
             if not groups:
                 self.log.error(
                     "No claim groups found for user! Something wrong with the `claim_groups_key` {}? {}".format(
-                        self.claim_groups_key, user_data_resp_json
+                        self.claim_groups_key, user_info
                     )
                 )
-                groups = []
+                return False
 
-            if self.check_user_in_groups(groups, self.allowed_groups):
-                user_info['admin'] = self.check_user_in_groups(
+            if not self.check_user_in_groups(groups, self.allowed_groups):
+                return False
+
+        return True
+
+    async def update_auth_model(self, auth_model):
+        user_info = auth_model["auth_state"][self.user_auth_state_key]
+        if self.allowed_groups:
+            if callable(self.claim_groups_key):
+                groups = self.claim_groups_key(user_info)
+            else:
+                groups = user_info.get(self.claim_groups_key)
+
+            # User has been checked to be in allowed_groups too if we're here
+            if groups:
+                auth_model['admin'] = self.check_user_in_groups(
                     groups, self.admin_groups
                 )
-            else:
-                user_info = None
-
-        return user_info
+        return auth_model
 
 
 class LocalGenericOAuthenticator(LocalAuthenticator, GenericOAuthenticator):

--- a/oauthenticator/globus.py
+++ b/oauthenticator/globus.py
@@ -187,7 +187,7 @@ class GlobusOAuthenticator(OAuthenticator):
             globus_data = base64.b64encode(pickle.dumps(state))
             spawner.environment['GLOBUS_DATA'] = globus_data.decode('utf-8')
 
-    def get_globus_tokens(self, tokens_info):
+    def get_globus_tokens(self, token_info):
         # Each token should have these attributes. Resource server is optional,
         # and likely won't be present.
         token_attrs = [
@@ -203,24 +203,24 @@ class GlobusOAuthenticator(OAuthenticator):
         # can't be retrieved with an Auth token.
         # Repackage the Auth token into a dict that looks like the other tokens
         auth_token_dict = {
-            attr_name: tokens_info.get(attr_name) for attr_name in token_attrs
+            attr_name: token_info.get(attr_name) for attr_name in token_attrs
         }
         # Make sure only the essentials make it into tokens. Other items, such as 'state' are
         # not needed after authentication and can be discarded.
         other_tokens = [
             {attr_name: token_dict.get(attr_name) for attr_name in token_attrs}
-            for token_dict in tokens_info['other_tokens']
+            for token_dict in token_info['other_tokens']
         ]
         return other_tokens + [auth_token_dict]
 
-    def build_auth_state_dict(self, tokens_info, user_info):
+    def build_auth_state_dict(self, token_info, user_info):
         """
         Usernames (and therefore Jupyterhub
         accounts) will correspond to a Globus User ID, so foouser@globusid.org
         will have the 'foouser' account in Jupyterhub.
         """
 
-        tokens = self.get_globus_tokens(tokens_info)
+        tokens = self.get_globus_tokens(token_info)
         # historically, tokens have been organized by resource server for convenience.
         # If multiple scopes are requested from the same resource server, they will be
         # combined into a single token from Globus Auth.
@@ -233,7 +233,7 @@ class GlobusOAuthenticator(OAuthenticator):
         return {
             'client_id': self.client_id,
             'tokens': by_resource_server,
-            'token_response': tokens_info,
+            'token_response': token_info,
             self.user_auth_state_key: user_info,
         }
 

--- a/oauthenticator/mediawiki.py
+++ b/oauthenticator/mediawiki.py
@@ -109,7 +109,7 @@ class MWOAuthenticator(OAuthenticator):
     # We're overriding this method because mediawiki it's more special
     # and needs a Handshaker object to send the tokes request.
     # So, we're building the params directly in the `get_token_info`.
-    def build_access_tokens_request_params(self, handler):
+    def build_access_tokens_request_params(self, handler, data=None):
         return None
 
     async def get_token_info(self, handler, params):

--- a/oauthenticator/mediawiki.py
+++ b/oauthenticator/mediawiki.py
@@ -108,11 +108,11 @@ class MWOAuthenticator(OAuthenticator):
 
     # We're overriding this method because mediawiki it's more special
     # and needs a Handshaker object to send the tokes request.
-    # So, we're building the params directly in the `get_tokens_info`.
-    def build_access_tokens_req_params(self, handler):
+    # So, we're building the params directly in the `get_token_info`.
+    def build_access_tokens_request_params(self, handler):
         return None
 
-    async def get_tokens_info(self, handler, params):
+    async def get_token_info(self, handler, params):
         # Exchange the OAuth code for an Access Token
         consumer_token = ConsumerToken(
             self.client_id,
@@ -129,23 +129,23 @@ class MWOAuthenticator(OAuthenticator):
         )
         return {"access_token": access_token, "consumer_token": consumer_token}
 
-    async def token_to_user(self, tokens_info):
-        handshaker = Handshaker(self.mw_index_url, tokens_info["consumer_token"])
+    async def token_to_user(self, token_info):
+        handshaker = Handshaker(self.mw_index_url, token_info["consumer_token"])
 
         return await wrap_future(
-            self.executor.submit(handshaker.identify, tokens_info["access_token"])
+            self.executor.submit(handshaker.identify, token_info["access_token"])
         )
 
     async def update_auth_model(self, auth_model):
         auth_model['name'] = auth_model['name'].replace(' ', '_')
         return auth_model
 
-    def build_auth_state_dict(self, tokens_info, user_info):
+    def build_auth_state_dict(self, token_info, user_info):
         username = self.user_info_to_username(user_info)
         # this shouldn't be necessary anymore,
         # but keep for backward-compatibility
         return {
-            'ACCESS_TOKEN_KEY': tokens_info["access_token"].key,
-            'ACCESS_TOKEN_SECRET': tokens_info["access_token"].secret,
+            'ACCESS_TOKEN_KEY': token_info["access_token"].key,
+            'ACCESS_TOKEN_SECRET': token_info["access_token"].secret,
             'MEDIAWIKI_USER_IDENTITY': user_info,
         }

--- a/oauthenticator/oauth2.py
+++ b/oauthenticator/oauth2.py
@@ -22,10 +22,7 @@ from traitlets import Any, Bool, Dict, List, Unicode, default
 
 
 def guess_callback_uri(protocol, host, hub_server_url):
-    return "{proto}://{host}{path}".format(
-        proto=protocol, host=host, path=url_path_join(hub_server_url, "oauth_callback")
-    )
-
+    return f'{protocol}://{host}{url_path_join(hub_server_url, "oauth_callback")}'
 
 STATE_COOKIE_NAME = "oauthenticator-state"
 
@@ -43,12 +40,12 @@ def _deserialize_state(b64_state):
     try:
         json_state = base64.urlsafe_b64decode(b64_state).decode("utf8")
     except ValueError:
-        app_log.error("Failed to b64-decode state: %r", b64_state)
+        app_log.error(f"Failed to b64-decode state: {b64_state}")
         return {}
     try:
         return json.loads(json_state)
     except ValueError:
-        app_log.error("Failed to json-decode state: %r", json_state)
+        app_log.error(f"Failed to json-decode state: {json_state}")
         return {}
 
 
@@ -90,7 +87,7 @@ class OAuthLoginHandler(OAuth2Mixin, BaseHandler):
             ).geturl()
             if next_url != original_next_url:
                 self.log.warning(
-                    "Ignoring next_url %r, using %r", original_next_url, next_url
+                    f"Ignoring next_url {original_next_url}, using {next_url}"
                 )
         if self._state is None:
             self._state = _serialize_state(
@@ -101,7 +98,7 @@ class OAuthLoginHandler(OAuth2Mixin, BaseHandler):
     def get(self):
         redirect_uri = self.authenticator.get_callback_url(self)
         token_params = self.authenticator.extra_authorize_params.copy()
-        self.log.info("OAuth redirect: %r", redirect_uri)
+        self.log.info(f"OAuth redirect: {redirect_uri}")
         state = self.get_state()
         self.set_state_cookie(state)
         token_params["state"] = state
@@ -484,7 +481,7 @@ class OAuthenticator(Authenticator):
             "Accept": "application/json",
             "Content-Type": "application/json",
             "User-Agent": "JupyterHub",
-            "Authorization": "{} {}".format(token_type, access_token),
+            "Authorization": f"{token_type} {access_token}"
         }
 
     def build_token_info_request_headers(self):
@@ -496,9 +493,9 @@ class OAuthenticator(Authenticator):
 
         if self.basic_auth:
             b64key = base64.b64encode(
-                bytes("{}:{}".format(self.client_id, self.client_secret), "utf8")
+                bytes("{self.client_id}:{self.client_secret}", "utf8")
             )
-            headers.update({"Authorization": "Basic {}".format(b64key.decode("utf8"))})
+            headers.update({"Authorization": f'Basic {b64key.decode("utf8")}'})
         return headers
 
     def user_info_to_username(self, user_info):
@@ -596,12 +593,10 @@ class OAuthenticator(Authenticator):
         if "error_description" in token_info:
             raise web.HTTPError(
                 403,
-                "An access token was not returned: {}".format(
-                    token_info["error_description"]
-                ),
+                f'An access token was not returned: {token_info["error_description"]}',
             )
         elif "access_token" not in token_info:
-            raise web.HTTPError(500, "Bad response: {}".format(token_info))
+            raise web.HTTPError(500, f"Bad response: {token_info}")
 
         return token_info
 

--- a/oauthenticator/oauth2.py
+++ b/oauthenticator/oauth2.py
@@ -289,6 +289,7 @@ class OAuthenticator(Authenticator):
         return os.environ.get("OAUTH2_USERDATA_URL", "")
 
     username_claim = Unicode(
+        "username",
         config=True,
         help="""Field in userdata reply to use for username
         The field in the userdata response from which to get the JupyterHub username.
@@ -298,9 +299,6 @@ class OAuthenticator(Authenticator):
         """,
     )
 
-    @default("username_claim")
-    def _username_claim_default(self):
-        return "username"
 
     # Enable refresh_pre_spawn by default if self.enable_auth_state
     @default("refresh_pre_spawn")

--- a/oauthenticator/oauth2.py
+++ b/oauthenticator/oauth2.py
@@ -299,7 +299,6 @@ class OAuthenticator(Authenticator):
         """,
     )
 
-
     # Enable refresh_pre_spawn by default if self.enable_auth_state
     @default("refresh_pre_spawn")
     def _refresh_pre_spawn(self):

--- a/oauthenticator/oauth2.py
+++ b/oauthenticator/oauth2.py
@@ -150,7 +150,7 @@ class OAuthCallbackHandler(BaseHandler):
         if not url_state:
             raise web.HTTPError(400, "OAuth state missing from URL")
         if cookie_state != url_state:
-            self.log.warning("OAuth state mismatch: %s != %s", cookie_state, url_state)
+            self.log.warning(f"OAuth state mismatch: {cookie_state} != {url_state}")
             raise web.HTTPError(400, "OAuth state mismatch")
 
     def check_error(self):
@@ -158,7 +158,7 @@ class OAuthCallbackHandler(BaseHandler):
         error = self.get_argument("error", False)
         if error:
             message = self.get_argument("error_description", error)
-            raise web.HTTPError(400, "OAuth error: %s" % message)
+            raise web.HTTPError(400, f"OAuth error: {message}")
 
     def check_code(self):
         """Check the OAuth code"""
@@ -519,7 +519,7 @@ class OAuthenticator(Authenticator):
         """
         username = user_info.get(self.username_claim, None)
         if not username:
-            message = "No %s found in %s", self.username_claim, user_info
+            message = f"No {self.username_claim} found in {user_info}",
             self.log.error(message)
             raise ValueError(message)
 

--- a/oauthenticator/oauth2.py
+++ b/oauthenticator/oauth2.py
@@ -550,7 +550,7 @@ class OAuthenticator(Authenticator):
             )
             return
 
-    def build_access_tokens_request_params(self, handler):
+    def build_access_tokens_request_params(self, handler, data=None):
         """
         Builds the parameters that should be passed to the URL request
         that exchanges the OAuth code for the Access Token.
@@ -566,6 +566,7 @@ class OAuthenticator(Authenticator):
             "client_id": self.client_id,
             "client_secret": self.client_secret,
             "redirect_uri": self.get_callback_url(handler),
+            "data": data
         }
         params.update(self.token_params)
 
@@ -710,9 +711,9 @@ class OAuthenticator(Authenticator):
         """
         return True
 
-    async def authenticate(self, handler, **kwargs):
+    async def authenticate(self, handler, data=None, **kwargs):
         # build the parameters to be used in the request exchanging the oauth code for the access token
-        access_token_params = self.build_access_tokens_request_params(handler)
+        access_token_params = self.build_access_tokens_request_params(handler, data)
         # exchange the oauth code for an access token and get the JSON with info about it
         token_info = await self.get_token_info(handler, access_token_params)
         # use the access_token to get userdata info

--- a/oauthenticator/oauth2.py
+++ b/oauthenticator/oauth2.py
@@ -254,13 +254,10 @@ class OAuthenticator(Authenticator):
     logout_handler = OAuthLogoutHandler
 
     user_auth_state_key = Unicode(
+        "oauth_user",
         config=True,
         help="""The name of the user key expected to be present in `auth_state`.""",
     )
-
-    @default("user_auth_state_key")
-    def _user_auth_state_key_default(self):
-        return "oauth_user"
 
     authorize_url = Unicode(
         config=True, help="""The authenticate url for initiating oauth"""

--- a/oauthenticator/oauth2.py
+++ b/oauthenticator/oauth2.py
@@ -24,6 +24,7 @@ from traitlets import Any, Bool, Dict, List, Unicode, default
 def guess_callback_uri(protocol, host, hub_server_url):
     return f'{protocol}://{host}{url_path_join(hub_server_url, "oauth_callback")}'
 
+
 STATE_COOKIE_NAME = "oauthenticator-state"
 
 
@@ -481,7 +482,7 @@ class OAuthenticator(Authenticator):
             "Accept": "application/json",
             "Content-Type": "application/json",
             "User-Agent": "JupyterHub",
-            "Authorization": f"{token_type} {access_token}"
+            "Authorization": f"{token_type} {access_token}",
         }
 
     def build_token_info_request_headers(self):
@@ -516,7 +517,7 @@ class OAuthenticator(Authenticator):
         """
         username = user_info.get(self.username_claim, None)
         if not username:
-            message = f"No {self.username_claim} found in {user_info}",
+            message = (f"No {self.username_claim} found in {user_info}",)
             self.log.error(message)
             raise ValueError(message)
 
@@ -563,7 +564,7 @@ class OAuthenticator(Authenticator):
             "client_id": self.client_id,
             "client_secret": self.client_secret,
             "redirect_uri": self.get_callback_url(handler),
-            "data": data
+            "data": data,
         }
         params.update(self.token_params)
 

--- a/oauthenticator/oauth2.py
+++ b/oauthenticator/oauth2.py
@@ -100,16 +100,16 @@ class OAuthLoginHandler(OAuth2Mixin, BaseHandler):
 
     def get(self):
         redirect_uri = self.authenticator.get_callback_url(self)
-        extra_params = self.authenticator.extra_authorize_params.copy()
+        token_params = self.authenticator.extra_authorize_params.copy()
         self.log.info('OAuth redirect: %r', redirect_uri)
         state = self.get_state()
         self.set_state_cookie(state)
-        extra_params['state'] = state
+        token_params['state'] = state
         self.authorize_redirect(
             redirect_uri=redirect_uri,
             client_id=self.authenticator.client_id,
             scope=self.authenticator.scope,
-            extra_params=extra_params,
+            token_params=token_params,
             response_type='code',
         )
 
@@ -321,7 +321,7 @@ class OAuthenticator(Authenticator):
     )
 
     # Originally a GenericOAuthenticator only trait
-    extra_params = Dict(
+    token_params = Dict(
         help="Extra parameters for first POST request exchanging the OAuth code for an Access Token"
     ).tag(config=True)
 
@@ -571,7 +571,7 @@ class OAuthenticator(Authenticator):
             'client_secret': self.client_secret,
             'redirect_uri': self.get_callback_url(handler),
         }
-        params.update(self.extra_params)
+        params.update(self.token_params)
 
         return params
 

--- a/oauthenticator/okpy.py
+++ b/oauthenticator/okpy.py
@@ -1,13 +1,8 @@
 """
 Custom Authenticator to use okpy OAuth with JupyterHub
 """
-from binascii import a2b_base64
-
 from jupyterhub.auth import LocalAuthenticator
-from tornado import web
 from tornado.auth import OAuth2Mixin
-from tornado.httpclient import HTTPRequest
-from tornado.httputil import url_concat
 from traitlets import default
 
 from .oauth2 import OAuthenticator
@@ -15,6 +10,10 @@ from .oauth2 import OAuthenticator
 
 class OkpyOAuthenticator(OAuthenticator, OAuth2Mixin):
     login_service = "OK"
+
+    @default("user_auth_state_key")
+    def _user_auth_state_key_default(self):
+        return "okpy_user"
 
     @default("authorize_url")
     def _authorize_url_default(self):
@@ -28,58 +27,20 @@ class OkpyOAuthenticator(OAuthenticator, OAuth2Mixin):
     def _userdata_url_default(self):
         return "https://okpy.org/api/v3/user"
 
-    @default('scope')
+    @default("scope")
     def _default_scope(self):
-        return ['email']
+        return ["email"]
 
-    def get_auth_request(self, code):
-        params = dict(
-            redirect_uri=self.oauth_callback_url,
-            code=code,
-            grant_type='authorization_code',
-        )
-        b64key = a2b_base64("{}:{}".format(self.client_id, self.client_secret)).decode(
-            'ascii'
-        )
-        url = url_concat(self.token_url, params)
-        req = HTTPRequest(
-            url,
-            method="POST",
-            headers={
-                "Accept": "application/json",
-                "User-Agent": "JupyterHub",
-                "Authorization": "Basic {}".format(b64key),
-            },
-            body='',  # Body is required for a POST...
-        )
-        return req
+    @default("username_claim")
+    def _username_claim_default(self):
+        return "email"
 
-    def get_user_info_request(self, access_token):
-        headers = {
-            "Accept": "application/json",
-            "User-Agent": "JupyterHub",
-            "Authorization": "Bearer {}".format(access_token),
-        }
-        params = {"envelope": "false"}
-        url = url_concat(self.userdata_url, params)
-        req = HTTPRequest(url, method="GET", headers=headers)
-        return req
-
-    async def authenticate(self, handler, data=None):
-        code = handler.get_argument("code", False)
-        if not code:
-            raise web.HTTPError(400, "Authentication Cancelled.")
-        auth_request = self.get_auth_request(code)
-        state = await self.fetch(auth_request)
-        if not state:
-            raise web.HTTPError(500, 'Authentication Failed: Token Not Acquired')
-        access_token = state['access_token']
-        info_request = self.get_user_info_request(access_token)
-        user = await self.fetch(info_request)
-        return {
-            'name': user['email'],
-            'auth_state': {'access_token': access_token, 'okpy_user': user},
-        }
+    @default("userdata_params")
+    def _default_userdata_params(self):
+        # Otherwise all responses from the API are wrapped in
+        # an envelope that contains metadata about the response.
+        # ref: https://okpy.github.io/documentation/ok-api.html
+        return {"envelope": "false"}
 
 
 class LocalOkpyOAuthenticator(LocalAuthenticator, OkpyOAuthenticator):

--- a/oauthenticator/openshift.py
+++ b/oauthenticator/openshift.py
@@ -7,8 +7,6 @@ import os
 
 import requests
 from jupyterhub.auth import LocalAuthenticator
-from tornado.httpclient import HTTPRequest
-from tornado.httputil import url_concat
 from traitlets import Bool, Set, Unicode, default
 
 from oauthenticator.oauth2 import OAuthenticator
@@ -67,6 +65,10 @@ class OpenShiftOAuthenticator(OAuthenticator):
         config=True,
     )
 
+    @default("user_auth_state_key")
+    def _user_auth_state_key_default(self):
+        return "openshift_user"
+
     @default("openshift_rest_api_url")
     def _openshift_rest_api_url_default(self):
         return self.openshift_url
@@ -79,6 +81,10 @@ class OpenShiftOAuthenticator(OAuthenticator):
     def _token_url_default(self):
         return "%s/oauth/token" % self.openshift_auth_api_url
 
+    @default("username_claim")
+    def _username_claim_default(self):
+        return "name"
+
     @default("userdata_url")
     def _userdata_url_default(self):
         return "%s/apis/user.openshift.io/v1/users/~" % self.openshift_rest_api_url
@@ -87,85 +93,37 @@ class OpenShiftOAuthenticator(OAuthenticator):
     def user_in_groups(user_groups: set, allowed_groups: set):
         return any(user_groups.intersection(allowed_groups))
 
-    async def authenticate(self, handler, data=None):
-        code = handler.get_argument("code")
+    def user_info_to_username(self, user_info):
+        return user_info['metadata']['name']
 
-        # Exchange the OAuth code for a OpenShift Access Token
-        #
-        # See: https://docs.openshift.org/latest/architecture/additional_concepts/authentication.html#api-authentication
-
-        params = dict(
-            client_id=self.client_id,
-            client_secret=self.client_secret,
-            grant_type="authorization_code",
-            code=code,
-        )
-
-        url = url_concat(self.token_url, params)
-
-        req = HTTPRequest(
-            url,
-            method="POST",
-            validate_cert=self.validate_cert,
-            ca_certs=self.ca_certs,
-            headers={"Accept": "application/json"},
-            body='',  # Body is required for a POST...
-        )
-
-        resp_json = await self.fetch(req)
-        access_token = resp_json['access_token']
-
-        # Determine who the logged in user is
-        headers = {
-            "Accept": "application/json",
-            "User-Agent": "JupyterHub",
-            "Authorization": "Bearer {}".format(access_token),
-        }
-
-        req = HTTPRequest(
-            self.userdata_url,
-            method="GET",
-            validate_cert=self.validate_cert,
-            ca_certs=self.ca_certs,
-            headers=headers,
-        )
-
-        ocp_user = await self.fetch(req)
-
-        username = ocp_user['metadata']['name']
-
-        user_info = {
-            'name': username,
-            'auth_state': {'access_token': access_token, 'openshift_user': ocp_user},
-        }
-
-        if self.allowed_groups or self.admin_groups:
-            user_info = await self._add_openshift_group_info(user_info)
-
-        return user_info
-
-    async def _add_openshift_group_info(self, user_info: dict):
+    async def update_auth_model(self, auth_model):
         """
         Use the group info stored on the OpenShift User object to determine if a user
-        is authenticated based on groups, an admin, or both.
+        is an admin and update the auth_model with this info.
         """
-        user_groups = set(user_info['auth_state']['openshift_user']['groups'])
-        username = user_info['name']
+        user_groups = set(auth_model['auth_state']['openshift_user']['groups'])
 
         if self.admin_groups:
-            is_admin = self.user_in_groups(user_groups, self.admin_groups)
+            auth_model['admin'] = self.user_in_groups(user_groups, self.admin_groups)
 
-        user_in_allowed_group = self.user_in_groups(user_groups, self.allowed_groups)
+        return auth_model
 
-        if self.admin_groups and (is_admin or user_in_allowed_group):
-            user_info['admin'] = is_admin
-            return user_info
-        elif user_in_allowed_group:
-            return user_info
-        else:
+    async def user_is_authorized(self, auth_model):
+        """
+        Use the group info stored on the OpenShift User object to determine if a user
+        is authorized to login.
+        """
+        user_groups = set(auth_model['auth_state']['openshift_user']['groups'])
+        username = auth_model['name']
+
+        if self.allowed_groups or self.admin_groups:
             msg = f"username:{username} User not in any of the allowed/admin groups"
-            self.log.warning(msg)
-            return None
+            if not self.user_in_groups(user_groups, self.allowed_groups):
+                if not self.user_in_groups(user_groups, self.admin_groups):
+                    self.log.warning(msg)
+                    return False
+
+        return True
 
 
 class LocalOpenShiftOAuthenticator(LocalAuthenticator, OpenShiftOAuthenticator):

--- a/oauthenticator/tests/test_auth0.py
+++ b/oauthenticator/tests/test_auth0.py
@@ -92,7 +92,7 @@ def test_deprecated_config(caplog):
     assert (
         log.name,
         logging.WARNING,
-        'Auth0OAuthenticator.username_key is deprecated in Auth0OAuthenticator 15.1.0, use '
+        'Auth0OAuthenticator.username_key is deprecated in Auth0OAuthenticator 16.0.0, use '
         'Auth0OAuthenticator.username_claim instead',
     ) in caplog.record_tuples
 

--- a/oauthenticator/tests/test_cilogon.py
+++ b/oauthenticator/tests/test_cilogon.py
@@ -45,11 +45,7 @@ async def test_cilogon(cilogon_client):
     auth_state = user_info['auth_state']
     assert 'access_token' in auth_state
     assert 'token_response' in auth_state
-    assert auth_state == {
-        'access_token': auth_state['access_token'],
-        'cilogon_user': user_model('wash'),
-        'token_response': auth_state['token_response'],
-    }
+    assert auth_state["cilogon_user"] == user_model('wash')
 
 
 async def test_cilogon_alternate_claim(cilogon_client):
@@ -64,11 +60,7 @@ async def test_cilogon_alternate_claim(cilogon_client):
     auth_state = user_info['auth_state']
     assert 'access_token' in auth_state
     assert 'token_response' in auth_state
-    assert auth_state == {
-        'access_token': auth_state['access_token'],
-        'cilogon_user': alternative_user_model('jtkirk@ufp.gov', 'uid'),
-        'token_response': auth_state['token_response'],
-    }
+    assert auth_state["cilogon_user"] == alternative_user_model('jtkirk@ufp.gov', 'uid')
 
 
 async def test_cilogon_additional_claim(cilogon_client):
@@ -83,11 +75,7 @@ async def test_cilogon_additional_claim(cilogon_client):
     auth_state = user_info['auth_state']
     assert 'access_token' in auth_state
     assert 'token_response' in auth_state
-    assert auth_state == {
-        'access_token': auth_state['access_token'],
-        'cilogon_user': alternative_user_model('jtkirk@ufp.gov', 'uid'),
-        'token_response': auth_state['token_response'],
-    }
+    assert auth_state["cilogon_user"] == alternative_user_model('jtkirk@ufp.gov', 'uid')
 
 
 async def test_cilogon_missing_alternate_claim(cilogon_client):

--- a/oauthenticator/tests/test_generic.py
+++ b/oauthenticator/tests/test_generic.py
@@ -69,6 +69,7 @@ async def test_generic_data(get_authenticator, generic_client):
     name = user_info['name']
     assert name == 'wash'
 
+
 async def test_generic_callable_username_key(get_authenticator, generic_client):
     authenticator = get_authenticator(username_key=lambda r: r['alternate_username'])
     handler = generic_client.handler_for_user(

--- a/oauthenticator/tests/test_generic.py
+++ b/oauthenticator/tests/test_generic.py
@@ -59,6 +59,16 @@ async def test_generic(get_authenticator, generic_client):
     assert 'scope' in auth_state
 
 
+async def test_generic_data(get_authenticator, generic_client):
+    authenticator = get_authenticator()
+
+    handler = get_simple_handler(generic_client)
+    data = {'testing': 'data'}
+    user_info = await authenticator.authenticate(handler, data)
+    assert sorted(user_info) == ['auth_state', 'name']
+    name = user_info['name']
+    assert name == 'wash'
+
 async def test_generic_callable_username_key(get_authenticator, generic_client):
     authenticator = get_authenticator(username_key=lambda r: r['alternate_username'])
     handler = generic_client.handler_for_user(

--- a/oauthenticator/tests/test_github.py
+++ b/oauthenticator/tests/test_github.py
@@ -44,15 +44,12 @@ async def test_github(github_client):
     assert name == 'wash'
     auth_state = user_info['auth_state']
     assert 'access_token' in auth_state
-
-    assert auth_state == {
-        'access_token': auth_state['access_token'],
-        'github_user': {
-            'email': 'dinosaurs@space',
-            'id': 5,
-            'login': name,
-            'name': 'Hoban Washburn',
-        },
+    assert 'github_user' in auth_state
+    assert auth_state["github_user"] == {
+        'email': 'dinosaurs@space',
+        'id': 5,
+        'login': name,
+        'name': 'Hoban Washburn',
     }
 
 

--- a/oauthenticator/tests/test_mediawiki.py
+++ b/oauthenticator/tests/test_mediawiki.py
@@ -58,8 +58,9 @@ async def test_mediawiki(mediawiki):
         spec=web.RequestHandler,
         get_secure_cookie=Mock(return_value=json.dumps(['key', 'secret'])),
         request=Mock(query='oauth_token=key&oauth_verifier=me'),
+        find_user=Mock(return_value=None),
     )
-    user = await authenticator.authenticate(handler, None)
+    user = await authenticator.authenticate(handler)
     assert user['name'] == 'wash'
     auth_state = user['auth_state']
     assert auth_state['ACCESS_TOKEN_KEY'] == 'key'


### PR DESCRIPTION
- Creates a base `authenticate` method that consists of:
 ```python
    async def authenticate(self, handler, data=None):
        tokens_info = await self.get_tokens_info(handler)
        user_info = await self.token_to_user(tokens_info)
        auth_state = await self.create_auth_state(tokens_info, user_info)

        return auth_state
```
  The scope is to also introduce `refresh_user` in this workflow
- Implements genric `get_tokens_info` and `token_to_user` methods in `oauth2.py` and lets the oauthenticators only implement `create_auth_state` (this ca be further refactored into smaller pieces)
- Moves some attributes from `generic` to `oauth2`

The puropose of this refactoring is to make implementing https://github.com/jupyterhub/oauthenticator/issues/398 easier.

- [X] oauthenticator.oauth2
- [X] oauthenticator.auth0
- [X] oauthenticator.azuread
- [X] oauthenticator.bitbucket
- [X] oauthenticator.cilogon
- [X] oauthenticator.generic
- [X] oauthenticator.github
- [X] oauthenticator.gitlab
- [x] oauthenticator.globus
- [x] oauthenticator.google
- [x] oauthenticator.okpy
- [x] oauthenticator.openshift
- [x] oauthenticator.mediawiki