### PR TITLE
Fix Content-Type header, should be x-www-form-urlencoded for token request, and not passed for other GET requests

### DIFF
--- a/oauthenticator/azuread.py
+++ b/oauthenticator/azuread.py
@@ -34,16 +34,6 @@ class AzureAdOAuthenticator(OAuthenticator):
     def _token_url_default(self):
         return f"https://login.microsoftonline.com/{self.tenant_id}/oauth2/token"
 
-    def build_token_info_request_headers(self):
-        return {
-            "Content-Type": "application/x-www-form-urlencoded",
-            "Accept": "application/json",
-        }
-
-    def build_token_info_body(self, params):
-        # convert params to a string with urlencoded key-value pairs
-        return "&".join([f"{k}={v}" for k, v in params.items()])
-
     async def token_to_user(self, token_info):
         id_token = token_info['id_token']
         decoded = jwt.decode(

--- a/oauthenticator/azuread.py
+++ b/oauthenticator/azuread.py
@@ -34,6 +34,16 @@ class AzureAdOAuthenticator(OAuthenticator):
     def _token_url_default(self):
         return f"https://login.microsoftonline.com/{self.tenant_id}/oauth2/token"
 
+    def build_token_info_request_headers(self):
+        return {
+            "Content-Type": "application/x-www-form-urlencoded",
+            "Accept": "application/json",
+        }
+
+    def build_token_info_body(self, params):
+        # convert params to a string with urlencoded key-value pairs
+        return "&".join([f"{k}={v}" for k, v in params.items()])
+
     async def token_to_user(self, token_info):
         id_token = token_info['id_token']
         decoded = jwt.decode(

--- a/oauthenticator/oauth2.py
+++ b/oauthenticator/oauth2.py
@@ -541,6 +541,13 @@ class OAuthenticator(Authenticator):
             headers.update({"Authorization": f'Basic {b64key.decode("utf8")}'})
         return headers
 
+    def build_token_info_body(self, params):
+        """
+        Builds and returns the body to be used in the access token request.
+        Called by the :meth:`oauthenticator.OAuthenticator.get_token_info`.
+        """
+        return json.dumps(params)
+
     def user_info_to_username(self, user_info):
         """
         Gets the self.username_claim key's value from the user_info dictionary.
@@ -634,7 +641,7 @@ class OAuthenticator(Authenticator):
             url,
             method="POST",
             headers=self.build_token_info_request_headers(),
-            body=json.dumps(params),
+            body=self.build_token_info_body(params),
             validate_cert=self.validate_server_cert,
         )
 

--- a/oauthenticator/oauth2.py
+++ b/oauthenticator/oauth2.py
@@ -522,7 +522,6 @@ class OAuthenticator(Authenticator):
         """
         return {
             "Accept": "application/json",
-            "Content-Type": "application/json",
             "User-Agent": "JupyterHub",
             "Authorization": f"{token_type} {access_token}",
         }

--- a/oauthenticator/oauth2.py
+++ b/oauthenticator/oauth2.py
@@ -530,10 +530,16 @@ class OAuthenticator(Authenticator):
         """
         Builds and returns the headers to be used in the access token request.
         Called by the :meth:`oauthenticator.OAuthenticator.get_token_info`.
+
+        The Content-Type header is specified by the OAuth 2.0 RFC in
+        https://www.rfc-editor.org/rfc/rfc6749#section-4.1.3. utf-8 is also
+        required according to https://www.rfc-editor.org/rfc/rfc6749#appendix-B,
+        and that can be specified with a Content-Type directive according to
+        https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Type#directives.
         """
         headers = {
             "Accept": "application/json",
-            "Content-Type": "application/x-www-form-urlencoded",
+            "Content-Type": "application/x-www-form-urlencoded; charset=utf-8",
             "User-Agent": "JupyterHub",
         }
 

--- a/oauthenticator/oauth2.py
+++ b/oauthenticator/oauth2.py
@@ -533,7 +533,8 @@ class OAuthenticator(Authenticator):
         Called by the :meth:`oauthenticator.OAuthenticator.get_token_info`.
         """
         headers = {
-            "Accept": "application/x-www-form-urlencoded",
+            "Accept": "application/json",
+            "Content-Type": "application/x-www-form-urlencoded",
             "User-Agent": "JupyterHub",
         }
 

--- a/oauthenticator/oauth2.py
+++ b/oauthenticator/oauth2.py
@@ -7,7 +7,7 @@ import base64
 import json
 import os
 import uuid
-from urllib.parse import quote, urlparse, urlunparse
+from urllib.parse import quote, urlencode, urlparse, urlunparse
 
 from jupyterhub.auth import Authenticator
 from jupyterhub.crypto import EncryptionUnavailable, InvalidToken, decrypt
@@ -643,9 +643,7 @@ class OAuthenticator(Authenticator):
             url,
             method="POST",
             headers=self.build_token_info_request_headers(),
-            body="&".join(
-                [f"{k}={v}" for k, v in params.items()]
-            ),  # convert params to a string with urlencoded key-value pairs
+            body=urlencode(params).encode("utf-8"),
             validate_cert=self.validate_server_cert,
         )
 

--- a/oauthenticator/oauth2.py
+++ b/oauthenticator/oauth2.py
@@ -532,7 +532,10 @@ class OAuthenticator(Authenticator):
         Builds and returns the headers to be used in the access token request.
         Called by the :meth:`oauthenticator.OAuthenticator.get_token_info`.
         """
-        headers = {"Accept": "application/json", "User-Agent": "JupyterHub"}
+        headers = {
+            "Accept": "application/x-www-form-urlencoded",
+            "User-Agent": "JupyterHub",
+        }
 
         if not self.basic_auth:
             b64key = base64.b64encode(
@@ -540,13 +543,6 @@ class OAuthenticator(Authenticator):
             )
             headers.update({"Authorization": f'Basic {b64key.decode("utf8")}'})
         return headers
-
-    def build_token_info_body(self, params):
-        """
-        Builds and returns the body to be used in the access token request.
-        Called by the :meth:`oauthenticator.OAuthenticator.get_token_info`.
-        """
-        return json.dumps(params)
 
     def user_info_to_username(self, user_info):
         """
@@ -641,7 +637,9 @@ class OAuthenticator(Authenticator):
             url,
             method="POST",
             headers=self.build_token_info_request_headers(),
-            body=self.build_token_info_body(params),
+            body="&".join(
+                [f"{k}={v}" for k, v in params.items()]
+            ),  # convert params to a string with urlencoded key-value pairs
             validate_cert=self.validate_server_cert,
         )
 

--- a/oauthenticator/tests/mocks.py
+++ b/oauthenticator/tests/mocks.py
@@ -2,7 +2,6 @@
 import json
 import os
 import re
-import urllib
 import uuid
 from io import BytesIO
 from unittest.mock import Mock
@@ -141,30 +140,17 @@ def setup_oauth_mock(
         Replies with JSON model for the token.
         """
         assert request.method == 'POST', request.method
-        if token_request_style == 'json':
-            body = request.body.decode('utf8')
-            try:
-                body = dict(urllib.parse.parse_qsl(body))
-            except ValueError:
-                return HTTPResponse(
-                    request=request,
-                    code=400,
-                    reason="Body not JSON: %r" % body,
-                )
-            else:
-                code = body['code']
-        else:
-            query = urlparse(request.url).query
-            if not query:
-                query = request.body.decode('utf8')
-            query = parse_qs(query)
-            if 'code' not in query:
-                return HTTPResponse(
-                    request=request,
-                    code=400,
-                    reason=f"No code in access token request: url={request.url}, body={request.body}",
-                )
-            code = query['code'][0]
+        query = urlparse(request.url).query
+        if not query:
+            query = request.body.decode('utf8')
+        query = parse_qs(query)
+        if 'code' not in query:
+            return HTTPResponse(
+                request=request,
+                code=400,
+                reason=f"No code in access token request: url={request.url}, body={request.body}",
+            )
+        code = query['code'][0]
         if code not in oauth_codes:
             return HTTPResponse(
                 request=request, code=403, reason=f"No such code: {code}"

--- a/oauthenticator/tests/mocks.py
+++ b/oauthenticator/tests/mocks.py
@@ -2,6 +2,7 @@
 import json
 import os
 import re
+import urllib
 import uuid
 from io import BytesIO
 from unittest.mock import Mock
@@ -143,7 +144,7 @@ def setup_oauth_mock(
         if token_request_style == 'json':
             body = request.body.decode('utf8')
             try:
-                body = json.loads(body)
+                body = dict(urllib.parse.parse_qsl(body))
             except ValueError:
                 return HTTPResponse(
                     request=request,

--- a/oauthenticator/tests/test_auth0.py
+++ b/oauthenticator/tests/test_auth0.py
@@ -29,7 +29,6 @@ def auth0_client(client):
         host=auth0_domain,
         access_token_path='/oauth/token',
         user_path='/userinfo',
-        token_request_style='json',
     )
     return client
 

--- a/oauthenticator/tests/test_globus.py
+++ b/oauthenticator/tests/test_globus.py
@@ -156,7 +156,6 @@ def globus_client(client, mock_globus_token_response):
         access_token_path='/v2/oauth2/token',
         user_path='/v2/oauth2/userinfo',
         token_type='bearer',
-        token_request_style='post',
     )
     set_extended_token_response(
         client, 'auth.globus.org', '/v2/oauth2/token', mock_globus_token_response


### PR DESCRIPTION
Use correct encoding for token request. 

Fixes: https://github.com/jupyterhub/oauthenticator/issues/598
Fixes: https://github.com/jupyterhub/oauthenticator/issues/564