### PR TITLE
docs: update broken links

### DIFF
--- a/docs/source/how-to/migrations/upgrade-to-16.md
+++ b/docs/source/how-to/migrations/upgrade-to-16.md
@@ -27,7 +27,7 @@ The following section describes what to pay attention to when upgrading to OAuth
 
 1. The name of the user key expected to be present in `auth_state` is now configurable through {attr}`.OAuthenticator.user_auth_state_key` for _all oauthenticators_, and it defaults to their prior specific values.
 
-2. The [`Authenticator.refresh_pre_spawn`](https://jupyterhub.readthedocs.io/en/stable/api/auth.html#jupyterhub.auth.Authenticator.refresh_pre_spawn) option is enabled by default if {attr}`.OAuthenticator.enable_auth_state` is set.
+2. The [`Authenticator.refresh_pre_spawn`](https://jupyterhub.readthedocs.io/en/stable/reference/api/auth.html#jupyterhub.auth.Authenticator.refresh_pre_spawn) option is enabled by default if {attr}`.OAuthenticator.enable_auth_state` is set.
 
 3. The userdata query parameters {attr}`.OAuthenticator.userdata_params` to be added to the request sent to {attr}`.OAuthenticator.userdata_url` to get user data login information is now a configurable feature of _all the oauthenticators_.
 

--- a/docs/source/tutorials/provider-specific-setup/providers/globus.md
+++ b/docs/source/tutorials/provider-specific-setup/providers/globus.md
@@ -130,7 +130,7 @@ included in the default list of scopes. When
 `c.GlobusOAuthenticator.admin_globus_groups` is set, only members of
 those groups will be JupyterHub admins.
 
-To block users, the [`c.Authenticator.blocked_users`](https://jupyterhub.readthedocs.io/en/stable/api/auth.html#jupyterhub.auth.Authenticator.blocked_users)
+To block users, the [`c.Authenticator.blocked_users`](https://jupyterhub.readthedocs.io/en/stable/reference/api/auth.html#jupyterhub.auth.Authenticator.blocked_users)
 configuration can be used. Or, users can be removed from the allowed
 Globus Groups, and the Group set require approval, so the user cannot
 rejoin it without action by an administrator.


### PR DESCRIPTION
JupyterHub 4.0.0 has missing redirects to be added in https://github.com/jupyterhub/jupyterhub/pull/4429, but we can directly fix our linkcheck failure and avoid a redirect via this PR.