### PR TITLE
use importlib-metadata to load entrypoints for docs

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -4,6 +4,7 @@
 -e ./
 
 autodoc-traits
+importlib_metadata>=3.6; python_version < '3.10'
 myst-parser
 sphinx>=2
 sphinx-autobuild

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -64,7 +64,7 @@ def render_autodoc_modules():
     }
 
     # load Authenticator classes from entrypoints
-    for name, ep in authenticator_entrypoints:
+    for ep in authenticator_entrypoints:
         if ep.value and ep.value.startswith('oauthenticator.'):
             module_name, _, object_name = ep.value.partition(":")
             modules[module_name]['configurables'].append(object_name)

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -34,14 +34,15 @@ release = oauthenticator.__version__
 
 from collections import defaultdict
 
-import entrypoints
+if sys.version_info < (3, 10):
+    from importlib_metadata import entry_points
+else:
+    from importlib.metadata import entry_points
 import jinja2
 
 
 def render_autodoc_modules():
-    authenticator_entrypoints = entrypoints.get_group_named(
-        "jupyterhub.authenticators"
-    ).values()
+    authenticator_entrypoints = entry_points(group="jupyterhub.authenticators")
 
     api = os.path.join(source, "api")
     api_gen = os.path.join(api, "gen")
@@ -63,9 +64,10 @@ def render_autodoc_modules():
     }
 
     # load Authenticator classes from entrypoints
-    for ep in authenticator_entrypoints:
-        if ep.module_name and ep.module_name.startswith('oauthenticator.'):
-            modules[ep.module_name]['configurables'].append(ep.object_name)
+    for name, ep in authenticator_entrypoints:
+        if ep.value and ep.value.startswith('oauthenticator.'):
+            module_name, _, object_name = ep.value.partition(":")
+            modules[module_name]['configurables'].append(object_name)
 
     with open(os.path.join(api, "authenticator.rst.tpl")) as f:
         tpl = jinja2.Template(f.read())


### PR DESCRIPTION
should get docs building again

docs had unexpressed direct dependency on entrypoints, which jupyterhub no longer depends on