### PR TITLE
[Generic] support providers that require 'nonce' and return an inlined 'id_token'

### DIFF
--- a/docs/source/changelog.md
+++ b/docs/source/changelog.md
@@ -6,6 +6,11 @@ command line for details.
 
 ## [Unreleased]
 
+#### Other breaking changes
+
+- `pyjwt` version 2.4.0 or greater is now required when use with authentication
+  classes that needs it: `AzureAdOAuthenticator`, `MWOAuthenticator` and now also `GenericOAuthenticator`.
+
 ## 15.0
 
 ### 15.1.0 - 2022-09-08

--- a/docs/source/writing-an-oauthenticator.md
+++ b/docs/source/writing-an-oauthenticator.md
@@ -10,6 +10,7 @@ and configuration to set the necessary configuration variables.
 - client_id
 - client_secret
 - login_service
+- authorize_url
 - userdata_url
 - token_url
 - username_key
@@ -17,12 +18,13 @@ and configuration to set the necessary configuration variables.
 Example config:
 
 ```python
-c.JupyterHub.authenticator_class = "generic"
+c.JupyterHub.authenticator_class = 'generic-oauth'
 
 c.GenericOAuthenticator.oauth_callback_url = 'https://{host}/hub/oauth_callback'
 c.GenericOAuthenticator.client_id = 'OAUTH-CLIENT-ID'
 c.GenericOAuthenticator.client_secret = 'OAUTH-CLIENT-SECRET-KEY'
 c.GenericOAuthenticator.login_service = 'name-of-service-provider'
+c.GenericOAuthenticator.authorize_url = 'url-submitting-authorization-request'
 c.GenericOAuthenticator.userdata_url = 'url-retrieving-user-data-with-access-token'
 c.GenericOAuthenticator.token_url = 'url-retrieving-access-token-oauth-completion'
 c.GenericOAuthenticator.username_key = 'username-key-for-USERDATA-URL'

--- a/oauthenticator/oauth2.py
+++ b/oauthenticator/oauth2.py
@@ -7,7 +7,7 @@ import base64
 import json
 import os
 import uuid
-from urllib.parse import quote, urlparse, urlunparse
+from urllib.parse import quote, urlencode, urlparse, urlunparse
 
 from jupyterhub.auth import Authenticator
 from jupyterhub.crypto import EncryptionUnavailable, InvalidToken, decrypt
@@ -490,7 +490,7 @@ class OAuthenticator(Authenticator):
         Builds and returns the headers to be used in the access token request.
         Called by the :meth:`oauthenticator.OAuthenticator.get_token_info`.
         """
-        headers = {"Accept": "application/json", "User-Agent": "JupyterHub"}
+        headers = {"Accept": "application/json", "User-Agent": "JupyterHub", "Content-Type": "application/x-www-form-urlencoded"}
 
         if self.basic_auth:
             b64key = base64.b64encode(
@@ -585,7 +585,7 @@ class OAuthenticator(Authenticator):
             url,
             method="POST",
             headers=self.build_token_info_request_headers(),
-            body=json.dumps(params),
+            body=urlencode(params).encode('utf-8'),
             validate_cert=self.validate_server_cert,
         )
 


### PR DESCRIPTION
**N.B.** WiP, tests not yet passing, looking for feedback before fixing them, Works For Me(tm)

[Portier](https://portier.github.io/) only validates an identity and does not provide an `access_token` suitable to send access to resource providers, as such the `access_token` is [literally set to `UNUSED`](https://github.com/portier/portier-broker/blob/84568f4148a61e928e51a69dc2c637495d6cf738/src/handlers/token.rs#L59-L63).

Portier also requires that `nonce` is provided so that it is verified in by the authenticator later.

An example response to calling `token_url`:
```
{'access_token': 'UNUSED', 'id_token': 'eyJhbGciOiJSUzI1NiIsImtpZCI6ImJfMC1QMTFDZnpISl9OZGtTZzBHdWhlRFptSTNaNnE4Q1JHanJDS000WEkifQ.eyJhdWQiOiJodHRwOi8vbG9jYWxob3N0OjgwODAiLCJlbWFpbCI6ImFsZXhAY29yZW1lbS5jb20iLCJlbWFpbF9vcmlnaW5hbCI6ImFsZXhAY29yZW1lbS5jb20iLCJlbWFpbF92ZXJpZmllZCI6dHJ1ZSwiZXhwIjoxNjY1NTk1MTA4LCJpYXQiOjE2NjU1OTQ1MDgsImlzcyI6Imh0dHBzOi8vYnJva2VyLnBvcnRpZXIuaW8iLCJub25jZSI6IjY5ZjU2YzY3Njk5YmYwMTM2NmZiMDY0MjFlMjY5ZDJkIiwic3ViIjoiYWxleEBjb3JlbWVtLmNvbSJ9.oQtdZaTc_wNT2D6DJjExuIY1VGW_zKN1zzMqj4Eau-PAzItVcVTkss7cbObNq1D0_cPqkHVKcrxjM1G1_mYJMM02MnJ71W-yIamCX5BGL8rjHB5AbKffK9L23AitoQf4x5hjW9FJUzAdgOT_3mDDfv7Cn5N2TKhw794QNe3TXoD2OYvUxtaMbhnXSzuUGh30p78nghazcVp-BS--q9IQmNBEcjMFrN3TFX1Wdo6IFCBN1UZmsfQfoHGbQPjyCKR8yRwGjQUjHrH5Q5hsKpMQQVFHYHwxi93rBX9vvCYo00nUw-l_D5nd2AOGi3bZitRg96wDwOcgVbZHNPbLRGSXow', 'token_type': 'bearer'}
```

Configuration used to make this work for me:
```
from oauthenticator.generic import GenericOAuthenticator
c.JupyterHub.authenticator_class = GenericOAuthenticator
c.GenericOAuthenticator.client_id = 'http://localhost:8000'
c.GenericOAuthenticator.scope = [ 'openid', 'email' ]
c.GenericOAuthenticator.oauth_callback_url = 'http://localhost:8000/hub/oauth_callback'
c.GenericOAuthenticator.authorize_url = 'https://broker.portier.io/auth'
c.GenericOAuthenticator.token_url = 'https://broker.portier.io/token'
c.GenericOAuthenticator.username_key = 'email'
```