### PR TITLE
[GitLab] possible fix to #545 : unionize allowed lists in GitLab Oauth

### DIFF
--- a/oauthenticator/gitlab.py
+++ b/oauthenticator/gitlab.py
@@ -179,12 +179,11 @@ class GitLabOAuthenticator(OAuthenticator):
 
         no_config_specified = not (is_group_specified or is_project_id_specified)
 
-        if (
-            (is_group_specified and user_in_group)
-            or (is_project_id_specified and user_in_project)
+        if (is_group_specified and user_in_group) or (
+            is_project_id_specified and user_in_project
         ):
-              self.allowed_users.add(username)
-        
+            self.allowed_users.add(username)
+
         if (
             (is_group_specified and user_in_group)
             or (is_project_id_specified and user_in_project)

--- a/oauthenticator/gitlab.py
+++ b/oauthenticator/gitlab.py
@@ -182,9 +182,14 @@ class GitLabOAuthenticator(OAuthenticator):
         if (
             (is_group_specified and user_in_group)
             or (is_project_id_specified and user_in_project)
+        ):
+              self.allowed_users.add(username)
+        
+        if (
+            (is_group_specified and user_in_group)
+            or (is_project_id_specified and user_in_project)
             or no_config_specified
         ):
-            self.allowed_users.add(username)
             return {
                 'name': username,
                 'auth_state': {'access_token': access_token, 'gitlab_user': resp_json},

--- a/oauthenticator/gitlab.py
+++ b/oauthenticator/gitlab.py
@@ -184,6 +184,7 @@ class GitLabOAuthenticator(OAuthenticator):
             or (is_project_id_specified and user_in_project)
             or no_config_specified
         ):
+            self.allowed_users.add(username)
             return {
                 'name': username,
                 'auth_state': {'access_token': access_token, 'gitlab_user': resp_json},


### PR DESCRIPTION
This is a fix issue #545 : it adds the username to the set of allowed_users if it passes the allowed_gitlab_groups or the allowed_projects_ids . 

I am not sure it is a good practice to edit the allowed_users set while in an async function, so I let the maintainers of oauthenticator review that solution, but it is working as expected when tested on my side.