### PR TITLE
Allow auth0_domain to be configured directly

### DIFF
--- a/oauthenticator/auth0.py
+++ b/oauthenticator/auth0.py
@@ -55,8 +55,9 @@ class Auth0OAuthenticator(OAuthenticator):
         # This is allowed to be empty unless auth0_domain is not supplied either
         return os.getenv("AUTH0_SUBDOMAIN", "")
 
+    @default("auth0_domain")
     def _auth0_domain_default(self):
-        domain = os.getenv("AUTH0_DOMAIN")
+        domain = os.getenv("AUTH0_DOMAIN", "")
         if domain:
             return domain
         if self.auth0_subdomain:

--- a/oauthenticator/auth0.py
+++ b/oauthenticator/auth0.py
@@ -5,10 +5,14 @@ Derived using the Github and Google OAuthenticator implementations as examples.
 
 The following environment variables may be used for configuration:
 
-* AUTH0_SUBDOMAIN - The subdomain for your Auth0 account
+* AUTH0_DOMAIN - The domain for your Auth0 account
+* AUTH0_SUBDOMAIN - Alternative to AUTH0_DOMAIN if your domain ends with .auth0.com
 * OAUTH_CLIENT_ID - Your client id
 * OAUTH_CLIENT_SECRET - Your client secret
 * OAUTH_CALLBACK_URL - Your callback handler URL
+
+You must provide either AUTH0_DOMAIN or AUTH0_SUBDOMAIN. If both are provided,
+AUTH0_DOMAIN will take precedence.
 
 Additionally, if you are concerned about your secrets being exposed by
 an env dump(I know I am!) you can set the client_secret, client_id and
@@ -16,6 +20,7 @@ oauth_callback_url directly on the config for Auth0OAuthenticator.
 
 One instance of this could be adding the following to your jupyterhub_config.py::
 
+  c.Auth0OAuthenticator.auth0_domain = 'auth.example.com'
   c.Auth0OAuthenticator.client_id = 'YOUR_CLIENT_ID'
   c.Auth0OAuthenticator.client_secret = 'YOUR_CLIENT_SECRET'
   c.Auth0OAuthenticator.oauth_callback_url = 'YOUR_CALLBACK_URL'
@@ -43,16 +48,23 @@ class Auth0OAuthenticator(OAuthenticator):
     login_service = "Auth0"
 
     auth0_subdomain = Unicode(config=True)
+    auth0_domain = Unicode(config=True)
 
     @default("auth0_subdomain")
     def _auth0_subdomain_default(self):
-        subdomain = os.getenv("AUTH0_SUBDOMAIN")
-        if not subdomain:
-            raise ValueError(
-                "Please specify $AUTH0_SUBDOMAIN env or %s.auth0_subdomain config"
-                % self.__class__.__name__
-            )
-        return subdomain
+        # This is allowed to be empty unless auth0_domain is not supplied either
+        return os.getenv("AUTH0_SUBDOMAIN", "")
+
+    def _auth0_domain_default(self):
+        domain = os.getenv("AUTH0_DOMAIN")
+        if domain:
+            return domain
+        if self.auth0_subdomain:
+            return '%s.auth0.com' % self.auth0_subdomain
+        raise ValueError(
+            "Please specify $AUTH0_DOMAIN env, $AUTH0_SUBDOMAIN env, %s.auth0_domain config, or %s.auth0_subdomain config"
+            % (self.__class__.__name__, self.__class__.__name__)
+        )
 
     username_key = Unicode(
         os.environ.get("OAUTH2_USERNAME_KEY", "email"),
@@ -62,15 +74,15 @@ class Auth0OAuthenticator(OAuthenticator):
 
     @default("logout_redirect_url")
     def _logout_redirect_url_default(self):
-        return 'https://%s.auth0.com/v2/logout' % self.auth0_subdomain
+        return 'https://%s/v2/logout' % self.auth0_domain
 
     @default("authorize_url")
     def _authorize_url_default(self):
-        return "https://%s.auth0.com/authorize" % self.auth0_subdomain
+        return "https://%s/authorize" % self.auth0_domain
 
     @default("token_url")
     def _token_url_default(self):
-        return "https://%s.auth0.com/oauth/token" % self.auth0_subdomain
+        return "https://%s/oauth/token" % self.auth0_domain
 
     async def authenticate(self, handler, data=None):
         code = handler.get_argument("code")
@@ -105,7 +117,7 @@ class Auth0OAuthenticator(OAuthenticator):
             "Authorization": "Bearer {}".format(access_token),
         }
         req = HTTPRequest(
-            "https://%s.auth0.com/userinfo" % self.auth0_subdomain,
+            "https://%s/userinfo" % self.auth0_domain,
             method="GET",
             headers=headers,
         )


### PR DESCRIPTION
This fixes #207 using the design [laid out by @GeorgianaElena](https://github.com/jupyterhub/oauthenticator/issues/207#issuecomment-1076402417). This adds a new configuration option `auth0_domain`. If supplied, it is the domain against which Auth0 API calls are made. If it is not supplied, it takes a default value of `{auth0_subdomain}.auth0.com` to remain backwards compatible.