### PR TITLE
Add missing requirements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,5 @@ jupyterhub>=1.2
 requests
 # ruamel.yaml is used to read and write .yaml files.
 ruamel.yaml
+tornado
+traitlets


### PR DESCRIPTION
These are transitively installed via JupyterHub, but they're also directly imported.

We could optionally set a minimum of traitlets 5, and remove https://github.com/jupyterhub/oauthenticator/blob/15.1.0/oauthenticator/traitlets.py since Callable is defined in 5+