### PR TITLE
feat: Implement `OAuthenticator.refresh_user`

### DIFF
--- a/oauthenticator/oauth2.py
+++ b/oauthenticator/oauth2.py
@@ -1018,7 +1018,7 @@ class OAuthenticator(Authenticator):
         # the client_id and client_secret should not be included in the access token request params
         # when basic authentication is used
         # ref: https://www.rfc-editor.org/rfc/rfc6749#section-2.3.1
-        if self.basic_auth:
+        if not self.basic_auth:
             params.update(
                 [("client_id", self.client_id), ("client_secret", self.client_secret)]
             )

--- a/oauthenticator/oauth2.py
+++ b/oauthenticator/oauth2.py
@@ -16,7 +16,6 @@ from urllib.parse import quote, urlencode, urlparse, urlunparse
 
 import jwt
 from jupyterhub.auth import Authenticator
-from jupyterhub.crypto import EncryptionUnavailable, InvalidToken, decrypt
 from jupyterhub.handlers import BaseHandler, LogoutHandler
 from jupyterhub.utils import url_path_join
 from tornado import web
@@ -987,31 +986,6 @@ class OAuthenticator(Authenticator):
             raise ValueError(message)
 
         return username
-
-    # Originally a GoogleOAuthenticator only feature
-    async def get_prev_refresh_token(self, handler, username):
-        """
-        Retrieves the `refresh_token` from previous encrypted auth state.
-        Called by the :meth:`oauthenticator.OAuthenticator.authenticate`
-        """
-        user = handler.find_user(username)
-        if not user or not user.encrypted_auth_state:
-            return
-
-        self.log.debug(
-            "Encrypted_auth_state was found, will try to decrypt and pull refresh_token from it..."
-        )
-
-        try:
-            encrypted = user.encrypted_auth_state
-            auth_state = await decrypt(encrypted)
-
-            return auth_state.get("refresh_token")
-        except (ValueError, InvalidToken, EncryptionUnavailable) as e:
-            self.log.warning(
-                f"Failed to retrieve encrypted auth_state for {username}. Error was {e}.",
-            )
-            return
 
     def build_access_tokens_request_params(self, handler, data=None):
         """

--- a/oauthenticator/oauth2.py
+++ b/oauthenticator/oauth2.py
@@ -1030,7 +1030,8 @@ class OAuthenticator(Authenticator):
         Makes a "POST" request to `self.token_url`, with the parameters received as argument.
 
         Returns:
-            the JSON response to the `token_url` the request.
+            the JSON response to the `token_url` the request as described in
+            https://www.rfc-editor.org/rfc/rfc6749#section-5.1
 
         Called by the :meth:`oauthenticator.OAuthenticator.authenticate`
         """

--- a/oauthenticator/oauth2.py
+++ b/oauthenticator/oauth2.py
@@ -698,8 +698,7 @@ class OAuthenticator(Authenticator):
 
     access_token_expiration_env = "OAUTH_ACCESS_TOKEN_EXPIRATION"
     access_token_expiration = Unicode(
-        config=True,
-        help="""Default expiration, in seconds, of the access token."""
+        config=True, help="""Default expiration, in seconds, of the access token."""
     )
 
     def _access_token_expiration_default(self):
@@ -1307,7 +1306,9 @@ class OAuthenticator(Authenticator):
             )
             return True
 
-        refresh_token_params = self.build_refresh_token_request_params(auth_state['refresh_token'])
+        refresh_token_params = self.build_refresh_token_request_params(
+            auth_state['refresh_token']
+        )
         return await self._oauth_call(handler, refresh_token_params)
 
     async def _oauth_call(self, handler, params, data=None):

--- a/oauthenticator/oauth2.py
+++ b/oauthenticator/oauth2.py
@@ -1281,7 +1281,7 @@ class OAuthenticator(Authenticator):
         # build the parameters to be used in the request exchanging the oauth code for the access token
         access_token_params = self.build_access_tokens_request_params(handler, data)
         # call the oauth endpoints
-        return await self._oauth_call(handler, access_token_params)
+        return await self._oauth_call(handler, access_token_params, **kwargs)
 
     async def refresh_user(self, user, handler=None, **kwargs):
         '''
@@ -1309,9 +1309,9 @@ class OAuthenticator(Authenticator):
         refresh_token_params = self.build_refresh_token_request_params(
             auth_state['refresh_token']
         )
-        return await self._oauth_call(handler, refresh_token_params)
+        return await self._oauth_call(handler, refresh_token_params, **kwargs)
 
-    async def _oauth_call(self, handler, params, data=None):
+    async def _oauth_call(self, handler, params, data=None, **kwargs):
         """
         Common logic shared by authenticate() and refresh_user()
         """

--- a/oauthenticator/oauth2.py
+++ b/oauthenticator/oauth2.py
@@ -270,7 +270,7 @@ class OAuthenticator(Authenticator):
     - Override the constant `user_auth_state_key`
     - Override various config's default values, such as
       `authorize_url`, `token_url`, `userdata_url`, and `login_service`.
-    - Override various methods called by the `authenticate` method, which
+    - Override various methods called by :meth:`authenticate`, which
       subclasses should not override.
     - Override handler classes such as `login_handler`, `callback_handler`, and
       `logout_handler`.
@@ -919,7 +919,8 @@ class OAuthenticator(Authenticator):
     def build_userdata_request_headers(self, access_token, token_type):
         """
         Builds and returns the headers to be used in the userdata request.
-        Called by the :meth:`oauthenticator.OAuthenticator.token_to_user`
+
+        Called by :meth:`.token_to_user`.
         """
 
         # token_type is case-insensitive, but the headers are case-sensitive
@@ -937,7 +938,8 @@ class OAuthenticator(Authenticator):
     def build_token_info_request_headers(self):
         """
         Builds and returns the headers to be used in the access token request.
-        Called by the :meth:`oauthenticator.OAuthenticator.get_token_info`.
+
+        Called by :meth:`.get_token_info`.
 
         The Content-Type header is specified by the OAuth 2.0 RFC in
         https://www.rfc-editor.org/rfc/rfc6749#section-4.1.3. utf-8 is also
@@ -971,7 +973,7 @@ class OAuthenticator(Authenticator):
         Returns:
             user_info["self.username_claim"] or raises an error if such value isn't found.
 
-        Called by the :meth:`oauthenticator.OAuthenticator.authenticate`
+        Called by :meth:`.authenticate` and :meth:`.refresh_user`.
         """
 
         if callable(self.username_claim):
@@ -991,7 +993,8 @@ class OAuthenticator(Authenticator):
         """
         Builds the parameters that should be passed to the URL request
         that exchanges the OAuth code for the Access Token.
-        Called by the :meth:`oauthenticator.OAuthenticator.authenticate`.
+
+        Called by :meth:`.authenticate`.
         """
         code = handler.get_argument("code")
         if not code:
@@ -1033,7 +1036,7 @@ class OAuthenticator(Authenticator):
         Builds the parameters that should be passed to the URL request
         to renew the Access Token based on the Refresh Token
 
-        Called by the :meth:`oauthenticator.OAuthenticator.refresh_user`.
+        Called by :meth:`.refresh_user`.
         """
         params = {
             "grant_type": "refresh_token",
@@ -1057,7 +1060,7 @@ class OAuthenticator(Authenticator):
             the JSON response to the `token_url` the request as described in
             https://www.rfc-editor.org/rfc/rfc6749#section-5.1
 
-        Called by the :meth:`oauthenticator.OAuthenticator.authenticate`
+        Called by :meth:`.authenticate` and :meth:`.refresh_user`.
         """
 
         token_info = await self.httpfetch(
@@ -1081,9 +1084,9 @@ class OAuthenticator(Authenticator):
     async def token_to_user(self, token_info):
         """
         Determines who the logged-in user by sending a "GET" request to
-        :data:`oauthenticator.OAuthenticator.userdata_url` using the `access_token`.
+        :attr:`.userdata_url` using the `access_token`.
 
-        If :data:`oauthenticator.OAuthenticator.userdata_from_id_token` is set then
+        If :attr:`.userdata_from_id_token` is set then
         extracts the corresponding info from an `id_token` instead.
 
         Args:
@@ -1092,7 +1095,7 @@ class OAuthenticator(Authenticator):
         Returns:
             the JSON response to the `userdata_url` request.
 
-        Called by the :meth:`oauthenticator.OAuthenticator.authenticate`
+        Called by :meth:`.authenticate` and :meth:`.refresh_user`.
         """
         if self.userdata_from_id_token:
             # Use id token instead of exchanging access token with userinfo endpoint.
@@ -1158,7 +1161,7 @@ class OAuthenticator(Authenticator):
                 - "token_response": the full token_info response
                 - self.user_auth_state_key: the full user_info response
 
-        Called by the :meth:`oauthenticator.OAuthenticator.authenticate`
+        Called by :meth:`.authenticate` and :meth:`.refresh_user`.
 
         .. versionchanged:: 17.0
             This method may be async.
@@ -1229,9 +1232,9 @@ class OAuthenticator(Authenticator):
             - `admin`: the admin status (True/False/None), where None means it
                 should be unchanged.
             - `auth_state`: the auth state dictionary,
-              returned by :meth:`oauthenticator.OAuthenticator.build_auth_state_dict`
+              returned by :meth:`.build_auth_state_dict`
 
-        Called by the :meth:`oauthenticator.OAuthenticator.authenticate`
+        Called by :meth:`.authenticate` and :meth:`.refresh_user`.
         """
         # NOTE: this base implementation should _not_ be updated to do anything
         # subclasses should have full control without calling super()
@@ -1379,7 +1382,9 @@ class OAuthenticator(Authenticator):
 
     async def _token_to_auth_model(self, token_info):
         """
-        Common logic shared by authenticate() and refresh_user()
+        Turn a token into the user's `auth_model` to be returned by :meth:`.authenticate`.
+
+        Common logic shared by :meth:`.authenticate` and :meth:`.refresh_user`.
         """
 
         # use the access_token to get userdata info

--- a/oauthenticator/oauth2.py
+++ b/oauthenticator/oauth2.py
@@ -703,7 +703,7 @@ class OAuthenticator(Authenticator):
         If the `expires_in` field is  omitted in the OAuth 2.0 token response
         then this value will be the default expiration, in seconds, of the
         access token.
-        """
+        """,
     )
 
     validate_server_cert_env = "OAUTH_TLS_VERIFY"

--- a/oauthenticator/tests/test_generic.py
+++ b/oauthenticator/tests/test_generic.py
@@ -15,14 +15,15 @@ client_id = "jupyterhub-oauth-client"
 
 def user_model(username, **kwargs):
     """Return a user model"""
-    return {
+    model = {
         "username": username,
         "aud": client_id,
         "sub": "oauth2|cilogon|http://cilogon.org/servera/users/43431",
         "scope": "basic",
         "groups": ["group1"],
-        **kwargs,
     }
+    model.update(kwargs)
+    return model
 
 
 @fixture(params=["id_token", "userdata_url"])
@@ -522,10 +523,13 @@ class MockUser:
 async def test_refresh_user(get_authenticator, generic_client, enable_refresh_tokens):
     generic_client.enable_refresh_tokens = enable_refresh_tokens
     authenticator = get_authenticator(allowed_users={"user1"})
-    handled_user_model = user_model("user1", permissions={"groups": ["super_user"]})
-    handler = generic_client.handler_for_user(handled_user_model)
+    authenticator.manage_groups = True
+    authenticator.auth_state_groups_key = "oauth_user.groups"
+    oauth_userinfo = user_model("user1", groups=["round1"])
+    handler = generic_client.handler_for_user(oauth_userinfo)
     auth_model = await authenticator.get_authenticated_user(handler, None)
     auth_state = auth_model["auth_state"]
+    assert auth_model["groups"] == ["round1"]
     if enable_refresh_tokens:
         assert "refresh_token" in auth_state
         assert "refresh_token" in auth_state["token_response"]
@@ -551,26 +555,39 @@ async def test_refresh_user(get_authenticator, generic_client, enable_refresh_to
     assert refreshed is False
 
     # case: actually refresh
+    oauth_userinfo["groups"] = ["refreshed"]
     refreshed = await authenticator.refresh_user(user, handler)
-    assert isinstance(refreshed, dict)
+    assert refreshed
     assert refreshed["name"] == auth_model["name"]
+    assert refreshed["groups"] == ["refreshed"]
     refreshed_state = refreshed["auth_state"]
     assert "access_token" in refreshed_state
-    if enable_refresh_tokens:
-        # refresh_token refreshed the access token
-        assert refreshed_state["access_token"] != auth_state["access_token"]
-        assert refreshed_state["refresh_token"]
-    else:
-        # refresh with access token succeeds, keeps access token unchanged
-        assert refreshed_state["access_token"] == auth_state["access_token"]
+    # refresh with access token succeeds, keeps tokens unchanged
+    assert refreshed_state.get("refresh_token") == auth_state.get("refresh_token")
+    assert refreshed_state["access_token"] == auth_state["access_token"]
 
-    # case: token used for refresh is no longer valid
-    user = MockUser(refreshed)
+    # case: access token is no longer valid, triggers refresh
+    oauth_userinfo["groups"] = ["token_refreshed"]
     generic_client.access_tokens.pop(refreshed_state["access_token"])
-    if enable_refresh_tokens:
-        generic_client.refresh_tokens.pop(refreshed_state["refresh_token"])
     refreshed = await authenticator.refresh_user(user, handler)
-    assert refreshed is False
+    if enable_refresh_tokens:
+        # access_token refreshed
+        assert refreshed
+        refreshed_state = refreshed["auth_state"]
+        assert (
+            refreshed_state["access_token"] != auth_model["auth_state"]["access_token"]
+        )
+        assert refreshed["groups"] == ["token_refreshed"]
+    else:
+        assert refreshed is False
+
+    if enable_refresh_tokens:
+        # case: token used for refresh is no longer valid
+        user = MockUser(refreshed)
+        generic_client.access_tokens.pop(refreshed_state["access_token"])
+        generic_client.refresh_tokens.pop(refreshed_state["refresh_token"])
+        refreshed = await authenticator.refresh_user(user, handler)
+        assert refreshed is False
 
 
 @mark.parametrize(

--- a/oauthenticator/tests/test_github.py
+++ b/oauthenticator/tests/test_github.py
@@ -141,7 +141,7 @@ async def test_github(
         assert user_info == handled_user_model
         assert auth_model["name"] == user_info[authenticator.username_claim]
     else:
-        assert auth_model == None
+        assert auth_model is None
 
 
 def make_link_header(urlinfo, page):


### PR DESCRIPTION
This MR aims to implement the `refresh_user()`'s `Authenticator` method in `OAuthenticator` class.

Following #398 [comment](https://github.com/jupyterhub/oauthenticator/issues/398#issuecomment-1400319340).

At the time of writing, nothing has been tested, and provider specific code would be needed, as the OAuth2 spec does not force the `expires_in` field in the `access_token` response body.

I may not have bandwidth soon to work again on this, feel free to take the lead !

closes #475 
closes #490 
closes #398 