### PR TITLE
maint: declare optional dependencies for version constraints

### DIFF
--- a/docs/source/tutorials/provider-specific-setup/providers/azuread.md
+++ b/docs/source/tutorials/provider-specific-setup/providers/azuread.md
@@ -1,9 +1,9 @@
 # Azure AD Setup
 
-1. Install `PyJWT>=2`
+1. Install oauthenticator with required dependency
 
    ```bash
-   pip3 install PyJWT
+   pip3 install "oauthenticator[azuread]"
    ```
 
 1. Set the `AAD_TENANT_ID` environment variable

--- a/setup.py
+++ b/setup.py
@@ -101,6 +101,8 @@ with open('requirements.txt') as f:
 
 setup_args['extras_require'] = {
     'googlegroups': ['google-api-python-client', 'google-auth-oauthlib'],
+    'mediawiki': ['mwoauth>=0.3.8'],
+    'azuread': ['pyjwt>=2'],
 }
 
 


### PR DESCRIPTION
We have various requirements on the optional dependencies versions, but we have only declared those via documentation in the past. To resolve that, we now declare them explicitly instead.

Like this, subprojects like [z2jh doesn't have to list the optional dependencies separately as it does now](https://github.com/jupyterhub/zero-to-jupyterhub-k8s/blob/b88b1a2969eaec490e10ac956b745deb1e9588a3/images/hub/requirements.in#L22-L24), but can instead request `oauthenticator[azuread, mediawiki]` and things will work out with the correct version contraints.

If someone explicitly still installs `pyjwt` manually etc, things will still work out at least assuming they get a package of a compatible version.

---

Linkcheck failure unrelated