### PR TITLE
maint: drop support for python 3.6

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -34,11 +34,11 @@ jobs:
       fail-fast: false
       matrix:
         python:
-          - "3.6"
           - "3.7"
           - "3.8"
           - "3.9"
           - "3.10"
+          - "3.11"
         include:
           - python: "3.9"
             oldest_dependencies: oldest_dependencies

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -15,7 +15,7 @@ repos:
     hooks:
       - id: pyupgrade
         args:
-          - --py36-plus
+          - --py37-plus
 
   # Autoformat: Python code
   - repo: https://github.com/PyCQA/autoflake

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,7 +26,6 @@ skip-string-normalization = true
 # target-version should be all supported versions, see
 # https://github.com/psf/black/issues/751#issuecomment-473066811
 target_version = [
-    "py36",
     "py37",
     "py38",
     "py39",

--- a/setup.py
+++ b/setup.py
@@ -47,7 +47,7 @@ setup_args = dict(
     license="BSD",
     platforms="Linux, Mac OS X",
     keywords=['Interactive', 'Interpreter', 'Shell', 'Web'],
-    python_requires=">=3.6",
+    python_requires=">=3.7",
     include_package_data=True,
     entry_points={
         'jupyterhub.authenticators': [


### PR DESCRIPTION
I don't think we need to call it breaking to drop support for the python version 3.6 as its reached end of life, but I'm not sure.