### PR TITLE
Fix bug in implementation of not yet released basic_auth config

### DIFF
--- a/oauthenticator/oauth2.py
+++ b/oauthenticator/oauth2.py
@@ -356,7 +356,7 @@ class OAuthenticator(Authenticator):
 
     # Originally a GenericOAuthenticator only trait
     basic_auth = Bool(
-        os.environ.get("OAUTH2_BASIC_AUTH", "False").lower() in {"false", "0"},
+        os.environ.get("OAUTH2_BASIC_AUTH", "False").lower() in {"true", "1"},
         config=True,
         help="Whether or not to use basic authentication for access token request",
     )
@@ -534,7 +534,7 @@ class OAuthenticator(Authenticator):
         """
         headers = {"Accept": "application/json", "User-Agent": "JupyterHub"}
 
-        if not self.basic_auth:
+        if self.basic_auth:
             b64key = base64.b64encode(
                 bytes("{self.client_id}:{self.client_secret}", "utf8")
             )
@@ -610,7 +610,7 @@ class OAuthenticator(Authenticator):
         # the client_id and client_secret should not be included in the access token request params
         # when basic authentication is used
         # ref: https://www.rfc-editor.org/rfc/rfc6749#section-2.3.1
-        if self.basic_auth:
+        if not self.basic_auth:
             params.update(
                 [("client_id", self.client_id), ("client_secret", self.client_secret)]
             )


### PR DESCRIPTION
See the linked issue for details. I think this fixes a bug that would surface for someone trying to configure `basic_auth` directly (not via environment variables). If they would set it to True it would act as if it was set to False and the other way around.

- Closes #600

We believe this fixes a bug introduced in a refactoring PR that hasn't yet been released.