### PR TITLE
Don't send POST params on query string also

### DIFF
--- a/oauthenticator/oauth2.py
+++ b/oauthenticator/oauth2.py
@@ -635,10 +635,9 @@ class OAuthenticator(Authenticator):
 
         Called by the :meth:`oauthenticator.OAuthenticator.authenticate`
         """
-        url = url_concat(self.token_url, params)
 
         token_info = await self.httpfetch(
-            url,
+            self.token_url,
             method="POST",
             headers=self.build_token_info_request_headers(),
             body=urlencode(params).encode("utf-8"),


### PR DESCRIPTION
token_url takes post data, don't also send the same data on the query string.