### PR TITLE
[Generic] Allow passing a string separated by periods for group claim key

### DIFF
--- a/oauthenticator/generic.py
+++ b/oauthenticator/generic.py
@@ -191,10 +191,18 @@ class GenericOAuthenticator(OAuthenticator):
             if callable(self.claim_groups_key):
                 groups = self.claim_groups_key(user_data_resp_json)
             else:
-                groups = reduce(
-                    dict.get, self.claim_groups_key.split("."), user_data_resp_json
-                )
-
+                try:
+                    groups = reduce(
+                        dict.get, self.claim_groups_key.split("."), user_data_resp_json
+                    )
+                except TypeError:
+                    # This happens if a nested key does not exist (reduce trying to call None.get)
+                    self.log.error(
+                        "The key {} does not exist in the user token, or it is set to null".format(
+                            self.claim_groups_key
+                        )
+                    )
+                    groups = None
             if not groups:
                 self.log.error(
                     "No claim groups found for user! Something wrong with the `claim_groups_key` {}? {}".format(

--- a/oauthenticator/generic.py
+++ b/oauthenticator/generic.py
@@ -3,6 +3,7 @@ Custom Authenticator to use generic OAuth2 with JupyterHub
 """
 import base64
 import os
+from functools import reduce
 from urllib.parse import urlencode
 
 from jupyterhub.auth import LocalAuthenticator
@@ -25,9 +26,8 @@ class GenericOAuthenticator(OAuthenticator):
         help="""
         Userdata groups claim key from returned json for USERDATA_URL.
 
-        Can be a string key name or a callable that accepts the returned
-        json (as a dict) and returns the groups list. The callable is useful
-        e.g. for extracting the groups from a nested object in the response.
+        Can be a string key name (use periods for nested keys), or a callable
+        that accepts the returned json (as a dict) and returns the groups list.
         """,
     )
 
@@ -191,7 +191,9 @@ class GenericOAuthenticator(OAuthenticator):
             if callable(self.claim_groups_key):
                 groups = self.claim_groups_key(user_data_resp_json)
             else:
-                groups = user_data_resp_json.get(self.claim_groups_key)
+                groups = reduce(
+                    dict.get, self.claim_groups_key.split("."), user_data_resp_json
+                )
 
             if not groups:
                 self.log.error(

--- a/oauthenticator/tests/test_generic.py
+++ b/oauthenticator/tests/test_generic.py
@@ -115,6 +115,21 @@ async def test_generic_groups_claim_key_nested_strings(
     assert user_info['name'] == 'wash'
 
 
+async def test_generic_groups_claim_key_nested_strings_nonexistant_key(
+    get_authenticator, generic_client
+):
+    authenticator = get_authenticator(
+        scope=['openid', 'profile', 'roles'],
+        claim_groups_key='permissions.groups',
+        allowed_groups=['super_user'],
+    )
+    handler = generic_client.handler_for_user(
+        user_model('wash', alternate_username='zoe')
+    )
+    user_info = await authenticator.authenticate(handler)
+    assert user_info is None
+
+
 async def test_generic_groups_claim_key_with_allowed_groups_unauthorized(
     get_authenticator, generic_client
 ):

--- a/oauthenticator/tests/test_generic.py
+++ b/oauthenticator/tests/test_generic.py
@@ -98,6 +98,23 @@ async def test_generic_groups_claim_key_with_allowed_groups(
     assert user_info['name'] == 'wash'
 
 
+async def test_generic_groups_claim_key_nested_strings(
+    get_authenticator, generic_client
+):
+    authenticator = get_authenticator(
+        scope=['openid', 'profile', 'roles'],
+        claim_groups_key='permissions.groups',
+        allowed_groups=['super_user'],
+    )
+    handler = generic_client.handler_for_user(
+        user_model(
+            'wash', alternate_username='zoe', permissions={"groups": ['super_user']}
+        )
+    )
+    user_info = await authenticator.authenticate(handler)
+    assert user_info['name'] == 'wash'
+
+
 async def test_generic_groups_claim_key_with_allowed_groups_unauthorized(
     get_authenticator, generic_client
 ):


### PR DESCRIPTION
This implements support for nested dict keys in the group claim key, by allowing the user to specify the key as a string of period-separated keys.

See https://github.com/jupyterhub/oauthenticator/issues/536