### PR TITLE
[All] Authorize `allowed_users`, `admin_users`, _or_ other allowed/admin groups

### DIFF
--- a/docs/source/how-to/example-oauthenticator.py
+++ b/docs/source/how-to/example-oauthenticator.py
@@ -88,9 +88,9 @@ class MyServiceOAuthenticator(OAuthenticator):
     # Updates `auth_model` dict if any fields have changed or additional information is available
     # or returns the unchanged `auth_model`.
     # Returns the model unchanged by default.
-    # Should be overridden to take into account  additional checks such as against group/admin/team membership.
+    # Should be overridden to take into account additional checks such as against group/admin/team membership.
     # if the OAuth provider has such a concept
-    async def update_auth_model(self, auth_model, **kwargs):
+    async def update_auth_model(self, username, auth_model):
         pass
 
 

--- a/docs/source/reference/changelog.md
+++ b/docs/source/reference/changelog.md
@@ -15,7 +15,7 @@ command line for details.
 - [Generic, Google] `GenericOAuthenticator.allowed_groups`,
   `GenericOAuthenticator.allowed_groups`
   `GoogleOAuthenticator.allowed_google_groups`, and
-  `GoogleOAuthenticatoradmin_google_groups` are now Set based configuration
+  `GoogleOAuthenticator.admin_google_groups` are now Set based configuration
   instead of List based configuration. It is still possible to set these with
   lists as as they are converted to sets automatically, but anyone reading and
   adding entries must now use set logic and not list logic.

--- a/docs/source/reference/changelog.md
+++ b/docs/source/reference/changelog.md
@@ -12,6 +12,9 @@ command line for details.
   `Authenticator.admin_users`, `Authenticator.allowed_users`, an Authenticator
   specific allowed team/group/organization, or declared in
   `JupyterHub.load_roles` or `JupyterHub.load_groups`.
+- [Google] If `GoogleOAuthenticator.admin_google_groups` is configured, users
+  logging in not explicitly there or in `Authenticator.admin_users` will get
+  their admin status revoked.
 - [Generic, Google] `GenericOAuthenticator.allowed_groups`,
   `GenericOAuthenticator.allowed_groups`
   `GoogleOAuthenticator.allowed_google_groups`, and
@@ -19,6 +22,7 @@ command line for details.
   instead of List based configuration. It is still possible to set these with
   lists as as they are converted to sets automatically, but anyone reading and
   adding entries must now use set logic and not list logic.
+- [Google] Authentication state's `google_groups` is now a set, not a list.
 
 (changelog:version-15)=
 

--- a/docs/source/reference/changelog.md
+++ b/docs/source/reference/changelog.md
@@ -6,6 +6,20 @@ command line for details.
 
 ## [Unreleased]
 
+### Breaking changes
+
+- [All] Users are now authorized based on *either* being part of
+  `Authenticator.admin_users`, `Authenticator.allowed_users`, an Authenticator
+  specific allowed team/group/organization, or declared in
+  `JupyterHub.load_roles` or `JupyterHub.load_groups`.
+- [Generic, Google] `GenericOAuthenticator.allowed_groups`,
+  `GenericOAuthenticator.allowed_groups`
+  `GoogleOAuthenticator.allowed_google_groups`, and
+  `GoogleOAuthenticatoradmin_google_groups` are now Set based configuration
+  instead of List based configuration. It is still possible to set these with
+  lists as as they are converted to sets automatically, but anyone reading and
+  adding entries must now use set logic and not list logic.
+
 (changelog:version-15)=
 
 ## 15.0

--- a/docs/source/reference/changelog.md
+++ b/docs/source/reference/changelog.md
@@ -8,7 +8,7 @@ command line for details.
 
 ### Breaking changes
 
-- [All] Users are now authorized based on *either* being part of
+- [All] Users are now authorized based on _either_ being part of
   `Authenticator.admin_users`, `Authenticator.allowed_users`, an Authenticator
   specific allowed team/group/organization, or declared in
   `JupyterHub.load_roles` or `JupyterHub.load_groups`.

--- a/oauthenticator/auth0.py
+++ b/oauthenticator/auth0.py
@@ -99,5 +99,4 @@ class Auth0OAuthenticator(OAuthenticator):
 
 
 class LocalAuth0OAuthenticator(LocalAuthenticator, Auth0OAuthenticator):
-
     """A version that mixes in local system user creation"""

--- a/oauthenticator/bitbucket.py
+++ b/oauthenticator/bitbucket.py
@@ -77,9 +77,8 @@ class BitbucketOAuthenticator(OAuthenticator):
         either part of `allowed_users` or `allowed_teams`, and not just those
         part of `allowed_users`.
         """
-        # Workaround situation when JupyterHub.load_roles or
-        # JupyterHub.load_groups is used to create a user, see discussion in
-        # https://github.com/jupyterhub/jupyterhub/issues/4461.
+        # A workaround for JupyterHub<=4.0.1, described in
+        # https://github.com/jupyterhub/oauthenticator/issues/621
         if auth_model is None:
             return True
 

--- a/oauthenticator/bitbucket.py
+++ b/oauthenticator/bitbucket.py
@@ -77,6 +77,12 @@ class BitbucketOAuthenticator(OAuthenticator):
         either part of `allowed_users` or `allowed_teams`, and not just those
         part of `allowed_users`.
         """
+        # Workaround situation when JupyterHub.load_roles or
+        # JupyterHub.load_groups is used to create a user, see discussion in
+        # https://github.com/jupyterhub/jupyterhub/issues/4461.
+        if auth_model is None:
+            return True
+
         # allow admin users recognized via admin_users or update_auth_model
         if auth_model["admin"]:
             return True

--- a/oauthenticator/bitbucket.py
+++ b/oauthenticator/bitbucket.py
@@ -58,17 +58,12 @@ class BitbucketOAuthenticator(OAuthenticator):
 
     async def update_auth_model(self, auth_model):
         """
-        Set the admin status based on finding the username in `admin_users` and
-        fetch user teams if `allowed_teams` is configured.
+        Fetch and store `user_teams` in auth state if `allowed_teams` is
+        configured.
         """
-        access_token = auth_model["auth_state"]["token_response"]["access_token"]
-        token_type = auth_model["auth_state"]["token_response"]["token_type"]
-
-        username = auth_model["name"]
-        if username in self.admin_users:
-            auth_model["admin"] = True
-
         if self.allowed_teams:
+            access_token = auth_model["auth_state"]["token_response"]["access_token"]
+            token_type = auth_model["auth_state"]["token_response"]["token_type"]
             user_teams = await self._fetch_user_teams(access_token, token_type)
             auth_model["auth_state"]["user_teams"] = user_teams
 

--- a/oauthenticator/bitbucket.py
+++ b/oauthenticator/bitbucket.py
@@ -69,7 +69,7 @@ class BitbucketOAuthenticator(OAuthenticator):
             auth_model["admin"] = True
 
         if self.allowed_teams:
-            user_teams = self._fetch_user_teams(access_token, token_type)
+            user_teams = await self._fetch_user_teams(access_token, token_type)
             auth_model["auth_state"]["user_teams"] = user_teams
 
         return auth_model

--- a/oauthenticator/cilogon.py
+++ b/oauthenticator/cilogon.py
@@ -326,9 +326,8 @@ class CILogonOAuthenticator(OAuthenticator):
         to be authorized if either is configured, otherwise all users are
         authorized.
         """
-        # Workaround situation when JupyterHub.load_roles or
-        # JupyterHub.load_groups is used to create a user, see discussion in
-        # https://github.com/jupyterhub/jupyterhub/issues/4461.
+        # A workaround for JupyterHub<=4.0.1, described in
+        # https://github.com/jupyterhub/oauthenticator/issues/621
         if auth_model is None:
             return True
 

--- a/oauthenticator/cilogon.py
+++ b/oauthenticator/cilogon.py
@@ -249,12 +249,11 @@ class CILogonOAuthenticator(OAuthenticator):
     )
 
     def user_info_to_username(self, user_info):
-        selected_idp = user_info["idp"]
-
         username_claims = [self.username_claim]
         if self.additional_username_claims:
             username_claims.extend(self.additional_username_claims)
         if self.allowed_idps:
+            selected_idp = user_info["idp"]
             # The username_claim which should be used for this idp
             username_claims = [
                 self.allowed_idps[selected_idp]["username_derivation"]["username_claim"]

--- a/oauthenticator/cilogon.py
+++ b/oauthenticator/cilogon.py
@@ -308,25 +308,20 @@ class CILogonOAuthenticator(OAuthenticator):
 
     async def check_allowed(self, username, auth_model):
         """
-        Returns True for users allowed to be authorized, raises errors for users
+        Returns True for authorized users, raises errors for users
         denied authorization.
 
-        Overrides the OAuthenticator.check_allowed implementation to allow users
-        either part of `allowed_users` or `allowed_idps`, and not just those
-        part of `allowed_users`.
+        Overrides the `OAuthenticator.check_allowed` implementation to only allow users
+        logging in using a provider that is  part of `allowed_idps`.
+        Following this, the user must either be part of `allowed_users` or `allowed_domains`
+        to be authorized if either is configured, otherwise all users are
+        authorized.
         """
+
         # allow admin users recognized via admin_users or update_auth_model
         if auth_model["admin"]:
             return True
 
-        # FIXME: Erik and Georgiana chatted and concluded that the user must be
-        #        part of allowed_idps no matter what, following that, the user
-        #        must either be part of allowed_users or allowed_domains to be
-        #        authorized if either is configured, and otherwise all users are
-        #        authorized.
-        #
-        #        Updated to reflect the discussion.
-        # TODO:  Validate the implementation
         if self.allowed_idps:
             user_info = auth_model["auth_state"][self.user_auth_state_key]
             selected_idp = user_info["idp"]
@@ -345,12 +340,6 @@ class CILogonOAuthenticator(OAuthenticator):
                     return True
 
                 if allowed_domains:
-                    # TODO:  broke apart
-                    #        user_info_to_username in multiple functions
-                    #        allowing us to get the username before the optional
-                    #        stripping operation and use it here.
-                    #        Validate implementation
-                    #
                     username_claims = self._get_final_username_claim_list(user_info)
                     username_with_domain = self._get_username_from_claim_list(
                         user_info, username_claims

--- a/oauthenticator/cilogon.py
+++ b/oauthenticator/cilogon.py
@@ -299,7 +299,7 @@ class CILogonOAuthenticator(OAuthenticator):
             action = username_derivation.get("action")
 
             if action == "strip_idp_domain":
-                username = username.split("@")[0]
+                username = username.split("@", 1)[0]
             elif action == "prefix":
                 prefix = username_derivation["prefix"]
                 username = f"{prefix}:{username}"
@@ -335,7 +335,7 @@ class CILogonOAuthenticator(OAuthenticator):
                     f"Trying to login from an identity provider that was not allowed {selected_idp}",
                 )
                 raise web.HTTPError(
-                    500,
+                    403,
                     "Trying to login using an identity provider that was not allowed",
                 )
 
@@ -355,7 +355,7 @@ class CILogonOAuthenticator(OAuthenticator):
                     username_with_domain = self._get_username_from_claim_list(
                         user_info, username_claims
                     )
-                    user_domain = username_with_domain.split("@")[1]
+                    user_domain = username_with_domain.split("@", 1)[1]
                     if user_domain in allowed_domains:
                         return True
                     else:

--- a/oauthenticator/cilogon.py
+++ b/oauthenticator/cilogon.py
@@ -360,7 +360,7 @@ class CILogonOAuthenticator(OAuthenticator):
                         return True
                     else:
                         raise web.HTTPError(
-                            500,
+                            403,
                             "Trying to login using a domain that was not allowed",
                         )
 

--- a/oauthenticator/cilogon.py
+++ b/oauthenticator/cilogon.py
@@ -326,6 +326,11 @@ class CILogonOAuthenticator(OAuthenticator):
         to be authorized if either is configured, otherwise all users are
         authorized.
         """
+        # Workaround situation when JupyterHub.load_roles or
+        # JupyterHub.load_groups is used to create a user, see discussion in
+        # https://github.com/jupyterhub/jupyterhub/issues/4461.
+        if auth_model is None:
+            return True
 
         # allow admin users recognized via admin_users or update_auth_model
         if auth_model["admin"]:

--- a/oauthenticator/cilogon.py
+++ b/oauthenticator/cilogon.py
@@ -298,15 +298,14 @@ class CILogonOAuthenticator(OAuthenticator):
         if auth_model["admin"]:
             return True
 
-        # FIXME: This needs to be thought over very carefully.
+        # FIXME: I chatted with Georgiana and we concluded that the user must be
+        #        part of allowed_idps no matter what, following that, the user
+        #        must either be part of allowed_users or allowed_domains to be
+        #        authorized if either is configured, and otherwise all users are
+        #        authorized.
         #
-        #        Is there or isn't there a commonly agreed "excepted behavior"
-        #        for when considering a combination of allowed_users,
-        #        allowed_idps, and allowed_idps allowed_domains?
+        #        The drafted implementation doesn't reflect this yet.
         #
-
-        # if allowed_users or allowed_idps is configured, we deny users not
-        # part of either
         if self.allowed_users or self.allowed_idps:
             user_info = auth_model["auth_state"][self.user_auth_state_key]
             selected_idp = user_info["idp"]

--- a/oauthenticator/generic.py
+++ b/oauthenticator/generic.py
@@ -105,6 +105,9 @@ class GenericOAuthenticator(OAuthenticator):
         - If claim_groups_key is a nested dictionary key like
           "permissions.groups", this function returns
           user_info["permissions"]["groups"].
+
+        Note that this method is introduced by GenericOAuthenticator and not
+        present in the base class.
         """
         if callable(self.claim_groups_key):
             return set(self.claim_groups_key(user_info))

--- a/oauthenticator/generic.py
+++ b/oauthenticator/generic.py
@@ -145,6 +145,12 @@ class GenericOAuthenticator(OAuthenticator):
         either part of `allowed_users` or `allowed_groups`, and not just those
         part of `allowed_users`.
         """
+        # Workaround situation when JupyterHub.load_roles or
+        # JupyterHub.load_groups is used to create a user, see discussion in
+        # https://github.com/jupyterhub/jupyterhub/issues/4461.
+        if auth_model is None:
+            return True
+
         # allow admin users recognized via admin_users or update_auth_model
         if auth_model["admin"]:
             return True

--- a/oauthenticator/generic.py
+++ b/oauthenticator/generic.py
@@ -121,16 +121,17 @@ class GenericOAuthenticator(OAuthenticator):
 
     async def update_auth_model(self, auth_model):
         """
-        Update admin status based on `admin_groups` if its configured.
+        Sets admin status to True or False if `admin_groups` is configured and
+        the user isn't part of `admin_users` or `admin_groups`. Note that
+        leaving it at None makes users able to retain an admin status while
+        setting it to False makes it be revoked.
         """
         if auth_model["admin"]:
+            # auth_model["admin"] being True means the user was in admin_users
             return auth_model
 
         if self.admin_groups:
-            # if admin_groups is configured and the user wasn't part of
-            # admin_users, we must set the admin status to True or False,
-            # otherwise removing a user from the admin_groups won't have an
-            # effect
+            # admin status should in this case be True or False, not None
             user_info = auth_model["auth_state"][self.user_auth_state_key]
             user_groups = self.get_user_groups(user_info)
             auth_model["admin"] = any(user_groups & self.admin_groups)
@@ -145,9 +146,8 @@ class GenericOAuthenticator(OAuthenticator):
         either part of `allowed_users` or `allowed_groups`, and not just those
         part of `allowed_users`.
         """
-        # Workaround situation when JupyterHub.load_roles or
-        # JupyterHub.load_groups is used to create a user, see discussion in
-        # https://github.com/jupyterhub/jupyterhub/issues/4461.
+        # A workaround for JupyterHub<=4.0.1, described in
+        # https://github.com/jupyterhub/oauthenticator/issues/621
         if auth_model is None:
             return True
 

--- a/oauthenticator/generic.py
+++ b/oauthenticator/generic.py
@@ -118,18 +118,17 @@ class GenericOAuthenticator(OAuthenticator):
 
     async def update_auth_model(self, auth_model):
         """
-        Set the admin status based on finding the username in `admin_users` or
-        finding a user group part of `admin_groups`.
+        Update admin status based on `admin_groups` if its configured.
         """
-        user_info = auth_model["auth_state"][self.user_auth_state_key]
+        if auth_model["admin"]:
+            return auth_model
 
-        username = auth_model["name"]
-        if username in self.admin_users:
-            auth_model["admin"] = True
-        elif self.admin_groups:
-            # if admin_groups is configured, we must either set or unset admin
-            # status and never leave it at None, otherwise removing a user from
-            # the admin_groups won't have an effect
+        if self.admin_groups:
+            # if admin_groups is configured and the user wasn't part of
+            # admin_users, we must set the admin status to True or False,
+            # otherwise removing a user from the admin_groups won't have an
+            # effect
+            user_info = auth_model["auth_state"][self.user_auth_state_key]
             user_groups = self.get_user_groups(user_info)
             auth_model["admin"] = any(user_groups & self.admin_groups)
 

--- a/oauthenticator/generic.py
+++ b/oauthenticator/generic.py
@@ -83,10 +83,6 @@ class GenericOAuthenticator(OAuthenticator):
             force_instance=True, defaults=dict(validate_cert=self.tls_verify)
         )
 
-    @staticmethod
-    def check_user_in_groups(member_groups, allowed_groups):
-        return bool(set(member_groups) & set(allowed_groups))
-
     def user_info_to_username(self, user_info):
         if callable(self.username_claim):
             username = self.username_claim(user_info)
@@ -131,7 +127,7 @@ class GenericOAuthenticator(OAuthenticator):
             if not groups:
                 return False
 
-            if not self.check_user_in_groups(groups, self.allowed_groups):
+            if not self.user_groups_in_allowed_groups(groups, self.allowed_groups):
                 return False
 
         return True

--- a/oauthenticator/generic.py
+++ b/oauthenticator/generic.py
@@ -116,7 +116,7 @@ class GenericOAuthenticator(OAuthenticator):
 
     async def user_is_authorized(self, auth_model):
         user_info = auth_model["auth_state"][self.user_auth_state_key]
-        if self.allowed_groups:
+        if not self.allowed_users and (self.allowed_groups or self.admin_groups):
             self.log.info(
                 f"Validating if user claim groups match any of {self.allowed_groups}"
             )

--- a/oauthenticator/generic.py
+++ b/oauthenticator/generic.py
@@ -116,7 +116,9 @@ class GenericOAuthenticator(OAuthenticator):
 
     async def user_is_authorized(self, auth_model):
         user_info = auth_model["auth_state"][self.user_auth_state_key]
-        if self.allowed_groups:
+        allowed_status = True if auth_model['name'] in self.allowed_users else None
+
+        if not allowed_status and self.allowed_groups:
             self.log.info(
                 f"Validating if user claim groups match any of {self.allowed_groups}"
             )

--- a/oauthenticator/generic.py
+++ b/oauthenticator/generic.py
@@ -116,7 +116,7 @@ class GenericOAuthenticator(OAuthenticator):
 
     async def user_is_authorized(self, auth_model):
         user_info = auth_model["auth_state"][self.user_auth_state_key]
-        if not self.allowed_users and (self.allowed_groups or self.admin_groups):
+        if self.allowed_groups:
             self.log.info(
                 f"Validating if user claim groups match any of {self.allowed_groups}"
             )
@@ -125,8 +125,11 @@ class GenericOAuthenticator(OAuthenticator):
             if not groups:
                 return False
 
+            all_allowed_groups = self.allowed_groups
+            if self.admin_groups:
+                all_allowed_groups += self.admin_groups
             if not self.user_groups_in_allowed_groups(
-                groups, self.allowed_groups + self.admin_groups
+                groups, all_allowed_groups
             ):
                 return False
 

--- a/oauthenticator/generic.py
+++ b/oauthenticator/generic.py
@@ -139,7 +139,7 @@ class GenericOAuthenticator(OAuthenticator):
         if not admin_status and self.admin_groups:
             groups = self.get_user_groups(user_info)
             if groups:
-                auth_model['admin'] = self.check_user_in_groups(
+                auth_model['admin'] = self.user_groups_in_allowed_groups(
                     groups, self.admin_groups
                 )
 

--- a/oauthenticator/generic.py
+++ b/oauthenticator/generic.py
@@ -100,9 +100,7 @@ class GenericOAuthenticator(OAuthenticator):
             groups = self.claim_groups_key(user_info)
         else:
             try:
-                groups = reduce(
-                    dict.get, self.claim_groups_key.split("."), user_info
-                )
+                groups = reduce(dict.get, self.claim_groups_key.split("."), user_info)
             except TypeError:
                 # This happens if a nested key does not exist (reduce trying to call None.get)
                 self.log.error(
@@ -127,7 +125,9 @@ class GenericOAuthenticator(OAuthenticator):
             if not groups:
                 return False
 
-            if not self.user_groups_in_allowed_groups(groups, self.allowed_groups + self.admin_groups):
+            if not self.user_groups_in_allowed_groups(
+                groups, self.allowed_groups + self.admin_groups
+            ):
                 return False
 
         return True

--- a/oauthenticator/generic.py
+++ b/oauthenticator/generic.py
@@ -109,7 +109,7 @@ class GenericOAuthenticator(OAuthenticator):
         if callable(self.claim_groups_key):
             return set(self.claim_groups_key(user_info))
         try:
-            return reduce(dict.get, self.claim_groups_key.split("."), user_info)
+            return set(reduce(dict.get, self.claim_groups_key.split("."), user_info))
         except TypeError:
             self.log.error(
                 f"The claim_groups_key {self.claim_groups_key} does not exist in the user token"

--- a/oauthenticator/generic.py
+++ b/oauthenticator/generic.py
@@ -127,7 +127,7 @@ class GenericOAuthenticator(OAuthenticator):
             if not groups:
                 return False
 
-            if not self.user_groups_in_allowed_groups(groups, self.allowed_groups):
+            if not self.user_groups_in_allowed_groups(groups, self.allowed_groups + self.admin_groups):
                 return False
 
         return True

--- a/oauthenticator/generic.py
+++ b/oauthenticator/generic.py
@@ -128,9 +128,7 @@ class GenericOAuthenticator(OAuthenticator):
             all_allowed_groups = self.allowed_groups
             if self.admin_groups:
                 all_allowed_groups += self.admin_groups
-            if not self.user_groups_in_allowed_groups(
-                groups, all_allowed_groups
-            ):
+            if not self.user_groups_in_allowed_groups(groups, all_allowed_groups):
                 return False
 
         return True

--- a/oauthenticator/generic.py
+++ b/oauthenticator/generic.py
@@ -70,7 +70,7 @@ class GenericOAuthenticator(OAuthenticator):
     tls_verify = Bool(
         os.environ.get('OAUTH2_TLS_VERIFY', 'True').lower() in {'true', '1'},
         config=True,
-        help="Disable TLS verification on http request",
+        help="Require valid tls certificates in HTTP requests",
     )
 
     @default("basic_auth")
@@ -116,20 +116,6 @@ class GenericOAuthenticator(OAuthenticator):
             )
             return set()
 
-    async def user_is_authorized(self, auth_model):
-        """
-        A user is authorized by being part of allowed_users, admin_users,
-        allowed_groups, or admin_groups.
-        """
-        user_info = auth_model["auth_state"][self.user_auth_state_key]
-
-        username = auth_model["name"]
-        if username in (self.allowed_users | self.admin_users):
-            return True
-
-        user_groups = self.get_user_groups(user_info)
-        return any(user_groups & (self.allowed_groups | self.admin_groups))
-
     async def update_auth_model(self, auth_model):
         """
         Set the admin status based on finding the username in `admin_users` or
@@ -140,16 +126,40 @@ class GenericOAuthenticator(OAuthenticator):
         username = auth_model["name"]
         if username in self.admin_users:
             auth_model["admin"] = True
-            return auth_model
-
-        if self.admin_groups:
-            # admin_groups are declared and the user wasn't part of admin_users,
-            # so we set admin to True or False to allow a user removed from an
-            # admin_groups to no longer be an admin.
+        elif self.admin_groups:
+            # if admin_groups is configured, we must either set or unset admin
+            # status and never leave it at None, otherwise removing a user from
+            # the admin_groups won't have an effect
             user_groups = self.get_user_groups(user_info)
             auth_model["admin"] = any(user_groups & self.admin_groups)
 
         return auth_model
+
+    async def check_allowed(self, username, auth_model):
+        """
+        Returns True for users allowed to be authorized.
+
+        Overrides the OAuthenticator.check_allowed implementation to allow users
+        either part of `allowed_users` or `allowed_groups`, and not just those
+        part of `allowed_users`.
+        """
+        # allow admin users recognized via admin_users or update_auth_model
+        if auth_model["admin"]:
+            return True
+
+        # if allowed_users or allowed_groups is configured, we deny users not
+        # part of either
+        if self.allowed_users or self.allowed_groups:
+            user_info = auth_model["auth_state"][self.user_auth_state_key]
+            user_groups = self.get_user_groups(user_info)
+            if username in self.allowed_users:
+                return True
+            if any(user_groups & self.allowed_groups):
+                return True
+            return False
+
+        # otherwise, authorize all users
+        return True
 
 
 class LocalGenericOAuthenticator(LocalAuthenticator, GenericOAuthenticator):

--- a/oauthenticator/github.py
+++ b/oauthenticator/github.py
@@ -165,11 +165,9 @@ class GitHubOAuthenticator(OAuthenticator):
                     )
                     if user_in_org:
                         return True
-                else:
-                    # User not found in member list for any organi`ation
-                    self.log.warning(
-                        f"User {username} is not in allowed org list",
-                    )
+                self.log.warning(
+                    f"User {username} is not part of allowed_organizations"
+                )
 
             return False
 
@@ -185,6 +183,8 @@ class GitHubOAuthenticator(OAuthenticator):
         Also fetch and store `teams` in auth state if
         `populate_teams_in_auth_state` is configured.
         """
+        user_info = auth_model["auth_state"][self.user_auth_state_key]
+
         # If a public email is not available, an extra API call has to be made
         # to a /user/emails using the access token to retrieve emails. The
         # scopes relevant for this are checked based on this documentation:
@@ -194,15 +194,12 @@ class GitHubOAuthenticator(OAuthenticator):
         # Note that the read:user scope does not imply the user:emails scope!
         access_token = auth_model["auth_state"]["token_response"]["access_token"]
         token_type = auth_model["auth_state"]["token_response"]["token_type"]
-        granted_scopes = []
-        if auth_model["auth_state"]["scope"]:
-            granted_scopes = auth_model["auth_state"]["scope"]
-
-        if not auth_model["auth_state"]["github_user"]["email"] and (
+        granted_scopes = auth_model["auth_state"].get("scope", [])
+        if not user_info["email"] and (
             "user" in granted_scopes or "user:email" in granted_scopes
         ):
             resp_json = await self.httpfetch(
-                self.github_api + "/user/emails",
+                f"{self.github_api}/user/emails",
                 "fetching user emails",
                 method="GET",
                 headers=self.build_userdata_request_headers(access_token, token_type),
@@ -210,7 +207,7 @@ class GitHubOAuthenticator(OAuthenticator):
             )
             for val in resp_json:
                 if val["primary"]:
-                    auth_model["auth_state"]["github_user"]["email"] = val["email"]
+                    user_info["email"] = val["email"]
                     break
 
         if self.populate_teams_in_auth_state:
@@ -221,15 +218,10 @@ class GitHubOAuthenticator(OAuthenticator):
                     "read:org scope is required for populate_teams_in_auth_state functionality to work"
                 )
             else:
-                # Number of teams to request per page
-                per_page = 100
-
-                #  https://docs.github.com/en/rest/reference/teams#list-teams-for-the-authenticated-user
-                url = self.github_api + f"/user/teams?per_page={per_page}"
-
-                auth_model["auth_state"]["teams"] = await self._paginated_fetch(
-                    url, access_token, token_type
-                )
+                # https://docs.github.com/en/rest/teams/teams?apiVersion=2022-11-28#list-teams-for-the-authenticated-user
+                url = f"{self.github_api}/user/teams?per_page=100"
+                user_teams = await self._paginated_fetch(url, access_token, token_type)
+                auth_model["auth_state"]["teams"] = user_teams
 
         return auth_model
 
@@ -280,23 +272,33 @@ class GitHubOAuthenticator(OAuthenticator):
         return content
 
     async def _check_membership_allowed_organizations(
-        self, org, username, access_token, token_type
+        self, org_team, username, access_token, token_type
     ):
         """
         Checks if a user is part of an organization or organization's team via
         GitHub's REST API. The `read:org` scope is required to not only check
         for public org/team membership.
 
-        The `org` parameter accepts values like `org-a` or `org-b:team-1`,
+        The `org_team` parameter accepts values like `org-a` or `org-b:team-1`,
         and will adjust to use a the relevant REST API to check either org or
         team membership.
         """
         headers = self.build_userdata_request_headers(access_token, token_type)
-        check_membership_url = self._build_check_membership_url(org, username)
+
+        if ":" in org_team:
+            # check if user is part of an organization's team
+            # https://docs.github.com/en/rest/teams/members?apiVersion=2022-11-28#get-team-member-legacy
+            org, team = org_team.split(":")
+            api_url = f"{self.github_api}/orgs/{org}/teams/{team}/members/{username}"
+        else:
+            # check if user is part of an organization
+            # https://docs.github.com/en/rest/orgs/members?apiVersion=2022-11-28#check-organization-membership-for-a-user
+            org = org_team
+            api_url = f"{self.github_api}/orgs/{org}/members/{username}"
 
         self.log.debug(f"Checking GitHub organization membership: {username} in {org}?")
         resp = await self.httpfetch(
-            check_membership_url,
+            api_url,
             parse_json=False,
             raise_error=False,
             method="GET",
@@ -304,7 +306,7 @@ class GitHubOAuthenticator(OAuthenticator):
             validate_cert=self.validate_server_cert,
         )
         if resp.code == 204:
-            self.log.info(f"Allowing {username} as member of {org}")
+            self.log.debug(f"Allowing {username} as member of {org_team}")
             return True
         else:
             try:
@@ -313,16 +315,9 @@ class GitHubOAuthenticator(OAuthenticator):
             except ValueError:
                 message = ''
             self.log.debug(
-                f"{username} does not appear to be a member of {org} (status={resp.code}): {message}",
+                f"{username} does not appear to be a member of {org_team} (status={resp.code}): {message}",
             )
         return False
-
-    def _build_check_membership_url(self, org: str, username: str) -> str:
-        if ":" in org:
-            org, team = org.split(":")
-            return f"{self.github_api}/orgs/{org}/teams/{team}/members/{username}"
-        else:
-            return f"{self.github_api}/orgs/{org}/members/{username}"
 
 
 class LocalGitHubOAuthenticator(LocalAuthenticator, GitHubOAuthenticator):

--- a/oauthenticator/github.py
+++ b/oauthenticator/github.py
@@ -130,9 +130,9 @@ class GitHubOAuthenticator(OAuthenticator):
 
     async def user_is_authorized(self, auth_model):
         # Check if user is a member of any allowed organizations.
-        # This check is performed here, as it requires `access_token`.
         access_token = auth_model["auth_state"]["token_response"]["access_token"]
         token_type = auth_model["auth_state"]["token_response"]["token_type"]
+
         if self.allowed_organizations:
             for org in self.allowed_organizations:
                 user_in_org = await self._check_membership_allowed_organizations(

--- a/oauthenticator/github.py
+++ b/oauthenticator/github.py
@@ -109,6 +109,10 @@ class GitHubOAuthenticator(OAuthenticator):
         config=True, help="Automatically allow members of selected organizations"
     )
 
+    # FIXME: when set saves the user teams inside the auth state under a `teams` key.
+    #        Should we standardize the `teams` key?
+    #        (In bitbucket.py the key is called `user_teams` and we set it by default without any flag)
+    #        What about allowed orgs. Should we update the auth_model with these too?
     populate_teams_in_auth_state = Bool(
         False,
         help="""

--- a/oauthenticator/github.py
+++ b/oauthenticator/github.py
@@ -109,10 +109,6 @@ class GitHubOAuthenticator(OAuthenticator):
         config=True, help="Automatically allow members of selected organizations"
     )
 
-    # FIXME: when set saves the user teams inside the auth state under a `teams` key.
-    #        Should we standardize the `teams` key?
-    #        (In bitbucket.py the key is called `user_teams` and we set it by default without any flag)
-    #        What about allowed orgs. Should we update the auth_model with these too?
     populate_teams_in_auth_state = Bool(
         False,
         help="""

--- a/oauthenticator/github.py
+++ b/oauthenticator/github.py
@@ -157,14 +157,14 @@ class GitHubOAuthenticator(OAuthenticator):
                 token_type = auth_model["auth_state"]["token_response"]["token_type"]
                 for org in self.allowed_organizations:
                     user_in_org = await self._check_membership_allowed_organizations(
-                        org, auth_model["name"], access_token, token_type
+                        org, username, access_token, token_type
                     )
                     if user_in_org:
                         return True
                 else:
                     # User not found in member list for any organi`ation
                     self.log.warning(
-                        f"User {auth_model['name']} is not in allowed org list",
+                        f"User {username} is not in allowed org list",
                     )
 
             return False

--- a/oauthenticator/github.py
+++ b/oauthenticator/github.py
@@ -136,6 +136,12 @@ class GitHubOAuthenticator(OAuthenticator):
         either part of `allowed_users` or `allowed_organizations`, and not just those
         part of `allowed_users`.
         """
+        # Workaround situation when JupyterHub.load_roles or
+        # JupyterHub.load_groups is used to create a user, see discussion in
+        # https://github.com/jupyterhub/jupyterhub/issues/4461.
+        if auth_model is None:
+            return True
+
         # allow admin users recognized via admin_users or update_auth_model
         if auth_model["admin"]:
             return True

--- a/oauthenticator/gitlab.py
+++ b/oauthenticator/gitlab.py
@@ -125,8 +125,8 @@ class GitLabOAuthenticator(OAuthenticator):
         Returns True for users allowed to be authorized.
 
         Overrides the OAuthenticator.check_allowed implementation to allow users
-        either part of `allowed_users` or `allowed_organizations`, and not just those
-        part of `allowed_users`.
+        either part of `allowed_users`, `allowed_gitlab_groups`, or `allowed_project_ids`,
+        and not just those part of `allowed_users`.
         """
         # allow admin users recognized via admin_users or update_auth_model
         if auth_model["admin"]:

--- a/oauthenticator/gitlab.py
+++ b/oauthenticator/gitlab.py
@@ -128,6 +128,12 @@ class GitLabOAuthenticator(OAuthenticator):
         either part of `allowed_users`, `allowed_gitlab_groups`, or `allowed_project_ids`,
         and not just those part of `allowed_users`.
         """
+        # Workaround situation when JupyterHub.load_roles or
+        # JupyterHub.load_groups is used to create a user, see discussion in
+        # https://github.com/jupyterhub/jupyterhub/issues/4461.
+        if auth_model is None:
+            return True
+
         # allow admin users recognized via admin_users or update_auth_model
         if auth_model["admin"]:
             return True

--- a/oauthenticator/gitlab.py
+++ b/oauthenticator/gitlab.py
@@ -138,8 +138,8 @@ class GitLabOAuthenticator(OAuthenticator):
             if username in self.allowed_users:
                 return True
 
-            await self._set_gitlab_version(access_token)
             access_token = auth_model["auth_state"]["token_response"]["access_token"]
+            await self._set_gitlab_version(access_token)
             user_id = auth_model["auth_state"][self.user_auth_state_key]["id"]
 
             if self.allowed_gitlab_groups:

--- a/oauthenticator/gitlab.py
+++ b/oauthenticator/gitlab.py
@@ -7,7 +7,6 @@ from urllib.parse import quote
 
 from jupyterhub.auth import LocalAuthenticator
 from tornado.escape import url_escape
-from tornado.httpclient import HTTPRequest
 from traitlets import CUnicode, Set, Unicode, default
 
 from .oauth2 import OAuthenticator
@@ -113,47 +112,53 @@ class GitLabOAuthenticator(OAuthenticator):
     )
 
     gitlab_version = None
+    member_api_variant = None
 
-    async def user_is_authorized(self, auth_model):
-        access_token = auth_model["auth_state"]["token_response"]["access_token"]
-        user_id = auth_model["auth_state"][self.user_auth_state_key]["id"]
-
+    async def _set_gitlab_version(self, access_token):
         # memoize gitlab version for class lifetime
         if self.gitlab_version is None:
             self.gitlab_version = await self._get_gitlab_version(access_token)
             self.member_api_variant = 'all/' if self.gitlab_version >= [12, 4] else ''
 
-        # Check if user is a member of any allowed groups or projects.
-        # These checks are performed here, as it requires `access_token`.
-        user_in_group = user_in_project = False
-        is_group_specified = is_project_id_specified = False
+    async def check_allowed(self, username, auth_model):
+        """
+        Returns True for users allowed to be authorized.
 
-        if self.allowed_gitlab_groups:
-            is_group_specified = True
-            user_in_group = await self._check_membership_allowed_groups(
-                user_id, access_token
-            )
-
-        # We skip project_id check if user is in allowed group.
-        if self.allowed_project_ids and not user_in_group:
-            is_project_id_specified = True
-            user_in_project = await self._check_membership_allowed_project_ids(
-                user_id, access_token
-            )
-
-        no_config_specified = not (is_group_specified or is_project_id_specified)
-
-        if (
-            (is_group_specified and user_in_group)
-            or (is_project_id_specified and user_in_project)
-            or no_config_specified
-        ):
+        Overrides the OAuthenticator.check_allowed implementation to allow users
+        either part of `allowed_users` or `allowed_organizations`, and not just those
+        part of `allowed_users`.
+        """
+        # allow admin users recognized via admin_users or update_auth_model
+        if auth_model["admin"]:
             return True
 
-        self.log.warning(
-            f"{auth_model['name']} not in group or project allowed list",
-        )
-        return False
+        # if allowed_users or allowed_gitlab_groups or allowed_project_ids is configured,
+        # we deny users not part of either
+        if self.allowed_users or self.allowed_gitlab_groups or self.allowed_project_ids:
+            if username in self.allowed_users:
+                return True
+
+            await self._set_gitlab_version(access_token)
+            access_token = auth_model["auth_state"]["token_response"]["access_token"]
+            user_id = auth_model["auth_state"][self.user_auth_state_key]["id"]
+
+            if self.allowed_gitlab_groups:
+                user_in_group = await self._check_membership_allowed_groups(
+                    user_id, access_token
+                )
+                if user_in_group:
+                    return True
+
+            if self.allowed_project_ids:
+                user_in_project = await self._check_membership_allowed_project_ids(
+                    user_id, access_token
+                )
+                if user_in_project:
+                    return True
+            return False
+
+        # otherwise, authorize all users
+        return True
 
     async def _get_gitlab_version(self, access_token):
         url = f"{self.gitlab_api}/version"
@@ -176,9 +181,6 @@ class GitLabOAuthenticator(OAuthenticator):
                 quote(group, safe=''),
                 self.member_api_variant,
                 user_id,
-            )
-            req = HTTPRequest(
-                url,
             )
             resp = await self.httpfetch(
                 url,

--- a/oauthenticator/gitlab.py
+++ b/oauthenticator/gitlab.py
@@ -139,7 +139,6 @@ class GitLabOAuthenticator(OAuthenticator):
                 return True
 
             access_token = auth_model["auth_state"]["token_response"]["access_token"]
-            await self._set_gitlab_version(access_token)
             user_id = auth_model["auth_state"][self.user_auth_state_key]["id"]
 
             if self.allowed_gitlab_groups:
@@ -175,6 +174,8 @@ class GitLabOAuthenticator(OAuthenticator):
 
     async def _check_membership_allowed_groups(self, user_id, access_token):
         headers = _api_headers(access_token)
+        await self._set_gitlab_version(access_token)
+
         # Check if user is a member of any group in the allowed list
         for group in map(url_escape, self.allowed_gitlab_groups):
             url = "%s/groups/%s/members/%s%d" % (
@@ -197,6 +198,8 @@ class GitLabOAuthenticator(OAuthenticator):
 
     async def _check_membership_allowed_project_ids(self, user_id, access_token):
         headers = _api_headers(access_token)
+        await self._set_gitlab_version(access_token)
+
         # Check if user has developer access to any project in the allowed list
         for project in self.allowed_project_ids:
             url = "%s/projects/%s/members/%s%d" % (

--- a/oauthenticator/gitlab.py
+++ b/oauthenticator/gitlab.py
@@ -128,9 +128,8 @@ class GitLabOAuthenticator(OAuthenticator):
         either part of `allowed_users`, `allowed_gitlab_groups`, or `allowed_project_ids`,
         and not just those part of `allowed_users`.
         """
-        # Workaround situation when JupyterHub.load_roles or
-        # JupyterHub.load_groups is used to create a user, see discussion in
-        # https://github.com/jupyterhub/jupyterhub/issues/4461.
+        # A workaround for JupyterHub<=4.0.1, described in
+        # https://github.com/jupyterhub/oauthenticator/issues/621
         if auth_model is None:
             return True
 
@@ -138,8 +137,8 @@ class GitLabOAuthenticator(OAuthenticator):
         if auth_model["admin"]:
             return True
 
-        # if allowed_users or allowed_gitlab_groups or allowed_project_ids is configured,
-        # we deny users not part of either
+        # if allowed_users, allowed_gitlab_groups, or allowed_project_ids is
+        # configured, we deny users not part of either
         if self.allowed_users or self.allowed_gitlab_groups or self.allowed_project_ids:
             if username in self.allowed_users:
                 return True

--- a/oauthenticator/gitlab.py
+++ b/oauthenticator/gitlab.py
@@ -155,6 +155,7 @@ class GitLabOAuthenticator(OAuthenticator):
                 )
                 if user_in_project:
                     return True
+
             return False
 
         # otherwise, authorize all users

--- a/oauthenticator/globus.py
+++ b/oauthenticator/globus.py
@@ -232,7 +232,7 @@ class GlobusOAuthenticator(OAuthenticator):
 
     # FIXME: Should we persist info about user groups in auth model
     #        to be consistent with what's happening in bitbucket.py
-    #        where the `auth_model`` is updated with `user_teams`.
+    #        where the `auth_model` is updated with `user_teams`.
     async def get_users_groups_ids(self, tokens):
         user_group_ids = set()
         # Get Groups access token, may not be in dict headed to auth state

--- a/oauthenticator/globus.py
+++ b/oauthenticator/globus.py
@@ -182,7 +182,7 @@ class GlobusOAuthenticator(OAuthenticator):
 
     def get_globus_tokens(self, token_info):
         # Each token should have these attributes. Resource server is optional,
-        # and likely xwon't be present.
+        # and likely won't be present.
         token_attrs = [
             'expires_in',
             'resource_server',

--- a/oauthenticator/globus.py
+++ b/oauthenticator/globus.py
@@ -284,7 +284,9 @@ class GlobusOAuthenticator(OAuthenticator):
                 return True
 
             if self.allowed_globus_groups:
-                tokens = self.get_globus_tokens(auth_model["auth_state"]["token_response"])
+                tokens = self.get_globus_tokens(
+                    auth_model["auth_state"]["token_response"]
+                )
                 user_group_ids = await self.get_users_groups_ids(tokens)
 
                 if self.check_user_in_groups(

--- a/oauthenticator/globus.py
+++ b/oauthenticator/globus.py
@@ -259,7 +259,7 @@ class GlobusOAuthenticator(OAuthenticator):
         Returns True for users allowed to be authorized.
 
         Overrides the OAuthenticator.check_allowed implementation to allow users
-        either part of `allowed_users` or `allowed_organizations`, and not just those
+        either part of `allowed_users` or `allowed_globus_groups`, and not just those
         part of `allowed_users`.
         """
         # allow admin users recognized via admin_users or update_auth_model

--- a/oauthenticator/globus.py
+++ b/oauthenticator/globus.py
@@ -275,6 +275,8 @@ class GlobusOAuthenticator(OAuthenticator):
                 return True
 
         if self.identity_provider:
+            # It's possible for identity provider domains to be namespaced
+            # https://docs.globus.org/api/auth/specification/#identity_provider_namespaces
             user_info = auth_model["auth_state"][self.user_auth_state_key]
             domain = user_info.get(self.username_claim).split('@', 1)[-1]
             if domain != self.identity_provider:
@@ -331,8 +333,6 @@ class GlobusOAuthenticator(OAuthenticator):
         will have the 'foouser' account in Jupyterhub.
         """
 
-        # It's possible for identity provider domains to be namespaced
-        # https://docs.globus.org/api/auth/specification/#identity_provider_namespaces # noqa
         return user_info.get(self.username_claim).split('@')[0]
 
     def get_default_headers(self):

--- a/oauthenticator/globus.py
+++ b/oauthenticator/globus.py
@@ -263,14 +263,6 @@ class GlobusOAuthenticator(OAuthenticator):
         if auth_model["admin"]:
             return True
 
-        # FIXME: consider overriding the `is_admin`` and add this logic there
-        tokens = self.get_globus_tokens(auth_model["auth_state"]["token_response"])
-        user_group_ids = await self.get_users_groups_ids(tokens)
-        if self.admin_globus_groups:
-            if self.check_user_in_groups(user_group_ids, self.admin_globus_groups):
-                auth_model["admin"] = True
-                return True
-
         if self.identity_provider:
             # It's possible for identity provider domains to be namespaced
             # https://docs.globus.org/api/auth/specification/#identity_provider_namespaces
@@ -292,6 +284,9 @@ class GlobusOAuthenticator(OAuthenticator):
                 return True
 
             if self.allowed_globus_groups:
+                tokens = self.get_globus_tokens(auth_model["auth_state"]["token_response"])
+                user_group_ids = await self.get_users_groups_ids(tokens)
+
                 if self.check_user_in_groups(
                     user_group_ids, self.allowed_globus_groups
                 ):
@@ -308,7 +303,7 @@ class GlobusOAuthenticator(OAuthenticator):
         # If users is already marked as an admin, it means that
         # they are present in the `admin_users`` list
         # no need to check groups membership
-        if auth_model['admin'] is True:
+        if auth_model["admin"] is True:
             return auth_model
 
         if self.admin_globus_groups:
@@ -317,10 +312,9 @@ class GlobusOAuthenticator(OAuthenticator):
             user_group_ids = await self.get_users_groups_ids(tokens)
             # Admin users are being managed via Globus Groups
             # Default to False
-            auth_model['admin'] = False
+            auth_model["admin"] = False
             if self.check_user_in_groups(user_group_ids, self.admin_globus_groups):
-                auth_model['admin'] = True
-
+                auth_model["admin"] = True
         return auth_model
 
     def user_info_to_username(self, user_info):

--- a/oauthenticator/globus.py
+++ b/oauthenticator/globus.py
@@ -259,6 +259,12 @@ class GlobusOAuthenticator(OAuthenticator):
         either part of `allowed_users` or `allowed_globus_groups`, and not just those
         part of `allowed_users`.
         """
+        # Workaround situation when JupyterHub.load_roles or
+        # JupyterHub.load_groups is used to create a user, see discussion in
+        # https://github.com/jupyterhub/jupyterhub/issues/4461.
+        if auth_model is None:
+            return True
+
         # allow admin users recognized via admin_users or update_auth_model
         if auth_model["admin"]:
             return True

--- a/oauthenticator/globus.py
+++ b/oauthenticator/globus.py
@@ -251,9 +251,6 @@ class GlobusOAuthenticator(OAuthenticator):
 
         return user_group_ids
 
-    # TODO: Mark this as breaking change because before globus_admin_groups and globus_user_groups
-    #       were the ones that were being considered to determine the admin and access status of a user
-    #       and not their union with the generic admin_users and allowed_users like it is happening now.
     async def check_allowed(self, username, auth_model):
         """
         Returns True for users allowed to be authorized.

--- a/oauthenticator/google.py
+++ b/oauthenticator/google.py
@@ -131,7 +131,6 @@ class GoogleOAuthenticator(OAuthenticator, GoogleOAuth2Mixin):
 
         return auth_model
 
-
     async def check_allowed(self, username, auth_model):
         """
         Returns True for users allowed to be authorized.

--- a/oauthenticator/google.py
+++ b/oauthenticator/google.py
@@ -139,6 +139,12 @@ class GoogleOAuthenticator(OAuthenticator, GoogleOAuth2Mixin):
         either part of `allowed_users` or `allowed_google_groups`, and not just those
         part of `allowed_users`.
         """
+        # Workaround situation when JupyterHub.load_roles or
+        # JupyterHub.load_groups is used to create a user, see discussion in
+        # https://github.com/jupyterhub/jupyterhub/issues/4461.
+        if auth_model is None:
+            return True
+
         # allow admin users recognized via admin_users or update_auth_model
         if auth_model["admin"]:
             return True

--- a/oauthenticator/google.py
+++ b/oauthenticator/google.py
@@ -133,7 +133,8 @@ class GoogleOAuthenticator(OAuthenticator, GoogleOAuth2Mixin):
                     403, f"Google account domain @{user_email_domain} not authorized."
                 )
 
-        if self.allowed_google_groups:
+        allowed_status = True if auth_model['name'] in self.allowed_users else None
+        if not allowed_status and self.allowed_google_groups:
             google_groups = self._google_groups_for_user(user_email, user_email_domain)
             if not google_groups:
                 return False

--- a/oauthenticator/google.py
+++ b/oauthenticator/google.py
@@ -133,7 +133,7 @@ class GoogleOAuthenticator(OAuthenticator, GoogleOAuth2Mixin):
                     403, f"Google account domain @{user_email_domain} not authorized."
                 )
 
-        if not self.allowed_users and (self.allowed_google_groups or self.admin_google_groups):
+        if self.allowed_google_groups:
             google_groups = self._google_groups_for_user(user_email, user_email_domain)
             if not google_groups:
                 return False
@@ -143,7 +143,9 @@ class GoogleOAuthenticator(OAuthenticator, GoogleOAuth2Mixin):
             # Check if user is a member of any allowed or admin groups.
             allowed_groups_per_domain = self.allowed_google_groups.get(
                 user_email_domain, []
-            ) + self.admin_google_groups.get(user_email_domain, [])
+            )
+            if self.admin_google_groups:
+                allowed_groups_per_domain += self.admin_google_groups.get(user_email_domain, [])
             if not allowed_groups_per_domain:
                 return False
             else:

--- a/oauthenticator/google.py
+++ b/oauthenticator/google.py
@@ -133,7 +133,7 @@ class GoogleOAuthenticator(OAuthenticator, GoogleOAuth2Mixin):
                     403, f"Google account domain @{user_email_domain} not authorized."
                 )
 
-        if self.allowed_google_groups:
+        if not self.allowed_users and (self.allowed_google_groups or self.admin_google_groups):
             google_groups = self._google_groups_for_user(user_email, user_email_domain)
             if not google_groups:
                 return False

--- a/oauthenticator/google.py
+++ b/oauthenticator/google.py
@@ -142,7 +142,6 @@ class GoogleOAuthenticator(OAuthenticator, GoogleOAuth2Mixin):
 
             # Check if user is a member of any allowed or admin groups.
             allowed_groups_per_domain = self.allowed_google_groups.get(user_email_domain, []) + self.admin_google_groups.get(user_email_domain, [])
-            print(allowed_groups_per_domain)
             if not allowed_groups_per_domain:
                 return False
             else:

--- a/oauthenticator/google.py
+++ b/oauthenticator/google.py
@@ -145,7 +145,9 @@ class GoogleOAuthenticator(OAuthenticator, GoogleOAuth2Mixin):
                 user_email_domain, []
             )
             if self.admin_google_groups:
-                allowed_groups_per_domain += self.admin_google_groups.get(user_email_domain, [])
+                allowed_groups_per_domain += self.admin_google_groups.get(
+                    user_email_domain, []
+                )
             if not allowed_groups_per_domain:
                 return False
             else:

--- a/oauthenticator/google.py
+++ b/oauthenticator/google.py
@@ -141,7 +141,9 @@ class GoogleOAuthenticator(OAuthenticator, GoogleOAuth2Mixin):
             auth_model['auth_state']['google_user']['google_groups'] = google_groups
 
             # Check if user is a member of any allowed or admin groups.
-            allowed_groups_per_domain = self.allowed_google_groups.get(user_email_domain, []) + self.admin_google_groups.get(user_email_domain, [])
+            allowed_groups_per_domain = self.allowed_google_groups.get(
+                user_email_domain, []
+            ) + self.admin_google_groups.get(user_email_domain, [])
             if not allowed_groups_per_domain:
                 return False
             else:
@@ -150,7 +152,6 @@ class GoogleOAuthenticator(OAuthenticator, GoogleOAuth2Mixin):
                 )
 
         return True
-
 
     async def update_auth_model(self, auth_model):
         username = auth_model["name"]
@@ -161,7 +162,9 @@ class GoogleOAuthenticator(OAuthenticator, GoogleOAuth2Mixin):
 
             if user_email_domain in self.admin_google_groups.keys():
                 # Check if user is a member of any admin groups.
-                google_groups = self._google_groups_for_user(user_email, user_email_domain)
+                google_groups = self._google_groups_for_user(
+                    user_email, user_email_domain
+                )
                 if google_groups:
                     auth_model['admin'] = self.user_groups_in_allowed_groups(
                         google_groups, self.admin_google_groups[user_email_domain]

--- a/oauthenticator/google.py
+++ b/oauthenticator/google.py
@@ -130,7 +130,7 @@ class GoogleOAuthenticator(OAuthenticator, GoogleOAuth2Mixin):
         user_info = auth_model["auth_state"][self.user_auth_state_key]
         user_email = user_info["email"]
         user_domain = user_email.split("@")[1]
-        user_groups = set(self._google_groups_for_user(user_email, user_domain))
+        user_groups = self._fetch_user_groups(user_email, user_domain)
         admin_groups = self.admin_google_groups.get(user_domain, set())
 
         if any(user_groups & admin_groups):
@@ -253,7 +253,7 @@ class GoogleOAuthenticator(OAuthenticator, GoogleOAuth2Mixin):
             http=http,
         )
 
-    def _google_groups_for_user(self, user_email, user_email_domain, http=None):
+    def _fetch_user_groups(self, user_email, user_email_domain, http=None):
         """
         Return a set with the google groups a given user is a member of
         """
@@ -273,12 +273,12 @@ class GoogleOAuthenticator(OAuthenticator, GoogleOAuth2Mixin):
             http=http,
         )
 
-        results = service.groups().list(userKey=user_email).execute()
-        results = {
-            g['email'].split('@')[0] for g in results.get('groups', [{'email': None}])
+        resp = service.groups().list(userKey=user_email).execute()
+        user_groups = {
+            g['email'].split('@')[0] for g in resp.get('groups', [{'email': None}])
         }
-        self.log.debug(f"user_email {user_email} is a member of {results}")
-        return results
+        self.log.debug(f"user_email {user_email} is a member of {user_groups}")
+        return user_groups
 
 
 class LocalGoogleOAuthenticator(LocalAuthenticator, GoogleOAuthenticator):

--- a/oauthenticator/google.py
+++ b/oauthenticator/google.py
@@ -163,7 +163,7 @@ class GoogleOAuthenticator(OAuthenticator, GoogleOAuth2Mixin):
                 # Check if user is a member of any admin groups.
                 google_groups = self._google_groups_for_user(user_email, user_email_domain)
                 if google_groups:
-                    auth_model['admin'] = check_user_in_groups(
+                    auth_model['admin'] = self.user_groups_in_allowed_groups(
                         google_groups, self.admin_google_groups[user_email_domain]
                     )
 
@@ -219,7 +219,7 @@ class GoogleOAuthenticator(OAuthenticator, GoogleOAuth2Mixin):
 
     def _google_groups_for_user(self, user_email, user_email_domain, http=None):
         """
-        Return google groups a given user is a member of
+        Return a list with the google groups a given user is a member of
         """
         credentials = self._service_client_credentials(
             scopes=[f"{self.google_api_url}/auth/admin.directory.group.readonly"],

--- a/oauthenticator/mediawiki.py
+++ b/oauthenticator/mediawiki.py
@@ -102,6 +102,7 @@ class MWOAuthenticator(OAuthenticator):
         """
         Override normalize_username to avoid lowercasing usernames
         """
+        username = username.replace(' ', '_')
         return username
 
     def _executor_default(self):
@@ -137,12 +138,7 @@ class MWOAuthenticator(OAuthenticator):
             self.executor.submit(handshaker.identify, token_info["access_token"])
         )
 
-    async def update_auth_model(self, auth_model):
-        auth_model['name'] = auth_model['name'].replace(' ', '_')
-        return auth_model
-
     def build_auth_state_dict(self, token_info, user_info):
-        username = self.user_info_to_username(user_info)
         # this shouldn't be necessary anymore,
         # but keep for backward-compatibility
         return {

--- a/oauthenticator/oauth2.py
+++ b/oauthenticator/oauth2.py
@@ -732,7 +732,7 @@ class OAuthenticator(Authenticator):
             self.user_auth_state_key: user_info,
         }
 
-    async def update_auth_model(self, username, auth_model):
+    async def update_auth_model(self, auth_model):
         """
         Updates and returns the `auth_model` dict.
 

--- a/oauthenticator/oauth2.py
+++ b/oauthenticator/oauth2.py
@@ -762,6 +762,14 @@ class OAuthenticator(Authenticator):
         """
         return True
 
+    @staticmethod
+    def user_groups_in_allowed_groups(user_groups: set, allowed_groups: set):
+        """
+        Returns True if user is a member of any group in the allowed groups,
+        and False otherwise
+        """
+        return any(user_groups.intersection(allowed_groups))
+
     async def authenticate(self, handler, data=None, **kwargs):
         # build the parameters to be used in the request exchanging the oauth code for the access token
         access_token_params = self.build_access_tokens_request_params(handler, data)

--- a/oauthenticator/oauth2.py
+++ b/oauthenticator/oauth2.py
@@ -785,8 +785,6 @@ class OAuthenticator(Authenticator):
         # build the auth model to be read if authentication goes right
         auth_model = {
             "name": username,
-            # FIXME: Think about is_admin override, should we call is_admin from
-            #        here or possibly after update_auth_model?
             "admin": True if username in self.admin_users else None,
             "auth_state": self.build_auth_state_dict(token_info, user_info),
         }
@@ -807,9 +805,8 @@ class OAuthenticator(Authenticator):
         Subclasses with authorization logic involving allowed groups should
         override this.
         """
-        # Workaround situation when JupyterHub.load_roles or
-        # JupyterHub.load_groups is used to create a user, see discussion in
-        # https://github.com/jupyterhub/jupyterhub/issues/4461.
+        # A workaround for JupyterHub<=4.0.1, described in
+        # https://github.com/jupyterhub/oauthenticator/issues/621
         if auth_model is None:
             return True
 

--- a/oauthenticator/oauth2.py
+++ b/oauthenticator/oauth2.py
@@ -785,6 +785,8 @@ class OAuthenticator(Authenticator):
         # build the auth model to be read if authentication goes right
         auth_model = {
             "name": username,
+            # FIXME: Think about is_admin override, should we call is_admin from
+            #        here or possibly after update_auth_model?
             "admin": True if username in self.admin_users else None,
             "auth_state": self.build_auth_state_dict(token_info, user_info),
         }

--- a/oauthenticator/oauth2.py
+++ b/oauthenticator/oauth2.py
@@ -763,12 +763,16 @@ class OAuthenticator(Authenticator):
         return True
 
     @staticmethod
-    def user_groups_in_allowed_groups(user_groups: set, allowed_groups: set):
+    def user_groups_in_allowed_groups(user_groups, allowed_groups):
         """
         Returns True if user is a member of any group in the allowed groups,
         and False otherwise
         """
-        return any(user_groups.intersection(allowed_groups))
+        if not isinstance(user_groups, set):
+            user_groups = set(user_groups)
+        if not isinstance(allowed_groups, set):
+            allowed_groups = set(allowed_groups)
+        return any((user_groups).intersection(allowed_groups))
 
     async def authenticate(self, handler, data=None, **kwargs):
         # build the parameters to be used in the request exchanging the oauth code for the access token

--- a/oauthenticator/oauth2.py
+++ b/oauthenticator/oauth2.py
@@ -733,7 +733,7 @@ class OAuthenticator(Authenticator):
             self.user_auth_state_key: user_info,
         }
 
-    async def update_auth_model(self, auth_model, **kwargs):
+    async def update_auth_model(self, auth_model):
         """
         Updates `auth_model` dict if any fields have changed or additional information is available
         or returns the unchanged `auth_model`.
@@ -806,7 +806,7 @@ class OAuthenticator(Authenticator):
             return None
 
         # update the auth model with any info if available
-        return await self.update_auth_model(auth_model, **kwargs)
+        return await self.update_auth_model(auth_model)
 
     _deprecated_oauth_aliases = {}
 

--- a/oauthenticator/oauth2.py
+++ b/oauthenticator/oauth2.py
@@ -807,6 +807,12 @@ class OAuthenticator(Authenticator):
         Subclasses with authorization logic involving allowed groups should
         override this.
         """
+        # Workaround situation when JupyterHub.load_roles or
+        # JupyterHub.load_groups is used to create a user, see discussion in
+        # https://github.com/jupyterhub/jupyterhub/issues/4461.
+        if auth_model is None:
+            return True
+
         # authorize users to become admins by admin_users or logic in
         # update_auth_model
         if auth_model["admin"]:

--- a/oauthenticator/openshift.py
+++ b/oauthenticator/openshift.py
@@ -113,11 +113,14 @@ class OpenShiftOAuthenticator(OAuthenticator):
         user_groups = set(auth_model['auth_state']['openshift_user']['groups'])
         username = auth_model['name']
 
-        if not self.allowed_users and (self.allowed_groups or self.admin_groups):
+        if self.allowed_groups:
             msg = f"username:{username} User not in any of the allowed/admin groups"
             # User is authorized if either in allowed_groups or in admin_groups
+            all_allowed_groups = self.allowed_groups
+            if self.admin_groups:
+                all_allowed_groups = all_allowed_groups.unions(self.admin_groups)
             if not self.user_groups_in_allowed_groups(
-                user_groups, self.allowed_groups.union(self.admin_groups)
+                user_groups, all_allowed_groups
             ):
                 self.log.warning(msg)
                 return False

--- a/oauthenticator/openshift.py
+++ b/oauthenticator/openshift.py
@@ -99,8 +99,10 @@ class OpenShiftOAuthenticator(OAuthenticator):
         is an admin and update the auth_model with this info.
         """
         user_groups = set(auth_model['auth_state']['openshift_user']['groups'])
+        admin_status = True if auth_model['name'] in self.admin_users else None
 
-        if self.admin_groups:
+        # Check if user has been marked as admin by membership in self.admin_groups
+        if not admin_status and self.admin_groups:
             auth_model['admin'] = self.user_in_groups(user_groups, self.admin_groups)
 
         return auth_model

--- a/oauthenticator/openshift.py
+++ b/oauthenticator/openshift.py
@@ -120,9 +120,7 @@ class OpenShiftOAuthenticator(OAuthenticator):
             all_allowed_groups = self.allowed_groups
             if self.admin_groups:
                 all_allowed_groups = all_allowed_groups.unions(self.admin_groups)
-            if not self.user_groups_in_allowed_groups(
-                user_groups, all_allowed_groups
-            ):
+            if not self.user_groups_in_allowed_groups(user_groups, all_allowed_groups):
                 self.log.warning(msg)
                 return False
 

--- a/oauthenticator/openshift.py
+++ b/oauthenticator/openshift.py
@@ -120,9 +120,7 @@ class OpenShiftOAuthenticator(OAuthenticator):
             all_allowed_groups = self.allowed_groups
             if self.admin_groups:
                 all_allowed_groups = all_allowed_groups.union(self.admin_groups)
-            if not self.user_groups_in_allowed_groups(
-                user_groups, all_allowed_groups
-            ):
+            if not self.user_groups_in_allowed_groups(user_groups, all_allowed_groups):
                 self.log.warning(msg)
                 return False
 

--- a/oauthenticator/openshift.py
+++ b/oauthenticator/openshift.py
@@ -113,7 +113,7 @@ class OpenShiftOAuthenticator(OAuthenticator):
         user_groups = set(auth_model['auth_state']['openshift_user']['groups'])
         username = auth_model['name']
 
-        if self.allowed_groups or self.admin_groups:
+        if not self.allowed_users and (self.allowed_groups or self.admin_groups):
             msg = f"username:{username} User not in any of the allowed/admin groups"
             # User is authorized if either in allowed_groups or in admin_groups
             if not self.user_groups_in_allowed_groups(

--- a/oauthenticator/openshift.py
+++ b/oauthenticator/openshift.py
@@ -86,10 +86,6 @@ class OpenShiftOAuthenticator(OAuthenticator):
     def _userdata_url_default(self):
         return f"{self.openshift_rest_api_url}/apis/user.openshift.io/v1/users/~"
 
-    @staticmethod
-    def user_in_groups(user_groups: set, allowed_groups: set):
-        return any(user_groups.intersection(allowed_groups))
-
     def user_info_to_username(self, user_info):
         return user_info['metadata']['name']
 
@@ -103,7 +99,7 @@ class OpenShiftOAuthenticator(OAuthenticator):
 
         # Check if user has been marked as admin by membership in self.admin_groups
         if not admin_status and self.admin_groups:
-            auth_model['admin'] = self.user_in_groups(user_groups, self.admin_groups)
+            auth_model['admin'] = self.user_groups_in_allowed_groups(user_groups, self.admin_groups)
 
         return auth_model
 

--- a/oauthenticator/openshift.py
+++ b/oauthenticator/openshift.py
@@ -91,18 +91,14 @@ class OpenShiftOAuthenticator(OAuthenticator):
 
     async def update_auth_model(self, auth_model):
         """
-        Set the admin status based on finding the username in `admin_users` or
-        finding a user group part of `admin_groups`.
+        Update admin status based on `admin_groups` if its configured.
         """
-        user_info = auth_model["auth_state"][self.user_auth_state_key]
-
-        username = auth_model["name"]
-        if username in self.admin_users:
-            auth_model["admin"] = True
-        elif self.admin_groups:
-            # if admin_groups is configured, we must either set or unset admin
-            # status and never leave it at None, otherwise removing a user from
-            # the admin_groups won't have an effect
+        if self.admin_groups:
+            # if admin_groups is configured and the user wasn't part of
+            # admin_users, we must set the admin status to True or False,
+            # otherwise removing a user from the admin_groups won't have an
+            # effect
+            user_info = auth_model["auth_state"][self.user_auth_state_key]
             user_groups = set(user_info["groups"])
             auth_model["admin"] = any(user_groups & self.admin_groups)
 

--- a/oauthenticator/openshift.py
+++ b/oauthenticator/openshift.py
@@ -114,7 +114,7 @@ class OpenShiftOAuthenticator(OAuthenticator):
         if self.allowed_groups or self.admin_groups:
             msg = f"username:{username} User not in any of the allowed/admin groups"
             # User is authorized if either in allowed_groups or in admin_groups
-            if not self.user_in_groups(user_groups, self.allowed_groups + self.admin_groups):
+            if not self.user_groups_in_allowed_groups(user_groups, self.allowed_groups.union(self.admin_groups)):
                 self.log.warning(msg)
                 return False
 

--- a/oauthenticator/openshift.py
+++ b/oauthenticator/openshift.py
@@ -112,6 +112,12 @@ class OpenShiftOAuthenticator(OAuthenticator):
         either part of `allowed_users` or `allowed_groups`, and not just those
         part of `allowed_users`.
         """
+        # Workaround situation when JupyterHub.load_roles or
+        # JupyterHub.load_groups is used to create a user, see discussion in
+        # https://github.com/jupyterhub/jupyterhub/issues/4461.
+        if auth_model is None:
+            return True
+
         # allow admin users recognized via admin_users or update_auth_model
         if auth_model["admin"]:
             return True

--- a/oauthenticator/openshift.py
+++ b/oauthenticator/openshift.py
@@ -119,9 +119,7 @@ class OpenShiftOAuthenticator(OAuthenticator):
             all_allowed_groups = self.allowed_groups
             if self.admin_groups:
                 all_allowed_groups = all_allowed_groups.unions(self.admin_groups)
-            if not self.user_groups_in_allowed_groups(
-                user_groups, all_allowed_groups
-            ):
+            if not self.user_groups_in_allowed_groups(user_groups, all_allowed_groups):
                 self.log.warning(msg)
                 return False
 

--- a/oauthenticator/openshift.py
+++ b/oauthenticator/openshift.py
@@ -113,10 +113,10 @@ class OpenShiftOAuthenticator(OAuthenticator):
 
         if self.allowed_groups or self.admin_groups:
             msg = f"username:{username} User not in any of the allowed/admin groups"
-            if not self.user_in_groups(user_groups, self.allowed_groups):
-                if not self.user_in_groups(user_groups, self.admin_groups):
-                    self.log.warning(msg)
-                    return False
+            # User is authorized if either in allowed_groups or in admin_groups
+            if not self.user_in_groups(user_groups, self.allowed_groups + self.admin_groups):
+                self.log.warning(msg)
+                return False
 
         return True
 

--- a/oauthenticator/openshift.py
+++ b/oauthenticator/openshift.py
@@ -99,7 +99,9 @@ class OpenShiftOAuthenticator(OAuthenticator):
 
         # Check if user has been marked as admin by membership in self.admin_groups
         if not admin_status and self.admin_groups:
-            auth_model['admin'] = self.user_groups_in_allowed_groups(user_groups, self.admin_groups)
+            auth_model['admin'] = self.user_groups_in_allowed_groups(
+                user_groups, self.admin_groups
+            )
 
         return auth_model
 
@@ -114,7 +116,9 @@ class OpenShiftOAuthenticator(OAuthenticator):
         if self.allowed_groups or self.admin_groups:
             msg = f"username:{username} User not in any of the allowed/admin groups"
             # User is authorized if either in allowed_groups or in admin_groups
-            if not self.user_groups_in_allowed_groups(user_groups, self.allowed_groups.union(self.admin_groups)):
+            if not self.user_groups_in_allowed_groups(
+                user_groups, self.allowed_groups.union(self.admin_groups)
+            ):
                 self.log.warning(msg)
                 return False
 

--- a/oauthenticator/openshift.py
+++ b/oauthenticator/openshift.py
@@ -119,7 +119,9 @@ class OpenShiftOAuthenticator(OAuthenticator):
             all_allowed_groups = self.allowed_groups
             if self.admin_groups:
                 all_allowed_groups = all_allowed_groups.unions(self.admin_groups)
-            if not self.user_groups_in_allowed_groups(user_groups, all_allowed_groups):
+            if not self.user_groups_in_allowed_groups(
+                user_groups, all_allowed_groups
+            ):
                 self.log.warning(msg)
                 return False
 

--- a/oauthenticator/openshift.py
+++ b/oauthenticator/openshift.py
@@ -112,8 +112,9 @@ class OpenShiftOAuthenticator(OAuthenticator):
         """
         user_groups = set(auth_model['auth_state']['openshift_user']['groups'])
         username = auth_model['name']
+        allowed_status = True if username in self.allowed_users else None
 
-        if self.allowed_groups:
+        if not allowed_status and self.allowed_groups:
             msg = f"username:{username} User not in any of the allowed/admin groups"
             # User is authorized if either in allowed_groups or in admin_groups
             all_allowed_groups = self.allowed_groups

--- a/oauthenticator/openshift.py
+++ b/oauthenticator/openshift.py
@@ -112,9 +112,8 @@ class OpenShiftOAuthenticator(OAuthenticator):
         either part of `allowed_users` or `allowed_groups`, and not just those
         part of `allowed_users`.
         """
-        # Workaround situation when JupyterHub.load_roles or
-        # JupyterHub.load_groups is used to create a user, see discussion in
-        # https://github.com/jupyterhub/jupyterhub/issues/4461.
+        # A workaround for JupyterHub<=4.0.1, described in
+        # https://github.com/jupyterhub/oauthenticator/issues/621
         if auth_model is None:
             return True
 

--- a/oauthenticator/openshift.py
+++ b/oauthenticator/openshift.py
@@ -119,8 +119,10 @@ class OpenShiftOAuthenticator(OAuthenticator):
             # User is authorized if either in allowed_groups or in admin_groups
             all_allowed_groups = self.allowed_groups
             if self.admin_groups:
-                all_allowed_groups = all_allowed_groups.unions(self.admin_groups)
-            if not self.user_groups_in_allowed_groups(user_groups, all_allowed_groups):
+                all_allowed_groups = all_allowed_groups.union(self.admin_groups)
+            if not self.user_groups_in_allowed_groups(
+                user_groups, all_allowed_groups
+            ):
                 self.log.warning(msg)
                 return False
 

--- a/oauthenticator/openshift.py
+++ b/oauthenticator/openshift.py
@@ -124,10 +124,10 @@ class OpenShiftOAuthenticator(OAuthenticator):
         # if allowed_users or allowed_groups is configured, we deny users not
         # part of either
         if self.allowed_users or self.allowed_groups:
-            user_info = auth_model["auth_state"][self.user_auth_state_key]
-            user_groups = set(user_info["groups"])
             if username in self.allowed_users:
                 return True
+            user_info = auth_model["auth_state"][self.user_auth_state_key]
+            user_groups = set(user_info["groups"])
             if any(user_groups & self.allowed_groups):
                 return True
             return False

--- a/oauthenticator/tests/mocks.py
+++ b/oauthenticator/tests/mocks.py
@@ -253,5 +253,5 @@ async def no_code_test(authenticator):
     handler = Mock(spec=web.RequestHandler)
     handler.get_argument = Mock(return_value=None)
     with pytest.raises(web.HTTPError) as exc:
-        name = await authenticator.authenticate(handler)
+        auth_model = await authenticator.get_authenticated_user(handler, None)
     assert exc.value.status_code == 400

--- a/oauthenticator/tests/test_auth0.py
+++ b/oauthenticator/tests/test_auth0.py
@@ -42,11 +42,10 @@ async def test_auth0(config, auth0_client):
     authenticator = Auth0OAuthenticator(config=cfg)
 
     handler = auth0_client.handler_for_user(user_model('kaylee@serenity.now'))
-    user_info = await authenticator.authenticate(handler)
-    assert sorted(user_info) == ['auth_state', 'name']
-    name = user_info['name']
-    assert name == 'kaylee@serenity.now'
-    auth_state = user_info['auth_state']
+    auth_model = await authenticator.get_authenticated_user(handler, None)
+    assert sorted(auth_model) == ['admin', 'auth_state', 'name']
+    assert auth_model['name'] == 'kaylee@serenity.now'
+    auth_state = auth_model['auth_state']
     assert 'access_token' in auth_state
     assert 'auth0_user' in auth_state
 
@@ -60,9 +59,8 @@ async def test_username_key(config, auth0_client):
     authenticator = Auth0OAuthenticator(config=cfg)
     authenticator.username_key = 'nickname'
     handler = auth0_client.handler_for_user(user_model('kaylee@serenity.now', 'kayle'))
-    user_info = await authenticator.authenticate(handler)
-
-    assert user_info['name'] == 'kayle'
+    auth_model = await authenticator.get_authenticated_user(handler, None)
+    assert auth_model['name'] == 'kayle'
 
 
 async def test_custom_logout(monkeypatch):

--- a/oauthenticator/tests/test_azuread.py
+++ b/oauthenticator/tests/test_azuread.py
@@ -92,17 +92,17 @@ async def test_azuread(username_claim, azure_client):
         )
     )
 
-    user_info = await authenticator.authenticate(handler)
-    assert sorted(user_info) == ['auth_state', 'name']
+    auth_model = await authenticator.authenticate(handler)
+    assert sorted(auth_model) == ['admin', 'auth_state', 'name']
 
-    auth_state = user_info['auth_state']
+    auth_state = auth_model['auth_state']
     assert 'access_token' in auth_state
     assert 'user' in auth_state
 
     auth_state_user_info = auth_state['user']
     assert auth_state_user_info['aud'] == authenticator.client_id
 
-    username = user_info['name']
+    username = auth_model['name']
     if username_claim:
         assert username == auth_state_user_info[username_claim]
     else:

--- a/oauthenticator/tests/test_bitbucket.py
+++ b/oauthenticator/tests/test_bitbucket.py
@@ -28,11 +28,10 @@ def bitbucket_client(client):
 async def test_bitbucket(bitbucket_client):
     authenticator = BitbucketOAuthenticator()
     handler = bitbucket_client.handler_for_user(user_model('yorba'))
-    user_info = await authenticator.authenticate(handler)
-    assert sorted(user_info) == ['auth_state', 'name']
-    name = user_info['name']
-    assert name == 'yorba'
-    auth_state = user_info['auth_state']
+    auth_model = await authenticator.get_authenticated_user(handler, None)
+    assert sorted(auth_model) == ['admin', 'auth_state', 'name']
+    assert auth_model['name'] == 'yorba'
+    auth_state = auth_model['auth_state']
     assert 'access_token' in auth_state
     assert 'bitbucket_user' in auth_state
 
@@ -59,25 +58,23 @@ async def test_allowed_teams(bitbucket_client):
     client.hosts['api.bitbucket.org'].append(('/2.0/workspaces', list_teams))
 
     handler = client.handler_for_user(user_model('caboose'))
-    user_info = await authenticator.authenticate(handler)
-    name = user_info['name']
-    assert name == 'caboose'
+    auth_model = await authenticator.get_authenticated_user(handler, None)
+    assert auth_model['name'] == 'caboose'
 
     handler = client.handler_for_user(user_model('donut'))
-    name = await authenticator.authenticate(handler)
-    assert name is None
+    auth_model = await authenticator.get_authenticated_user(handler, None)
+    assert auth_model is None
 
     # reverse it, just to be safe
     authenticator.allowed_teams = ['red']
 
     handler = client.handler_for_user(user_model('caboose'))
-    name = await authenticator.authenticate(handler)
-    assert name is None
+    auth_model = await authenticator.get_authenticated_user(handler, None)
+    assert auth_model is None
 
     handler = client.handler_for_user(user_model('donut'))
-    user_info = await authenticator.authenticate(handler)
-    name = user_info['name']
-    assert name == 'donut'
+    auth_model = await authenticator.get_authenticated_user(handler, None)
+    assert auth_model['name'] == 'donut'
 
 
 async def test_deprecated_config(caplog):

--- a/oauthenticator/tests/test_generic.py
+++ b/oauthenticator/tests/test_generic.py
@@ -190,6 +190,27 @@ async def test_generic_groups_claim_key_with_allowed_groups_and_admin_groups_not
     assert user_info['admin'] is False
 
 
+async def test_generic_groups_claim_key_with_allowed_groups_and_no_admin_groups_but_admin_users(
+    get_authenticator, generic_client
+):
+    authenticator = get_authenticator(
+        scope=['openid', 'profile', 'roles'],
+        claim_groups_key='groups',
+        allowed_groups=['user'],
+        admin_groups=[],
+        admin_users=['wash'],
+    )
+    handler = generic_client.handler_for_user(
+        user_model('wash', alternate_username='zoe', groups=['user'])
+    )
+
+    # Assert that the authenticated user is actually an admin due to being listed in `admin_users`
+    # Even though admin_groups is empty
+    user_info = await authenticator.get_authenticated_user(handler, data=None)
+    assert user_info['name'] == 'wash'
+    assert user_info['admin'] is True
+
+
 async def test_generic_callable_groups_claim_key_with_allowed_groups_and_admin_groups(
     get_authenticator, generic_client
 ):

--- a/oauthenticator/tests/test_generic.py
+++ b/oauthenticator/tests/test_generic.py
@@ -48,11 +48,10 @@ async def test_generic(get_authenticator, generic_client):
     authenticator = get_authenticator()
 
     handler = get_simple_handler(generic_client)
-    user_info = await authenticator.authenticate(handler)
-    assert sorted(user_info) == ['auth_state', 'name']
-    name = user_info['name']
-    assert name == 'wash'
-    auth_state = user_info['auth_state']
+    auth_model = await authenticator.get_authenticated_user(handler, None)
+    assert sorted(auth_model) == ['admin', 'auth_state', 'name']
+    assert auth_model['name'] == 'wash'
+    auth_state = auth_model['auth_state']
     assert 'access_token' in auth_state
     assert 'oauth_user' in auth_state
     assert 'refresh_token' in auth_state
@@ -64,10 +63,9 @@ async def test_generic_data(get_authenticator, generic_client):
 
     handler = get_simple_handler(generic_client)
     data = {'testing': 'data'}
-    user_info = await authenticator.authenticate(handler, data)
-    assert sorted(user_info) == ['auth_state', 'name']
-    name = user_info['name']
-    assert name == 'wash'
+    auth_model = await authenticator.authenticate(handler, data)
+    assert sorted(auth_model) == ['admin', 'auth_state', 'name']
+    assert auth_model['name'] == 'wash'
 
 
 async def test_generic_callable_username_key(get_authenticator, generic_client):
@@ -75,8 +73,8 @@ async def test_generic_callable_username_key(get_authenticator, generic_client):
     handler = generic_client.handler_for_user(
         user_model('wash', alternate_username='zoe')
     )
-    user_info = await authenticator.authenticate(handler)
-    assert user_info['name'] == 'zoe'
+    auth_model = await authenticator.get_authenticated_user(handler, None)
+    assert auth_model['name'] == 'zoe'
 
 
 async def test_generic_callable_groups_claim_key_with_allowed_groups(
@@ -90,8 +88,8 @@ async def test_generic_callable_groups_claim_key_with_allowed_groups(
     handler = generic_client.handler_for_user(
         user_model('wash', alternate_username='zoe', policies={'roles': ['super_user']})
     )
-    user_info = await authenticator.authenticate(handler)
-    assert user_info['name'] == 'wash'
+    auth_model = await authenticator.get_authenticated_user(handler, None)
+    assert auth_model['name'] == 'wash'
 
 
 async def test_generic_groups_claim_key_with_allowed_groups(
@@ -105,8 +103,8 @@ async def test_generic_groups_claim_key_with_allowed_groups(
     handler = generic_client.handler_for_user(
         user_model('wash', alternate_username='zoe', groups=['super_user'])
     )
-    user_info = await authenticator.authenticate(handler)
-    assert user_info['name'] == 'wash'
+    auth_model = await authenticator.get_authenticated_user(handler, None)
+    assert auth_model['name'] == 'wash'
 
 
 async def test_generic_groups_claim_key_nested_strings(
@@ -122,8 +120,8 @@ async def test_generic_groups_claim_key_nested_strings(
             'wash', alternate_username='zoe', permissions={"groups": ['super_user']}
         )
     )
-    user_info = await authenticator.authenticate(handler)
-    assert user_info['name'] == 'wash'
+    auth_model = await authenticator.get_authenticated_user(handler, None)
+    assert auth_model['name'] == 'wash'
 
 
 async def test_generic_groups_claim_key_nested_strings_nonexistant_key(
@@ -137,8 +135,8 @@ async def test_generic_groups_claim_key_nested_strings_nonexistant_key(
     handler = generic_client.handler_for_user(
         user_model('wash', alternate_username='zoe')
     )
-    user_info = await authenticator.authenticate(handler)
-    assert user_info is None
+    auth_model = await authenticator.get_authenticated_user(handler, None)
+    assert auth_model is None
 
 
 async def test_generic_groups_claim_key_with_allowed_groups_unauthorized(
@@ -152,8 +150,8 @@ async def test_generic_groups_claim_key_with_allowed_groups_unauthorized(
     handler = generic_client.handler_for_user(
         user_model('wash', alternate_username='zoe', groups=['public'])
     )
-    user_info = await authenticator.authenticate(handler)
-    assert user_info is None
+    auth_model = await authenticator.get_authenticated_user(handler, None)
+    assert auth_model is None
 
 
 async def test_generic_groups_claim_key_with_allowed_groups_and_admin_groups(
@@ -168,9 +166,9 @@ async def test_generic_groups_claim_key_with_allowed_groups_and_admin_groups(
     handler = generic_client.handler_for_user(
         user_model('wash', alternate_username='zoe', groups=['user', 'administrator'])
     )
-    user_info = await authenticator.authenticate(handler)
-    assert user_info['name'] == 'wash'
-    assert user_info['admin'] is True
+    auth_model = await authenticator.get_authenticated_user(handler, None)
+    assert auth_model['name'] == 'wash'
+    assert auth_model['admin'] is True
 
 
 async def test_generic_groups_claim_key_with_allowed_groups_and_admin_groups_not_admin(
@@ -185,9 +183,9 @@ async def test_generic_groups_claim_key_with_allowed_groups_and_admin_groups_not
     handler = generic_client.handler_for_user(
         user_model('wash', alternate_username='zoe', groups=['user'])
     )
-    user_info = await authenticator.authenticate(handler)
-    assert user_info['name'] == 'wash'
-    assert user_info['admin'] is False
+    auth_model = await authenticator.get_authenticated_user(handler, None)
+    assert auth_model['name'] == 'wash'
+    assert auth_model['admin'] is False
 
 
 async def test_generic_groups_claim_key_with_allowed_groups_and_no_admin_groups_but_admin_users(
@@ -206,9 +204,9 @@ async def test_generic_groups_claim_key_with_allowed_groups_and_no_admin_groups_
 
     # Assert that the authenticated user is actually an admin due to being listed in `admin_users`
     # Even though admin_groups is empty
-    user_info = await authenticator.get_authenticated_user(handler, data=None)
-    assert user_info['name'] == 'wash'
-    assert user_info['admin'] is True
+    auth_model = await authenticator.get_authenticated_user(handler, data=None)
+    assert auth_model['name'] == 'wash'
+    assert auth_model['admin'] is True
 
 
 async def test_generic_callable_groups_claim_key_with_allowed_groups_and_admin_groups(
@@ -228,6 +226,6 @@ async def test_generic_callable_groups_claim_key_with_allowed_groups_and_admin_g
             policies={'roles': ['user', 'administrator']},
         )
     )
-    user_info = await authenticator.authenticate(handler)
-    assert user_info['name'] == 'zoe'
-    assert user_info['admin'] is True
+    auth_model = await authenticator.get_authenticated_user(handler, None)
+    assert auth_model['name'] == 'zoe'
+    assert auth_model['admin'] is True

--- a/oauthenticator/tests/test_github.py
+++ b/oauthenticator/tests/test_github.py
@@ -5,7 +5,7 @@ import re
 from io import BytesIO
 from urllib.parse import parse_qs, urlparse
 
-from pytest import fixture, mark
+from pytest import fixture
 from tornado.httpclient import HTTPResponse
 from tornado.httputil import HTTPHeaders
 from traitlets.config import Config
@@ -191,23 +191,6 @@ async def test_allowed_org_membership(github_client):
 
         client_hosts.pop()
         client_hosts.pop()
-
-
-@mark.parametrize(
-    "org, username, expected",
-    [
-        ("blue", "texas", "https://api.github.com/orgs/blue/members/texas"),
-        (
-            "blue:alpha",
-            "tucker",
-            "https://api.github.com/orgs/blue/teams/alpha/members/tucker",
-        ),
-        ("red", "grif", "https://api.github.com/orgs/red/members/grif"),
-    ],
-)
-async def test_build_check_membership_url(org, username, expected):
-    output = GitHubOAuthenticator()._build_check_membership_url(org, username)
-    assert output == expected
 
 
 async def test_deprecated_config(caplog):

--- a/oauthenticator/tests/test_github.py
+++ b/oauthenticator/tests/test_github.py
@@ -39,16 +39,15 @@ def github_client(client):
 async def test_github(github_client):
     authenticator = GitHubOAuthenticator()
     handler = github_client.handler_for_user(user_model('wash'))
-    user_info = await authenticator.authenticate(handler)
-    name = user_info['name']
-    assert name == 'wash'
-    auth_state = user_info['auth_state']
+    auth_model = await authenticator.get_authenticated_user(handler, None)
+    assert auth_model['name'] == 'wash'
+    auth_state = auth_model['auth_state']
     assert 'access_token' in auth_state
     assert 'github_user' in auth_state
     assert auth_state["github_user"] == {
         'email': 'dinosaurs@space',
         'id': 5,
-        'login': name,
+        'login': auth_model['name'],
         'name': 'Hoban Washburn',
     }
 
@@ -157,38 +156,38 @@ async def test_allowed_org_membership(github_client):
         authenticator.allowed_organizations = ['blue']
 
         handler = client.handler_for_user(user_model('caboose'))
-        user = await authenticator.authenticate(handler)
-        assert user['name'] == 'caboose'
+        auth_model = await authenticator.get_authenticated_user(handler, None)
+        assert auth_model['name'] == 'caboose'
 
         handler = client.handler_for_user(user_model('donut'))
-        user = await authenticator.authenticate(handler)
-        assert user is None
+        auth_model = await authenticator.get_authenticated_user(handler, None)
+        assert auth_model is None
 
         # reverse it, just to be safe
         authenticator.allowed_organizations = ['red']
 
         handler = client.handler_for_user(user_model('caboose'))
-        user = await authenticator.authenticate(handler)
-        assert user is None
+        auth_model = await authenticator.get_authenticated_user(handler, None)
+        assert auth_model is None
 
         handler = client.handler_for_user(user_model('donut'))
-        user = await authenticator.authenticate(handler)
-        assert user['name'] == 'donut'
+        auth_model = await authenticator.get_authenticated_user(handler, None)
+        assert auth_model['name'] == 'donut'
 
         # test team membership
         authenticator.allowed_organizations = ['blue:alpha', 'red']
 
         handler = client.handler_for_user(user_model('tucker'))
-        user = await authenticator.authenticate(handler)
-        assert user['name'] == 'tucker'
+        auth_model = await authenticator.get_authenticated_user(handler, None)
+        assert auth_model['name'] == 'tucker'
 
         handler = client.handler_for_user(user_model('grif'))
-        user = await authenticator.authenticate(handler)
-        assert user['name'] == 'grif'
+        auth_model = await authenticator.get_authenticated_user(handler, None)
+        assert auth_model['name'] == 'grif'
 
         handler = client.handler_for_user(user_model('texas'))
-        user = await authenticator.authenticate(handler)
-        assert user is None
+        auth_model = await authenticator.get_authenticated_user(handler, None)
+        assert auth_model is None
 
         client_hosts.pop()
         client_hosts.pop()

--- a/oauthenticator/tests/test_globus.py
+++ b/oauthenticator/tests/test_globus.py
@@ -229,7 +229,7 @@ async def test_restricted_domain(globus_client):
     authenticator.identity_provider = 'alliance.gov'
     handler = globus_client.handler_for_user(user_model('wash@uflightacademy.edu'))
     with raises(web.HTTPError) as exc:
-        authenticator.get_authenticated_user(handler, None)
+        await authenticator.get_authenticated_user(handler, None)
     assert exc.value.status_code == 403
 
 
@@ -294,7 +294,7 @@ async def test_username_from_email_restricted_fail(globus_client):
     um = user_model('wash@serenity.com', 'alan@tudyk.org')
     handler = globus_client.handler_for_user(um)
     with raises(web.HTTPError) as exc:
-        authenticator.get_authenticated_user(handler, None)
+        await authenticator.get_authenticated_user(handler, None)
     assert exc.value.status_code == 403
 
 

--- a/oauthenticator/tests/test_globus.py
+++ b/oauthenticator/tests/test_globus.py
@@ -395,7 +395,7 @@ async def test_logout_revokes_tokens(globus_client, monkeypatch, mock_globus_use
 
 async def test_group_scope_added(globus_client):
     authenticator = GlobusOAuthenticator()
-    authenticator.allowed_globus_groups = set({'21c6bc5d-fc12-4f60-b999-76766cd596c2'})
+    authenticator.allowed_globus_groups = {'21c6bc5d-fc12-4f60-b999-76766cd596c2'}
     assert authenticator.scope == [
         'openid',
         'profile',
@@ -406,7 +406,7 @@ async def test_group_scope_added(globus_client):
 
 async def test_user_in_allowed_group(globus_client):
     authenticator = GlobusOAuthenticator()
-    authenticator.allowed_globus_groups = set({'21c6bc5d-fc12-4f60-b999-76766cd596c2'})
+    authenticator.allowed_globus_groups = {'21c6bc5d-fc12-4f60-b999-76766cd596c2'}
     handler = globus_client.handler_for_user(user_model('wash@uflightacademy.edu'))
     auth_model = await authenticator.get_authenticated_user(handler, None)
     assert auth_model['name'] == 'wash'
@@ -414,7 +414,7 @@ async def test_user_in_allowed_group(globus_client):
 
 async def test_user_not_allowed(globus_client):
     authenticator = GlobusOAuthenticator()
-    authenticator.allowed_globus_groups = set({'3f1f85c4-f084-4173-9efb-7c7e0b44291a'})
+    authenticator.allowed_globus_groups = {'3f1f85c4-f084-4173-9efb-7c7e0b44291a'}
     handler = globus_client.handler_for_user(user_model('wash@uflightacademy.edu'))
     auth_model = await authenticator.get_authenticated_user(handler, None)
     assert auth_model == None
@@ -422,7 +422,7 @@ async def test_user_not_allowed(globus_client):
 
 async def test_user_is_admin(globus_client):
     authenticator = GlobusOAuthenticator()
-    authenticator.admin_globus_groups = set({'21c6bc5d-fc12-4f60-b999-76766cd596c2'})
+    authenticator.admin_globus_groups = {'21c6bc5d-fc12-4f60-b999-76766cd596c2'}
     handler = globus_client.handler_for_user(user_model('wash@uflightacademy.edu'))
     auth_model = await authenticator.get_authenticated_user(handler, None)
     assert auth_model['name'] == 'wash'
@@ -431,8 +431,8 @@ async def test_user_is_admin(globus_client):
 
 async def test_user_allowed_not_admin(globus_client):
     authenticator = GlobusOAuthenticator()
-    authenticator.allowed_globus_groups = set({'21c6bc5d-fc12-4f60-b999-76766cd596c2'})
-    authenticator.admin_globus_groups = set({'3f1f85c4-f084-4173-9efb-7c7e0b44291a'})
+    authenticator.allowed_globus_groups = {'21c6bc5d-fc12-4f60-b999-76766cd596c2'}
+    authenticator.admin_globus_groups = {'3f1f85c4-f084-4173-9efb-7c7e0b44291a'}
     handler = globus_client.handler_for_user(user_model('wash@uflightacademy.edu'))
     auth_model = await authenticator.get_authenticated_user(handler, None)
     assert auth_model['name'] == 'wash'

--- a/oauthenticator/tests/test_globus.py
+++ b/oauthenticator/tests/test_globus.py
@@ -187,9 +187,9 @@ def mock_globus_user(globus_tokens_by_resource_server):
 async def test_globus(globus_client):
     authenticator = GlobusOAuthenticator()
     handler = globus_client.handler_for_user(user_model('wash@uflightacademy.edu'))
-    data = await authenticator.authenticate(handler)
-    assert data['name'] == 'wash'
-    tokens = list(data['auth_state']['tokens'].keys())
+    auth_model = await authenticator.get_authenticated_user(handler, None)
+    assert auth_model['name'] == 'wash'
+    tokens = list(auth_model['auth_state']['tokens'].keys())
     assert tokens == ['transfer.api.globus.org']
 
 
@@ -229,7 +229,7 @@ async def test_restricted_domain(globus_client):
     authenticator.identity_provider = 'alliance.gov'
     handler = globus_client.handler_for_user(user_model('wash@uflightacademy.edu'))
     with raises(web.HTTPError) as exc:
-        await authenticator.authenticate(handler)
+        authenticator.get_authenticated_user(handler, None)
     assert exc.value.status_code == 403
 
 
@@ -239,8 +239,8 @@ async def test_namespaced_domain(globus_client):
     authenticator.identity_provider = ''
     um = user_model('wash@legitshipping.com@serenity.com')
     handler = globus_client.handler_for_user(um)
-    data = await authenticator.authenticate(handler)
-    assert data['name'] == 'wash'
+    auth_model = await authenticator.get_authenticated_user(handler, None)
+    assert auth_model['name'] == 'wash'
 
 
 async def test_username_from_email(globus_client):
@@ -250,8 +250,8 @@ async def test_username_from_email(globus_client):
     authenticator.username_from_email = True
     um = user_model('wash@legitshipping.com@serenity.com', 'alan@tudyk.org')
     handler = globus_client.handler_for_user(um)
-    data = await authenticator.authenticate(handler)
-    assert data['name'] == 'alan'
+    auth_model = await authenticator.get_authenticated_user(handler, None)
+    assert auth_model['name'] == 'alan'
 
 
 async def test_username_not_from_email(globus_client):
@@ -260,8 +260,8 @@ async def test_username_not_from_email(globus_client):
     authenticator.identity_provider = ''
     um = user_model('wash@legitshipping.com@serenity.com', 'alan@tudyk.org')
     handler = globus_client.handler_for_user(um)
-    data = await authenticator.authenticate(handler)
-    assert data['name'] == 'wash'
+    auth_model = await authenticator.get_authenticated_user(handler, None)
+    assert auth_model['name'] == 'wash'
 
 
 async def test_email_scope_added(globus_client):
@@ -282,8 +282,8 @@ async def test_username_from_email_restricted_pass(globus_client):
     authenticator.username_from_email = True
     um = user_model('wash@serenity.com', 'alan@serenity.com')
     handler = globus_client.handler_for_user(um)
-    data = await authenticator.authenticate(handler)
-    assert data['name'] == 'alan'
+    auth_model = await authenticator.get_authenticated_user(handler, None)
+    assert auth_model['name'] == 'alan'
 
 
 async def test_username_from_email_restricted_fail(globus_client):
@@ -294,7 +294,7 @@ async def test_username_from_email_restricted_fail(globus_client):
     um = user_model('wash@serenity.com', 'alan@tudyk.org')
     handler = globus_client.handler_for_user(um)
     with raises(web.HTTPError) as exc:
-        await authenticator.authenticate(handler)
+        authenticator.get_authenticated_user(handler, None)
     assert exc.value.status_code == 403
 
 
@@ -306,9 +306,9 @@ async def test_token_exclusion(globus_client):
         'groups.api.globus.org',
     ]
     handler = globus_client.handler_for_user(user_model('wash@uflightacademy.edu'))
-    data = await authenticator.authenticate(handler)
-    assert data['name'] == 'wash'
-    assert list(data['auth_state']['tokens'].keys()) == []
+    auth_model = await authenticator.get_authenticated_user(handler, None)
+    assert auth_model['name'] == 'wash'
+    assert list(auth_model['auth_state']['tokens'].keys()) == []
 
 
 async def test_revoke_tokens(globus_client, mock_globus_user):
@@ -408,25 +408,25 @@ async def test_user_in_allowed_group(globus_client):
     authenticator = GlobusOAuthenticator()
     authenticator.allowed_globus_groups = set({'21c6bc5d-fc12-4f60-b999-76766cd596c2'})
     handler = globus_client.handler_for_user(user_model('wash@uflightacademy.edu'))
-    data = await authenticator.authenticate(handler)
-    assert data['name'] == 'wash'
+    auth_model = await authenticator.get_authenticated_user(handler, None)
+    assert auth_model['name'] == 'wash'
 
 
 async def test_user_not_allowed(globus_client):
     authenticator = GlobusOAuthenticator()
     authenticator.allowed_globus_groups = set({'3f1f85c4-f084-4173-9efb-7c7e0b44291a'})
     handler = globus_client.handler_for_user(user_model('wash@uflightacademy.edu'))
-    data = await authenticator.authenticate(handler)
-    assert data == None
+    auth_model = await authenticator.get_authenticated_user(handler, None)
+    assert auth_model == None
 
 
 async def test_user_is_admin(globus_client):
     authenticator = GlobusOAuthenticator()
     authenticator.admin_globus_groups = set({'21c6bc5d-fc12-4f60-b999-76766cd596c2'})
     handler = globus_client.handler_for_user(user_model('wash@uflightacademy.edu'))
-    data = await authenticator.authenticate(handler)
-    assert data['name'] == 'wash'
-    assert data['admin'] == True
+    auth_model = await authenticator.get_authenticated_user(handler, None)
+    assert auth_model['name'] == 'wash'
+    assert auth_model['admin'] == True
 
 
 async def test_user_allowed_not_admin(globus_client):
@@ -434,6 +434,6 @@ async def test_user_allowed_not_admin(globus_client):
     authenticator.allowed_globus_groups = set({'21c6bc5d-fc12-4f60-b999-76766cd596c2'})
     authenticator.admin_globus_groups = set({'3f1f85c4-f084-4173-9efb-7c7e0b44291a'})
     handler = globus_client.handler_for_user(user_model('wash@uflightacademy.edu'))
-    data = await authenticator.authenticate(handler)
-    assert data['name'] == 'wash'
-    assert data['admin'] == False
+    auth_model = await authenticator.get_authenticated_user(handler, None)
+    assert auth_model['name'] == 'wash'
+    assert auth_model['admin'] == False

--- a/oauthenticator/tests/test_google.py
+++ b/oauthenticator/tests/test_google.py
@@ -135,7 +135,7 @@ async def test_admin_google_groups(google_client):
         ]
         admin_user = allowed_user_info['admin']
         assert 'fakegroup' in allowed_user_groups
-        assert not admin_user
+        assert admin_user is False
     handler = google_client.handler_for_user(user_model('fakenonalloweduser@email.com'))
     with mock.patch.object(
         authenticator,

--- a/oauthenticator/tests/test_google.py
+++ b/oauthenticator/tests/test_google.py
@@ -37,8 +37,8 @@ async def test_google(google_client):
     handler = google_client.handler_for_user(user_model('fake@email.com'))
     with mock.patch.object(
         authenticator,
-        '_google_groups_for_user',
-        lambda *args: ['anotherone', 'fakeadmingroup'],
+        '_fetch_user_groups',
+        lambda *args: {'anotherone', 'fakeadmingroup'},
     ):
         user_info = await authenticator.get_authenticated_user(handler, None)
         assert sorted(user_info) == ['admin', 'auth_state', 'name']
@@ -56,8 +56,8 @@ async def test_google_username_claim(google_client):
     handler = google_client.handler_for_user(user_model('fake@email.com'))
     with mock.patch.object(
         authenticator,
-        '_google_groups_for_user',
-        lambda *args: ['anotherone', 'fakeadmingroup'],
+        '_fetch_user_groups',
+        lambda *args: {'anotherone', 'fakeadmingroup'},
     ):
         user_info = await authenticator.get_authenticated_user(handler, None)
         assert sorted(user_info) == ['admin', 'auth_state', 'name']
@@ -70,8 +70,8 @@ async def test_hosted_domain(google_client):
     handler = google_client.handler_for_user(user_model('fake@email.com'))
     with mock.patch.object(
         authenticator,
-        '_google_groups_for_user',
-        lambda *args: ['anotherone', 'fakeadmingroup'],
+        '_fetch_user_groups',
+        lambda *args: {'anotherone', 'fakeadmingroup'},
     ):
         user_info = await authenticator.get_authenticated_user(handler, None)
         name = user_info['name']
@@ -88,8 +88,8 @@ async def test_multiple_hosted_domain(google_client):
     handler = google_client.handler_for_user(user_model('fake@email.com'))
     with mock.patch.object(
         authenticator,
-        '_google_groups_for_user',
-        lambda *args: ['anotherone', 'fakeadmingroup'],
+        '_fetch_user_groups',
+        lambda *args: {'anotherone', 'fakeadmingroup'},
     ):
         user_info = await authenticator.get_authenticated_user(handler, None)
         name = user_info['name']
@@ -115,8 +115,8 @@ async def test_admin_google_groups(google_client):
     handler = google_client.handler_for_user(user_model('fakeadmin@email.com'))
     with mock.patch.object(
         authenticator,
-        '_google_groups_for_user',
-        lambda *args: ['anotherone', 'fakeadmingroup'],
+        '_fetch_user_groups',
+        lambda *args: {'anotherone', 'fakeadmingroup'},
     ):
         admin_user_info = await authenticator.get_authenticated_user(handler, None)
         # Make sure the user authenticated successfully
@@ -126,8 +126,8 @@ async def test_admin_google_groups(google_client):
     handler = google_client.handler_for_user(user_model('fakealloweduser@email.com'))
     with mock.patch.object(
         authenticator,
-        '_google_groups_for_user',
-        lambda *args: ['anotherone', 'fakegroup'],
+        '_fetch_user_groups',
+        lambda *args: {'anotherone', 'fakegroup'},
     ):
         allowed_user_info = await authenticator.get_authenticated_user(handler, None)
         allowed_user_groups = allowed_user_info['auth_state']['google_user'][
@@ -139,8 +139,8 @@ async def test_admin_google_groups(google_client):
     handler = google_client.handler_for_user(user_model('fakenonalloweduser@email.com'))
     with mock.patch.object(
         authenticator,
-        '_google_groups_for_user',
-        lambda *args: ['anotherone', 'fakenonallowedgroup'],
+        '_fetch_user_groups',
+        lambda *args: {'anotherone', 'fakenonallowedgroup'},
     ):
         allowed_user_groups = await authenticator.get_authenticated_user(handler, None)
         assert allowed_user_groups is None
@@ -155,8 +155,8 @@ async def test_admin_user_but_no_admin_google_groups(google_client):
     handler = google_client.handler_for_user(user_model('fakeadmin@email.com'))
     with mock.patch.object(
         authenticator,
-        '_google_groups_for_user',
-        lambda *args: ['anotherone', 'fakegroup'],
+        '_fetch_user_groups',
+        lambda *args: {'anotherone', 'fakegroup'},
     ):
         admin_user_info = await authenticator.get_authenticated_user(handler, data=None)
         # Make sure the user authenticated successfully
@@ -173,16 +173,16 @@ async def test_allowed_google_groups(google_client):
     handler = google_client.handler_for_user(user_model('fakeadmin@email.com'))
     with mock.patch.object(
         authenticator,
-        '_google_groups_for_user',
-        lambda *args: ['anotherone', 'fakeadmingroup'],
+        '_fetch_user_groups',
+        lambda *args: {'anotherone', 'fakeadmingroup'},
     ):
         admin_user_info = await authenticator.get_authenticated_user(handler, None)
         assert admin_user_info is None
     handler = google_client.handler_for_user(user_model('fakealloweduser@email.com'))
     with mock.patch.object(
         authenticator,
-        '_google_groups_for_user',
-        lambda *args: ['anotherone', 'fakegroup'],
+        '_fetch_user_groups',
+        lambda *args: {'anotherone', 'fakegroup'},
     ):
         allowed_user_info = await authenticator.get_authenticated_user(handler, None)
         allowed_user_groups = allowed_user_info['auth_state']['google_user'][
@@ -194,14 +194,14 @@ async def test_allowed_google_groups(google_client):
     handler = google_client.handler_for_user(user_model('fakenonalloweduser@email.com'))
     with mock.patch.object(
         authenticator,
-        '_google_groups_for_user',
-        lambda *args: ['anotherone', 'fakenonallowedgroup'],
+        '_fetch_user_groups',
+        lambda *args: {'anotherone', 'fakenonallowedgroup'},
     ):
         allowed_user_groups = await authenticator.get_authenticated_user(handler, None)
         assert allowed_user_groups is None
     handler = google_client.handler_for_user(user_model('fake@mycollege.edu'))
     with mock.patch.object(
-        authenticator, '_google_groups_for_user', lambda *args: ['fakegroup']
+        authenticator, '_fetch_user_groups', lambda *args: {'fakegroup'}
     ):
         allowed_user_groups = await authenticator.get_authenticated_user(handler, None)
         assert allowed_user_groups is None
@@ -215,8 +215,8 @@ async def test_admin_only_google_groups(google_client):
     handler = google_client.handler_for_user(user_model('fakeadmin@email.com'))
     with mock.patch.object(
         authenticator,
-        '_google_groups_for_user',
-        lambda *args: ['anotherone', 'fakeadmingroup'],
+        '_fetch_user_groups',
+        lambda *args: {'anotherone', 'fakeadmingroup'},
     ):
         admin_user_info = await authenticator.get_authenticated_user(handler, None)
         admin_user = admin_user_info['admin']

--- a/oauthenticator/tests/test_mediawiki.py
+++ b/oauthenticator/tests/test_mediawiki.py
@@ -60,7 +60,7 @@ async def test_mediawiki(mediawiki):
         request=Mock(query='oauth_token=key&oauth_verifier=me'),
         find_user=Mock(return_value=None),
     )
-    user = await authenticator.authenticate(handler)
+    user = await authenticator.get_authenticated_user(handler, None)
     assert user['name'] == 'wash'
     auth_state = user['auth_state']
     assert auth_state['ACCESS_TOKEN_KEY'] == 'key'

--- a/oauthenticator/tests/test_okpy.py
+++ b/oauthenticator/tests/test_okpy.py
@@ -26,8 +26,8 @@ def okpy_client(client):
 async def test_okpy(okpy_client):
     authenticator = OkpyOAuthenticator()
     handler = okpy_client.handler_for_user(user_model('testing@example.com'))
-    user_info = await authenticator.authenticate(handler)
-    assert sorted(user_info) == ['auth_state', 'name']
+    user_info = await authenticator.get_authenticated_user(handler, None)
+    assert sorted(user_info) == ['admin', 'auth_state', 'name']
     name = user_info['name']
     assert name == 'testing@example.com'
     auth_state = user_info['auth_state']

--- a/oauthenticator/tests/test_openshift.py
+++ b/oauthenticator/tests/test_openshift.py
@@ -93,6 +93,7 @@ async def test_openshift_in_allowed_groups_and_is_not_admin(openshift_client):
     assert sorted(user_info) == ['admin', 'auth_state', 'name']
     assert user_info['admin'] == False
 
+
 async def test_openshift_not_in_admin_users_but_not_in_admin_groups(openshift_client):
     authenticator = OpenShiftOAuthenticator()
     authenticator.allowed_groups = {'group1'}

--- a/oauthenticator/tests/test_openshift.py
+++ b/oauthenticator/tests/test_openshift.py
@@ -92,3 +92,13 @@ async def test_openshift_in_allowed_groups_and_is_not_admin(openshift_client):
     user_info = await authenticator.authenticate(handler)
     assert sorted(user_info) == ['admin', 'auth_state', 'name']
     assert user_info['admin'] == False
+
+async def test_openshift_not_in_admin_users_but_not_in_admin_groups(openshift_client):
+    authenticator = OpenShiftOAuthenticator()
+    authenticator.allowed_groups = {'group1'}
+    authenticator.admin_users = ['wash']
+    authenticator.openshift_auth_api_url = "https://openshift.default.svc.cluster.local"
+    handler = openshift_client.handler_for_user(user_model('wash'))
+    user_info = await authenticator.get_authenticated_user(handler, data=None)
+    assert sorted(user_info) == ['admin', 'auth_state', 'name']
+    assert user_info['admin'] == True

--- a/oauthenticator/tests/test_openshift.py
+++ b/oauthenticator/tests/test_openshift.py
@@ -27,8 +27,8 @@ async def test_openshift(openshift_client):
     authenticator = OpenShiftOAuthenticator()
     authenticator.openshift_auth_api_url = "https://openshift.default.svc.cluster.local"
     handler = openshift_client.handler_for_user(user_model('wash'))
-    user_info = await authenticator.authenticate(handler)
-    assert sorted(user_info) == ['auth_state', 'name']
+    user_info = await authenticator.get_authenticated_user(handler, None)
+    assert sorted(user_info) == ['admin', 'auth_state', 'name']
     name = user_info['name']
     assert name == 'wash'
     auth_state = user_info['auth_state']
@@ -41,8 +41,8 @@ async def test_openshift_allowed_groups(openshift_client):
     authenticator.allowed_groups = {'group1'}
     authenticator.openshift_auth_api_url = "https://openshift.default.svc.cluster.local"
     handler = openshift_client.handler_for_user(user_model('wash'))
-    user_info = await authenticator.authenticate(handler)
-    assert sorted(user_info) == ['auth_state', 'name']
+    user_info = await authenticator.get_authenticated_user(handler, None)
+    assert sorted(user_info) == ['admin', 'auth_state', 'name']
     name = user_info['name']
     assert name == 'wash'
     auth_state = user_info['auth_state']
@@ -57,7 +57,7 @@ async def test_openshift_not_in_allowed_groups(openshift_client):
     authenticator.allowed_groups = {'group3'}
     authenticator.openshift_auth_api_url = "https://openshift.default.svc.cluster.local"
     handler = openshift_client.handler_for_user(user_model('wash'))
-    user_info = await authenticator.authenticate(handler)
+    user_info = await authenticator.get_authenticated_user(handler, None)
     assert user_info == None
 
 
@@ -67,7 +67,7 @@ async def test_openshift_not_in_allowed_groups_but_is_admin(openshift_client):
     authenticator.admin_groups = {'group1'}
     authenticator.openshift_auth_api_url = "https://openshift.default.svc.cluster.local"
     handler = openshift_client.handler_for_user(user_model('wash'))
-    user_info = await authenticator.authenticate(handler)
+    user_info = await authenticator.get_authenticated_user(handler, None)
     assert sorted(user_info) == ['admin', 'auth_state', 'name']
     assert user_info['admin'] == True
 
@@ -78,7 +78,7 @@ async def test_openshift_in_allowed_groups_and_is_admin(openshift_client):
     authenticator.admin_groups = {'group1'}
     authenticator.openshift_auth_api_url = "https://openshift.default.svc.cluster.local"
     handler = openshift_client.handler_for_user(user_model('wash'))
-    user_info = await authenticator.authenticate(handler)
+    user_info = await authenticator.get_authenticated_user(handler, None)
     assert sorted(user_info) == ['admin', 'auth_state', 'name']
     assert user_info['admin'] == True
 
@@ -89,7 +89,7 @@ async def test_openshift_in_allowed_groups_and_is_not_admin(openshift_client):
     authenticator.admin_groups = {'group3'}
     authenticator.openshift_auth_api_url = "https://openshift.default.svc.cluster.local"
     handler = openshift_client.handler_for_user(user_model('wash'))
-    user_info = await authenticator.authenticate(handler)
+    user_info = await authenticator.get_authenticated_user(handler, None)
     assert sorted(user_info) == ['admin', 'auth_state', 'name']
     assert user_info['admin'] == False
 


### PR DESCRIPTION
## Updated PR description

Previously authorization logic resided in `OAuthenticator.user_is_authorized` called by `OAuthenticator.authenticate`. The downside is that the `Authenticator.get_authenticated_user` that in turn called `authenticate` also ran `Authenticator.check_allowed` after authenticate, which included a check if the user was part of `Authenticator.allowed_users`. This led to authorization done in two places, one called from `authenticate`, and one later. That meant that even if for example `GitHubOAuthenticator.allowed_organizations` made a user authorized, it could still be denied access if `allowed_users` was configured by the later call to `check_allowed`.

Due to this, we decided to put authorization logic in `check_allowed` directly, allowing us to declare for example that either the user was part of `allowed_users` or part of `allowed_organizations`.

Not all logic in the `OAuthenticator.user_is_authorized` methods was relocated to the new overrides of `Authenticator.check_allowed`, logic related to getting information about the user was mostly put in `OAuthenticator.update_auth_model` while the logic making authorization decisions on such information was put in the `check_allowed` overrides.

### Breaking changes

The changelog is updated with the following breaking changes.

### Breaking changes

>- [All] Users are now authorized based on _either_ being part of `Authenticator.admin_users`, `Authenticator.allowed_users`, an Authenticator specific allowed team/group/organization, or declared in `JupyterHub.load_roles` or `JupyterHub.load_groups`.
>- [Google] If `GoogleOAuthenticator.admin_google_groups` is configured, users logging in not explicitly there or in `Authenticator.admin_users` will get their admin status revoked.
>- [Generic, Google] `GenericOAuthenticator.allowed_groups`, `GenericOAuthenticator.allowed_groups`, `GoogleOAuthenticator.allowed_google_groups`, and `GoogleOAuthenticator.admin_google_groups` are now Set based configuration instead of List based configuration. It is still possible to set these with lists as as they are converted to sets automatically, but anyone reading and adding entries must now use set logic and not list logic.
>- [Google] Authentication state's `google_groups` is now a set, not a list.

### Related

- Fixes #591
- Fixes #396
- Closes #546

## Outdated PR description

<details>

Fixes https://github.com/jupyterhub/oauthenticator/issues/591 for `GenericOAuthenticator`, but also for the other oauthenticators with the same bug.

The main changes this PR introduces are:

See https://github.com/jupyterhub/oauthenticator/pull/594#issuecomment-1522810818 for the latest decided changes. The list below might be outdated.

<details><summary>Changes planned initially</summary>

- the `authenticate` function (through the `update_auth_model`) will return info about the admin status of the user only if user is not already in `admin_users` list and an `admin_groups` type of config was specified. Otherwise, the admin status will be added through [`get_authenticated_user`](https://github.com/jupyterhub/jupyterhub/blob/43d4b652507c7d4b06b8f33b3e85643cdb7cb2b4/jupyterhub/auth.py#L472)
- authorize access based on group membership if  user was not already authorized through `allowed_users`
- user is considered authorized in cases where they're member of an admin group, even though that admin group is not explicitly listed in the `allowed_groups`
- move the function that checks if the users groups are among the allowed groups in the base class
- add a test that caches the bug in https://github.com/jupyterhub/oauthenticator/issues/591 for all the authenticators that had it

</details>

### Related 

- Closes #546

### Todos after merging PR:
- [x] open issue about standardizing a flag like `populate_teams_in_auth_state` in all authenticators and the naming for the `teams` key, holding the info about the teams the user is a member of. (Eg. in `bitbucket.py` the key is called `user_teams` and we set it by default without any flag, but in `github.py` we have a flag and call it `teams`). Consider `allowed_orgs` too as for standadization.
  - https://github.com/jupyterhub/oauthenticator/issues/618
  
</details>