### PR TITLE
ci: add dependabot for github actions and update misc versions in workflows

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -1,0 +1,16 @@
+# dependabot.yaml reference: https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file
+#
+# Notes:
+# - Status and logs from dependabot are provided at
+#   https://github.com/jupyterhub/oauthenticator/network/updates.
+# - YAML anchors are not supported here or in GitHub Workflows.
+#
+version: 2
+updates:
+  # Maintain dependencies in our GitHub Workflows
+  - package-ecosystem: github-actions
+    directory: "/"
+    schedule:
+      interval: monthly
+      time: "05:00"
+      timezone: "Etc/UTC"

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -24,12 +24,12 @@ on:
 
 jobs:
   build-release:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-python@v2
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v4
         with:
-          python-version: 3.8
+          python-version: "3.10"
 
       - name: install build package
         run: |
@@ -43,7 +43,7 @@ jobs:
           ls -l dist
 
       - name: publish to pypi
-        uses: pypa/gh-action-pypi-publish@v1.4.1
+        uses: pypa/gh-action-pypi-publish@v1.6.4
         if: startsWith(github.ref, 'refs/tags/')
         with:
           user: __token__

--- a/.github/workflows/test-docs.yaml
+++ b/.github/workflows/test-docs.yaml
@@ -22,10 +22,12 @@ on:
 
 jobs:
   linkcheck:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v3
-      - uses: actions/setup-python@v3
+      - uses: actions/setup-python@v4
+        with:
+          python-version: "3.10"
 
       - name: Install deps
         run: pip install -r docs/requirements.txt

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -26,7 +26,7 @@ env:
 
 jobs:
   test:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     timeout-minutes: 10
 
     strategy:
@@ -44,8 +44,8 @@ jobs:
             oldest_dependencies: oldest_dependencies
 
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-python@v2
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v4
         with:
           python-version: "${{ matrix.python }}"
 

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -5,9 +5,9 @@
 version: 2
 
 build:
-  os: ubuntu-20.04
+  os: ubuntu-22.04
   tools:
-    python: "3.9"
+    python: "3.10"
 
 sphinx:
   configuration: docs/source/conf.py


### PR DESCRIPTION
I'm adding the label `ci` (Continuous integration) as this is changes related to _running tests_ etc, not even development of the tests themselves. If looking for a bug in the actual software, one should be able to dismiss that it has been introduced a bug because this PR is solely related to `ci` stuff.

With dependabot (an official github service) setup like this, it will open PRs for us when versions are outdated once a month. It won't update all versions I've updated in this PR (not ubuntu version or python version), but it will update all referenced github action's versions (`actions/checkout@v2` -> `@v3`). For example https://github.com/jupyterhub/jupyterhub/pull/4300.

Typically we have configured dependabot to provide weekly updates to github actions, but I figured we should go with monthly and will seek agreement about that in todays JupyterHub team meeting as well.