### PR TITLE
[All] Add `http_request_kwargs` config option

### DIFF
--- a/docs/source/topic/google.md
+++ b/docs/source/topic/google.md
@@ -27,7 +27,7 @@ and give it read only access to users and groups.
 3. The **Service account permissions (optional)** section that follows is not required. Click **Continue**.
 4. On the **Grant users access to this service account** screen, scroll down to the **Create key** section. Click add (`+`) **Create key**.
 5. n the side panel that appears, select the format for your key: **JSON**
-6. Click **Create**. Your new public/private key pair is generated and downloaded to your machine; it serves as the only copy of this key. For information on how to store it securely, see [Managing service account keys](https://cloud.google.com/iam/docs/understanding-service-accounts#managing_service_accounts).
+6. Click **Create**. Your new public/private key pair is generated and downloaded to your machine; it serves as the only copy of this key. For information on how to store it securely, see [Managing service account keys](https://cloud.google.com/iam/docs/understanding-service-accounts).
 7. Click **Close** on the **Private key saved to your computer** dialog, then click **Done** to return to the table of your service accounts.
 8. Locate the newly-created service account in the table. Under `Actions`, click then **Edit**.
 9. In the service account details, click 🔽 **Show domain-wide delegation**, then ensure the **Enable G Suite Domain-wide Delegation** checkbox is checked.

--- a/oauthenticator/bitbucket.py
+++ b/oauthenticator/bitbucket.py
@@ -2,7 +2,6 @@
 Custom Authenticator to use Bitbucket OAuth with JupyterHub
 """
 from jupyterhub.auth import LocalAuthenticator
-from tornado.httpclient import HTTPRequest
 from tornado.httputil import url_concat
 from traitlets import Set, default
 
@@ -68,8 +67,7 @@ class BitbucketOAuthenticator(OAuthenticator):
             "https://api.bitbucket.org/2.0/workspaces", {'role': 'member'}
         )
         while next_page:
-            req = HTTPRequest(next_page, method="GET", headers=headers)
-            resp_json = await self.fetch(req)
+            resp_json = await self.httpfetch(next_page, method="GET", headers=headers)
             next_page = resp_json.get('next', None)
 
             user_teams = {entry["name"] for entry in resp_json["values"]}

--- a/oauthenticator/gitlab.py
+++ b/oauthenticator/gitlab.py
@@ -160,13 +160,12 @@ class GitLabOAuthenticator(OAuthenticator):
 
     async def _get_gitlab_version(self, access_token):
         url = f"{self.gitlab_api}/version"
-        req = HTTPRequest(
+        resp_json = await self.httpfetch(
             url,
             method="GET",
             headers=_api_headers(access_token),
             validate_cert=self.validate_server_cert,
         )
-        resp_json = await self.fetch(req)
         version_strings = resp_json['version'].split('-')[0].split('.')[:3]
         version_ints = list(map(int, version_strings))
         return version_ints
@@ -183,11 +182,15 @@ class GitLabOAuthenticator(OAuthenticator):
             )
             req = HTTPRequest(
                 url,
+            )
+            resp = await self.httpfetch(
+                url,
+                parse_json=False,
+                raise_error=False,
                 method="GET",
                 headers=headers,
                 validate_cert=self.validate_server_cert,
             )
-            resp = await self.fetch(req, raise_error=False, parse_json=False)
             if resp.code == 200:
                 return True  # user _is_ in group
         return False
@@ -202,13 +205,13 @@ class GitLabOAuthenticator(OAuthenticator):
                 self.member_api_variant,
                 user_id,
             )
-            req = HTTPRequest(
+            resp_json = await self.httpfetch(
                 url,
+                raise_error=False,
                 method="GET",
                 headers=headers,
                 validate_cert=self.validate_server_cert,
             )
-            resp_json = await self.fetch(req, raise_error=False)
             if resp_json:
                 access_level = resp_json.get('access_level', 0)
 

--- a/oauthenticator/tests/mocks.py
+++ b/oauthenticator/tests/mocks.py
@@ -33,7 +33,7 @@ class MockAsyncHTTPClient(SimpleAsyncHTTPClient):
 
         Args:
             host (str): the host to mock (e.g. 'api.github.com')
-            paths (list(str|regex, callable)): a list of paths (or regexps for paths)
+            paths (list[(str|regex, callable)]): a list of paths (or regexps for paths)
                 and callables to be called for those paths.
                 The mock handlers will receive the request as their only argument.
 
@@ -47,7 +47,7 @@ class MockAsyncHTTPClient(SimpleAsyncHTTPClient):
         Example::
 
             client.add_host('api.github.com', [
-                ('/user': lambda request: {'login': 'name'})
+                ('/user', lambda request: {'login': 'name'})
             ])
         """
         self.hosts[host] = paths


### PR DESCRIPTION
Adds a new config property `http_request_kwargs` that allows additional keyword args to be passed by default to `tornado.HTTPRequest`.

This can for example be used to pass HTTP proxy configuration.

Closes https://github.com/jupyterhub/oauthenticator/issues/217
Closes https://github.com/jupyterhub/oauthenticator/issues/403