### PR TITLE
maint: cleanup already removed awscogito, azureadb2c, yandex

### DIFF
--- a/oauthenticator/awscognito.py
+++ b/oauthenticator/awscognito.py
@@ -1,1 +1,0 @@
-raise ImportError("AWS Cognito can be configured via GenericOAuthenticator")

--- a/oauthenticator/azureadb2c.py
+++ b/oauthenticator/azureadb2c.py
@@ -1,1 +1,0 @@
-raise ImportError("Azure AD B2C can be configured via AzureAdOAuthenticator")

--- a/oauthenticator/yandex.py
+++ b/oauthenticator/yandex.py
@@ -1,1 +1,0 @@
-raise ImportError("Yandex can be configured via GenericOAuthenticator")


### PR DESCRIPTION
- These authenticators were removed in #323 in 2019.

Cleanup these files helps me and likely other contributors to overview the available authenticators in the code base, which in turn can help maintenance efforts.