### PR TITLE
[AzureAD] Add an implementation for `Authenticator.manage_groups=True`

### DIFF
--- a/docs/source/tutorials/provider-specific-setup/providers/azuread.md
+++ b/docs/source/tutorials/provider-specific-setup/providers/azuread.md
@@ -53,3 +53,22 @@
 1. See `run.sh` for an [example](https://github.com/jupyterhub/oauthenticator/tree/main/examples/azuread)
 
 1. [Source Code](https://github.com/jupyterhub/oauthenticator/blob/HEAD/oauthenticator/azuread.py)
+
+## Loading user groups
+
+The `AzureAdOAuthenticator` can load the group-membership of users from the access token.
+This is done by setting the `AzureAdOAuthenticator.groups_claim` to the name of the claim that contains the
+group-membership.
+
+```python
+import os
+from oauthenticator.azuread import AzureAdOAuthenticator
+
+c.JupyterHub.authenticator_class = AzureAdOAuthenticator
+
+# {...} other settings (see above)
+
+c.AzureAdOAuthenticator.user_groups_claim = 'groups'
+```
+
+This requires Azure AD to be configured to include the group-membership in the access token.

--- a/oauthenticator/azuread.py
+++ b/oauthenticator/azuread.py
@@ -20,10 +20,11 @@ class AzureAdOAuthenticator(OAuthenticator):
     tenant_id = Unicode(config=True, help="The Azure Active Directory Tenant ID")
 
     user_auth_state_key = "user"
+    username_claim = "name"
 
-    @default("username_claim")
-    def _username_claim_default(self):
-        return "name"
+    user_groups_claim = Unicode(
+        "", config=True, help="Name of claim containing user group memberships"
+    )
 
     @default('tenant_id')
     def _tenant_id_default(self):
@@ -36,6 +37,12 @@ class AzureAdOAuthenticator(OAuthenticator):
     @default("token_url")
     def _token_url_default(self):
         return f"https://login.microsoftonline.com/{self.tenant_id}/oauth2/token"
+
+    def build_auth_state_dict(self, token_info, user_info):
+        auth_state = super().build_auth_state_dict(token_info, user_info)
+        auth_state["groups"] = token_info.get(self.user_groups_claim)
+
+        return auth_state
 
     async def token_to_user(self, token_info):
         id_token = token_info['id_token']

--- a/oauthenticator/azuread.py
+++ b/oauthenticator/azuread.py
@@ -25,13 +25,12 @@ class AzureAdOAuthenticator(OAuthenticator):
         "", config=True, help="Name of claim containing user group memberships"
     )
 
-    @default("username_claim")
-    def _username_claim_default(self):
-        return "name"
-
     @default('tenant_id')
     def _tenant_id_default(self):
         return os.environ.get('AAD_TENANT_ID', '')
+    @default('username_claim')
+    def _username_claim_default(self):
+        return 'name'
 
     @default("authorize_url")
     def _authorize_url_default(self):

--- a/oauthenticator/azuread.py
+++ b/oauthenticator/azuread.py
@@ -28,6 +28,7 @@ class AzureAdOAuthenticator(OAuthenticator):
     @default('tenant_id')
     def _tenant_id_default(self):
         return os.environ.get('AAD_TENANT_ID', '')
+
     @default('username_claim')
     def _username_claim_default(self):
         return 'name'
@@ -44,7 +45,8 @@ class AzureAdOAuthenticator(OAuthenticator):
         auth_model = await super().update_auth_model(auth_model, **kwargs)
 
         user_info = auth_model["auth_state"][self.user_auth_state_key]
-        auth_model["groups"] = user_info.get(self.user_groups_claim)
+        if self.user_groups_claim:
+            auth_model["groups"] = user_info.get(self.user_groups_claim)
 
         return auth_model
 

--- a/oauthenticator/azuread.py
+++ b/oauthenticator/azuread.py
@@ -20,11 +20,14 @@ class AzureAdOAuthenticator(OAuthenticator):
     tenant_id = Unicode(config=True, help="The Azure Active Directory Tenant ID")
 
     user_auth_state_key = "user"
-    username_claim = "name"
 
     user_groups_claim = Unicode(
         "", config=True, help="Name of claim containing user group memberships"
     )
+
+    @default("username_claim")
+    def _username_claim_default(self):
+        return "name"
 
     @default('tenant_id')
     def _tenant_id_default(self):
@@ -38,11 +41,13 @@ class AzureAdOAuthenticator(OAuthenticator):
     def _token_url_default(self):
         return f"https://login.microsoftonline.com/{self.tenant_id}/oauth2/token"
 
-    def build_auth_state_dict(self, token_info, user_info):
-        auth_state = super().build_auth_state_dict(token_info, user_info)
-        auth_state["groups"] = token_info.get(self.user_groups_claim)
+    async def update_auth_model(self, auth_model, **kwargs):
+        auth_model = await super().update_auth_model(auth_model, **kwargs)
 
-        return auth_state
+        user_info = auth_model["auth_state"][self.user_auth_state_key]
+        auth_model["groups"] = user_info.get(self.user_groups_claim)
+
+        return auth_model
 
     async def token_to_user(self, token_info):
         id_token = token_info['id_token']


### PR DESCRIPTION
Added support for external user group management to Azure AD authenticator.

This is a long overdue companion-PR to this PR in the jupyterhub-repo: https://github.com/jupyterhub/jupyterhub/pull/3548

This is a rework of the following PR: https://github.com/jupyterhub/oauthenticator/pull/448