### PR TITLE
refactor: separate deprecated config for readability

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -94,6 +94,19 @@ def render_autodoc_modules():
 render_autodoc_modules()
 
 
+# -- Add versionremoved directive ---------------------------------------------------
+# ref: https://github.com/sphinx-doc/sphinx/issues/11480
+#
+from sphinx.domains.changeset import VersionChange, versionlabel_classes, versionlabels
+
+
+def setup(app):
+    if "versionremoved" not in versionlabels:
+        versionlabels["versionremoved"] = "Removed in version %s"
+        versionlabel_classes["versionremoved"] = "removed"
+        app.add_directive("versionremoved", VersionChange)
+
+
 # -- General Sphinx configuration ---------------------------------------------------
 # ref: https://www.sphinx-doc.org/en/master/usage/configuration.html#general-configuration
 #

--- a/oauthenticator/auth0.py
+++ b/oauthenticator/auth0.py
@@ -81,7 +81,7 @@ class Auth0OAuthenticator(OAuthenticator):
         help="""
         .. deprecated:: 16.0
 
-           Use :attr:`.Auth0OAuthenticator.username_claim`.
+           Use :attr:`username_claim`.
         """,
     )
 

--- a/oauthenticator/auth0.py
+++ b/oauthenticator/auth0.py
@@ -78,7 +78,11 @@ class Auth0OAuthenticator(OAuthenticator):
     }
     username_key = Unicode(
         config=True,
-        help="Deprecated in 16.0, use :attr:`.Auth0OAuthenticator.username_claim`.",
+        help="""
+        .. deprecated:: 16.0
+
+           Use :attr:`.Auth0OAuthenticator.username_claim`.
+        """,
     )
 
 

--- a/oauthenticator/auth0.py
+++ b/oauthenticator/auth0.py
@@ -10,11 +10,6 @@ from .oauth2 import OAuthenticator
 
 
 class Auth0OAuthenticator(OAuthenticator):
-    _deprecated_oauth_aliases = {
-        "username_key": ("username_claim", "16.0.0"),
-        **OAuthenticator._deprecated_oauth_aliases,
-    }
-
     user_auth_state_key = "auth0_user"
 
     @default("login_service")
@@ -60,13 +55,6 @@ class Auth0OAuthenticator(OAuthenticator):
         # This is allowed to be empty unless auth0_domain is not supplied either
         return os.getenv("AUTH0_SUBDOMAIN", "")
 
-    username_key = Unicode(
-        config=True,
-        help="""
-        Deprecated, use `Auth0OAuthenticator.username_claim`
-        """,
-    )
-
     @default("logout_redirect_url")
     def _logout_redirect_url_default(self):
         return f"https://{self.auth0_domain}/v2/logout"
@@ -82,6 +70,15 @@ class Auth0OAuthenticator(OAuthenticator):
     @default("userdata_url")
     def _userdata_url_default(self):
         return f"https://{self.auth0_domain}/userinfo"
+
+    # _deprecated_oauth_aliases is used by deprecation logic in OAuthenticator
+    _deprecated_oauth_aliases = {
+        "username_key": ("username_claim", "16.0.0"),
+        **OAuthenticator._deprecated_oauth_aliases,
+    }
+    username_key = Unicode(
+        config=True, help="Deprecated, use :attr:`.Auth0OAuthenticator.username_claim`."
+    )
 
 
 class LocalAuth0OAuthenticator(LocalAuthenticator, Auth0OAuthenticator):

--- a/oauthenticator/auth0.py
+++ b/oauthenticator/auth0.py
@@ -77,7 +77,8 @@ class Auth0OAuthenticator(OAuthenticator):
         **OAuthenticator._deprecated_oauth_aliases,
     }
     username_key = Unicode(
-        config=True, help="Deprecated, use :attr:`.Auth0OAuthenticator.username_claim`."
+        config=True,
+        help="Deprecated in 16.0, use :attr:`.Auth0OAuthenticator.username_claim`.",
     )
 
 

--- a/oauthenticator/bitbucket.py
+++ b/oauthenticator/bitbucket.py
@@ -45,7 +45,7 @@ class BitbucketOAuthenticator(OAuthenticator):
     }
     team_whitelist = Set(
         config=True,
-        help="Deprecated, use :attr:`.BitbucketOAuthenticator.allowed_teams`.",
+        help="Deprecated in 0.12, use :attr:`.BitbucketOAuthenticator.allowed_teams`.",
     )
 
     async def _fetch_user_teams(self, access_token, token_type):

--- a/oauthenticator/bitbucket.py
+++ b/oauthenticator/bitbucket.py
@@ -48,7 +48,7 @@ class BitbucketOAuthenticator(OAuthenticator):
         help="""
         .. deprecated:: 0.12
 
-           Use :attr:`.BitbucketOAuthenticator.allowed_teams`.
+           Use :attr:`allowed_teams`.
         """,
     )
 

--- a/oauthenticator/bitbucket.py
+++ b/oauthenticator/bitbucket.py
@@ -11,11 +11,6 @@ from .oauth2 import OAuthenticator
 
 
 class BitbucketOAuthenticator(OAuthenticator):
-    _deprecated_oauth_aliases = {
-        "team_whitelist": ("allowed_teams", "0.12.0"),
-        **OAuthenticator._deprecated_oauth_aliases,
-    }
-
     client_id_env = "BITBUCKET_CLIENT_ID"
     client_secret_env = "BITBUCKET_CLIENT_SECRET"
     user_auth_state_key = "bitbucket_user"
@@ -36,18 +31,21 @@ class BitbucketOAuthenticator(OAuthenticator):
     def _userdata_url_default(self):
         return "https://api.bitbucket.org/2.0/user"
 
-    team_whitelist = Set(
-        config=True,
-        help="""
-        Deprecated, use `BitbucketOAuthenticator.allowed_teams`
-        """,
-    )
-
     allowed_teams = Set(
         config=True,
         help="""
         Allow members of selected Bitbucket teams to sign in.
         """,
+    )
+
+    # _deprecated_oauth_aliases is used by deprecation logic in OAuthenticator
+    _deprecated_oauth_aliases = {
+        "team_whitelist": ("allowed_teams", "0.12.0"),
+        **OAuthenticator._deprecated_oauth_aliases,
+    }
+    team_whitelist = Set(
+        config=True,
+        help="Deprecated, use :attr:`.BitbucketOAuthenticator.allowed_teams`.",
     )
 
     async def _fetch_user_teams(self, access_token, token_type):

--- a/oauthenticator/bitbucket.py
+++ b/oauthenticator/bitbucket.py
@@ -45,7 +45,11 @@ class BitbucketOAuthenticator(OAuthenticator):
     }
     team_whitelist = Set(
         config=True,
-        help="Deprecated in 0.12, use :attr:`.BitbucketOAuthenticator.allowed_teams`.",
+        help="""
+        .. deprecated:: 0.12
+
+           Use :attr:`.BitbucketOAuthenticator.allowed_teams`.
+        """,
     )
 
     async def _fetch_user_teams(self, access_token, token_type):

--- a/oauthenticator/cilogon.py
+++ b/oauthenticator/cilogon.py
@@ -260,6 +260,14 @@ class CILogonOAuthenticator(OAuthenticator):
            Use :attr:`.CILogonOAuthenticator.allowed_idps`.
         """,
     )
+    username_claim = Unicode(
+        config=True,
+        help="""
+        .. versionremoved:: 16.0
+
+           Use :attr:`.CILogonOAuthenticator.allowed_idps`.
+        """,
+    )
 
     def user_info_to_username(self, user_info):
         """

--- a/oauthenticator/cilogon.py
+++ b/oauthenticator/cilogon.py
@@ -221,19 +221,24 @@ class CILogonOAuthenticator(OAuthenticator):
         **OAuthenticator._deprecated_oauth_aliases,
     }
     idp_whitelist = List(
-        config=True, help="Removed, use :attr:`.CILogonOAuthenticator.allowed_idps`."
+        config=True,
+        help="Removed in 0.12, use :attr:`.CILogonOAuthenticator.allowed_idps`.",
     )
     idp = Unicode(
-        config=True, help="Removed, use :attr:`.CILogonOAuthenticator.allowed_idps`."
+        config=True,
+        help="Removed in 15.0, use :attr:`.CILogonOAuthenticator.allowed_idps`.",
     )
     strip_idp_domain = Bool(
-        config=True, help="Removed, use :attr:`.CILogonOAuthenticator.allowed_idps`."
+        config=True,
+        help="Removed in 15.0, use :attr:`.CILogonOAuthenticator.allowed_idps`.",
     )
     shown_idps = List(
-        config=True, help="Removed, use :attr:`.CILogonOAuthenticator.allowed_idps`."
+        config=True,
+        help="Removed in 16.0, use :attr:`.CILogonOAuthenticator.allowed_idps`.",
     )
     additional_username_claims = List(
-        config=True, help="Removed, use :attr:`.CILogonOAuthenticator.allowed_idps`."
+        config=True,
+        help="Removed in 16.0, use :attr:`.CILogonOAuthenticator.allowed_idps`.",
     )
 
     def user_info_to_username(self, user_info):

--- a/oauthenticator/cilogon.py
+++ b/oauthenticator/cilogon.py
@@ -222,23 +222,43 @@ class CILogonOAuthenticator(OAuthenticator):
     }
     idp_whitelist = List(
         config=True,
-        help="Removed in 0.12, use :attr:`.CILogonOAuthenticator.allowed_idps`.",
+        help="""
+        .. versionremoved:: 0.12
+
+           Use :attr:`.CILogonOAuthenticator.allowed_idps`.
+        """,
     )
     idp = Unicode(
         config=True,
-        help="Removed in 15.0, use :attr:`.CILogonOAuthenticator.allowed_idps`.",
+        help="""
+        .. versionremoved:: 15.0
+
+           Use :attr:`.CILogonOAuthenticator.allowed_idps`.
+        """,
     )
     strip_idp_domain = Bool(
         config=True,
-        help="Removed in 15.0, use :attr:`.CILogonOAuthenticator.allowed_idps`.",
+        help="""
+        .. versionremoved:: 15.0
+
+           Use :attr:`.CILogonOAuthenticator.allowed_idps`.
+        """,
     )
     shown_idps = List(
         config=True,
-        help="Removed in 16.0, use :attr:`.CILogonOAuthenticator.allowed_idps`.",
+        help="""
+        .. versionremoved:: 16.0
+
+           Use :attr:`.CILogonOAuthenticator.allowed_idps`.
+        """,
     )
     additional_username_claims = List(
         config=True,
-        help="Removed in 16.0, use :attr:`.CILogonOAuthenticator.allowed_idps`.",
+        help="""
+        .. versionremoved:: 16.0
+
+           Use :attr:`.CILogonOAuthenticator.allowed_idps`.
+        """,
     )
 
     def user_info_to_username(self, user_info):

--- a/oauthenticator/cilogon.py
+++ b/oauthenticator/cilogon.py
@@ -128,44 +128,43 @@ class CILogonOAuthenticator(OAuthenticator):
                     "username_derivation": {
                         "username_claim": "username",
                         "action": "prefix",
-                        "prefix": "gh",
+                        "prefix": "github",
                     },
                 },
                 "http://google.com/accounts/o8/id": {
                     "username_derivation": {
                         "username_claim": "username",
+                        "action": "prefix",
+                        "prefix": "google",
                     },
                     "allowed_domains": ["uni.edu", "something.org"],
                 },
             }
 
         Where `username_derivation` defines:
-            * :attr:`username_claim`: string
+
+            * `username_claim`: string (required)
                 The claim in the `userinfo` response from which to get the
                 JupyterHub username. Examples include: `eppn`, `email`. What
-                keys are available will depend on the scopes requested. It will
-                overwrite any value set through
-                CILogonOAuthenticator.username_claim for this identity provider.
-            * :attr:`action`: string What action to perform on the username.
-                Available options are "strip_idp_domain", which will strip the
-                domain from the username if specified and "prefix", which will
-                prefix the hub username with "prefix:".
-            * :attr:`domain:` string
+                keys are available will depend on the scopes requested.
+            * `action`: string
+                What action to perform on the username. Available options are
+                "strip_idp_domain", which will strip the domain from the
+                username if specified and "prefix", which will prefix the hub
+                username with "prefix:".
+            * `domain:` string (required if action is strip_idp_domain)
                 The domain after "@" which will be stripped from the username if
                 it exists and if the action is "strip_idp_domain".
-            * :attr:`prefix`: string The prefix which will be added at the
-                beginning of the username followed by a semi-column ":", if the
-                action is "prefix".
-            * :attr:`allowed_domains`: string It defines which domains will be
-                allowed to login using the specific identity provider.
+            * `prefix`: string (required if action is prefix)
+                The prefix which will be added at the beginning of the username
+                followed by a semi-column ":", if the action is "prefix".
+            * `allowed_domains`: string
+                It defines which domains will be allowed to login using the
+                specific identity provider.
 
-        Requirements:
-            * if `username_derivation.action` is `strip_idp_domain`, then `username_derivation.domain` must also be specified
-            * if `username_derivation.action` is `prefix`, then `username_derivation.prefix` must also be specified.
-            * `username_claim` must be provided for each idp in `allowed_idps`
+        .. versionchanged:: 15.0
 
-        .. versionchanged:: 15.0.0
-            `CILogonOAuthenticaor.allowed_idps` changed type from list to dict
+           Changed format from a list to a dictionary.
         """,
     )
 

--- a/oauthenticator/cilogon.py
+++ b/oauthenticator/cilogon.py
@@ -40,22 +40,6 @@ class CILogonLoginHandler(OAuthLoginHandler):
 
 
 class CILogonOAuthenticator(OAuthenticator):
-    _deprecated_oauth_aliases = {
-        # <deprecated-config>:
-        #   (
-        #    <new-config>,
-        #    <deprecation-version>,
-        #    <deprecated-config-and-new-config-have-same-type>
-        #   )
-        "idp_whitelist": ("allowed_idps", "0.12.0", False),
-        "idp": ("shown_idps", "15.0.0", False),
-        "strip_idp_domain": ("allowed_idps", "15.0.0", False),
-        "shown_idps": ("allowed_idps", "16.0.0", False),
-        "username_claim": ("allowed_idps", "16.0.0", False),
-        "additional_username_claims": ("allowed_idps", "16.0.0", False),
-        **OAuthenticator._deprecated_oauth_aliases,
-    }
-
     login_handler = CILogonLoginHandler
 
     user_auth_state_key = "cilogon_user"
@@ -86,14 +70,6 @@ class CILogonOAuthenticator(OAuthenticator):
     @default("userdata_url")
     def _userdata_url_default(self):
         return f"https://{self.cilogon_host}/oauth2/userinfo"
-
-    @default("username_claim")
-    def _username_claim_default(self):
-        """What keys are available will depend on the scopes requested.
-        See https://www.cilogon.org/oidc for details.
-        Note that this option can be overridden for specific identity providers via `allowed_idps[<identity provider>]["username_derivation"]["username_claim"]`.
-        """
-        return "eppn"
 
     scope = List(
         Unicode(),
@@ -127,13 +103,6 @@ class CILogonOAuthenticator(OAuthenticator):
             scopes += ['org.cilogon.userinfo']
 
         return scopes
-
-    idp_whitelist = List(
-        config=True,
-        help="""
-        Deprecated, use `CIlogonOAuthenticator.allowed_idps`
-        """,
-    )
 
     allowed_idps = Dict(
         config=True,
@@ -231,39 +200,6 @@ class CILogonOAuthenticator(OAuthenticator):
 
         return idps
 
-    strip_idp_domain = Bool(
-        False,
-        config=True,
-        help="""
-        Deprecated, use `CILogonOAuthenticator.allowed_idps[<ipd>]["username_derivation"]["action"] = "strip_idp_domain"`
-        to enable it and `CIlogonOAuthenticator.allowed_idps[<idp>]["username_derivation"]["domain"]` to list the domain
-        which will be stripped
-        """,
-    )
-
-    idp = Unicode(
-        config=True,
-        help="""
-        Deprecated, use `CILogonOAuthenticator.shown_idps`.
-        """,
-    )
-
-    shown_idps = List(
-        Unicode(),
-        config=True,
-        help="""
-        Deprecated, `CILogonOAuthenticator.allowed_idps` will determine the idps
-        shown.
-
-        A list of identity providers to be shown as login options. The `idp`
-        attribute is the SAML Entity ID of the user's selected identity
-        provider.
-
-        See https://cilogon.org/include/idplist.xml for the list of identity
-        providers supported by CILogon.
-        """,
-    )
-
     skin = Unicode(
         config=True,
         help="""
@@ -274,16 +210,30 @@ class CILogonOAuthenticator(OAuthenticator):
         """,
     )
 
+    # _deprecated_oauth_aliases is used by deprecation logic in OAuthenticator
+    _deprecated_oauth_aliases = {
+        "idp_whitelist": ("allowed_idps", "0.12.0", False),
+        "idp": ("shown_idps", "15.0.0", False),
+        "strip_idp_domain": ("allowed_idps", "15.0.0", False),
+        "shown_idps": ("allowed_idps", "16.0.0", False),
+        "additional_username_claims": ("allowed_idps", "16.0.0", False),
+        "username_claim": ("allowed_idps", "16.0.0", False),
+        **OAuthenticator._deprecated_oauth_aliases,
+    }
+    idp_whitelist = List(
+        config=True, help="Removed, use :attr:`.CILogonOAuthenticator.allowed_idps`."
+    )
+    idp = Unicode(
+        config=True, help="Removed, use :attr:`.CILogonOAuthenticator.allowed_idps`."
+    )
+    strip_idp_domain = Bool(
+        config=True, help="Removed, use :attr:`.CILogonOAuthenticator.allowed_idps`."
+    )
+    shown_idps = List(
+        config=True, help="Removed, use :attr:`.CILogonOAuthenticator.allowed_idps`."
+    )
     additional_username_claims = List(
-        config=True,
-        help="""
-        Deprecated, use `CILogonOAuthenticator.allowed_idps["username_derivation"]["username_claim"]`.
-
-        Additional claims to check if the username_claim fails.
-
-        This is useful for linked identities where not all of them return the
-        primary username_claim.
-        """,
+        config=True, help="Removed, use :attr:`.CILogonOAuthenticator.allowed_idps`."
     )
 
     def user_info_to_username(self, user_info):

--- a/oauthenticator/cilogon.py
+++ b/oauthenticator/cilogon.py
@@ -225,7 +225,7 @@ class CILogonOAuthenticator(OAuthenticator):
         help="""
         .. versionremoved:: 0.12
 
-           Use :attr:`.CILogonOAuthenticator.allowed_idps`.
+           Use :attr:`allowed_idps`.
         """,
     )
     idp = Unicode(
@@ -233,7 +233,7 @@ class CILogonOAuthenticator(OAuthenticator):
         help="""
         .. versionremoved:: 15.0
 
-           Use :attr:`.CILogonOAuthenticator.allowed_idps`.
+           Use :attr:`allowed_idps`.
         """,
     )
     strip_idp_domain = Bool(
@@ -241,7 +241,7 @@ class CILogonOAuthenticator(OAuthenticator):
         help="""
         .. versionremoved:: 15.0
 
-           Use :attr:`.CILogonOAuthenticator.allowed_idps`.
+           Use :attr:`allowed_idps`.
         """,
     )
     shown_idps = List(
@@ -249,7 +249,7 @@ class CILogonOAuthenticator(OAuthenticator):
         help="""
         .. versionremoved:: 16.0
 
-           Use :attr:`.CILogonOAuthenticator.allowed_idps`.
+           Use :attr:`allowed_idps`.
         """,
     )
     additional_username_claims = List(
@@ -257,7 +257,7 @@ class CILogonOAuthenticator(OAuthenticator):
         help="""
         .. versionremoved:: 16.0
 
-           Use :attr:`.CILogonOAuthenticator.allowed_idps`.
+           Use :attr:`allowed_idps`.
         """,
     )
     username_claim = Unicode(
@@ -265,7 +265,7 @@ class CILogonOAuthenticator(OAuthenticator):
         help="""
         .. versionremoved:: 16.0
 
-           Use :attr:`.CILogonOAuthenticator.allowed_idps`.
+           Use :attr:`allowed_idps`.
         """,
     )
 

--- a/oauthenticator/generic.py
+++ b/oauthenticator/generic.py
@@ -98,7 +98,7 @@ class GenericOAuthenticator(OAuthenticator):
         help="""
         .. deprecated:: 16.0
 
-           Use :attr:`.GenericOAuthenticator.username_claim`.
+           Use :attr:`username_claim`.
         """,
     )
     extra_params = Dict(
@@ -106,7 +106,7 @@ class GenericOAuthenticator(OAuthenticator):
         help="""
         .. deprecated:: 16.0
 
-           Use :attr:`.GenericOAuthenticator.token_params`.
+           Use :attr:`token_params`.
         """,
     )
 

--- a/oauthenticator/generic.py
+++ b/oauthenticator/generic.py
@@ -95,11 +95,19 @@ class GenericOAuthenticator(OAuthenticator):
     username_key = Union(
         [Unicode(), Callable()],
         config=True,
-        help="Deprecated in 16.0, use :attr:`.GenericOAuthenticator.username_claim`.",
+        help="""
+        .. deprecated:: 16.0
+
+           Use :attr:`.GenericOAuthenticator.username_claim`.
+        """,
     )
     extra_params = Dict(
         config=True,
-        help="Deprecated in 16.0, use :attr:`.GenericOAuthenticator.token_params`.",
+        help="""
+        .. deprecated:: 16.0
+
+           Use :attr:`.GenericOAuthenticator.token_params`.
+        """,
     )
 
     def user_info_to_username(self, user_info):

--- a/oauthenticator/generic.py
+++ b/oauthenticator/generic.py
@@ -95,10 +95,11 @@ class GenericOAuthenticator(OAuthenticator):
     username_key = Union(
         [Unicode(), Callable()],
         config=True,
-        help="Deprecated, use :attr:`.GenericOAuthenticator.username_claim`.",
+        help="Deprecated in 16.0, use :attr:`.GenericOAuthenticator.username_claim`.",
     )
     extra_params = Dict(
-        config=True, help="Deprecated, use :attr:`.GenericOAuthenticator.token_params`."
+        config=True,
+        help="Deprecated in 16.0, use :attr:`.GenericOAuthenticator.token_params`.",
     )
 
     def user_info_to_username(self, user_info):

--- a/oauthenticator/generic.py
+++ b/oauthenticator/generic.py
@@ -13,19 +13,6 @@ from .oauth2 import OAuthenticator
 
 
 class GenericOAuthenticator(OAuthenticator):
-    _deprecated_oauth_aliases = {
-        "username_key": ("username_claim", "16.0.0"),
-        "extra_params": ("token_params", "16.0.0"),
-        **OAuthenticator._deprecated_oauth_aliases,
-    }
-
-    extra_params = Dict(
-        config=True,
-        help="""
-        Deprecated, use `GenericOAuthenticator.token_params`
-        """,
-    )
-
     @default("login_service")
     def _login_service_default(self):
         return os.environ.get("LOGIN_SERVICE", "OAuth 2.0")
@@ -69,12 +56,6 @@ class GenericOAuthenticator(OAuthenticator):
         """,
     )
 
-    username_key = Union(
-        [Unicode(os.environ.get('OAUTH2_USERNAME_KEY', 'username')), Callable()],
-        config=True,
-        help="""Deprecated, use `GenericOAuthenticator.username_claim`""",
-    )
-
     username_claim = Union(
         [Unicode(os.environ.get('OAUTH2_USERNAME_KEY', 'username')), Callable()],
         config=True,
@@ -104,6 +85,21 @@ class GenericOAuthenticator(OAuthenticator):
         return AsyncHTTPClient(
             force_instance=True, defaults=dict(validate_cert=self.tls_verify)
         )
+
+    # _deprecated_oauth_aliases is used by deprecation logic in OAuthenticator
+    _deprecated_oauth_aliases = {
+        "username_key": ("username_claim", "16.0.0"),
+        "extra_params": ("token_params", "16.0.0"),
+        **OAuthenticator._deprecated_oauth_aliases,
+    }
+    username_key = Union(
+        [Unicode(), Callable()],
+        config=True,
+        help="Deprecated, use :attr:`.GenericOAuthenticator.username_claim`.",
+    )
+    extra_params = Dict(
+        config=True, help="Deprecated, use :attr:`.GenericOAuthenticator.token_params`."
+    )
 
     def user_info_to_username(self, user_info):
         """

--- a/oauthenticator/github.py
+++ b/oauthenticator/github.py
@@ -13,11 +13,6 @@ from .oauth2 import OAuthenticator
 
 
 class GitHubOAuthenticator(OAuthenticator):
-    _deprecated_oauth_aliases = {
-        "github_organization_whitelist": ("allowed_organizations", "0.12.0"),
-        **OAuthenticator._deprecated_oauth_aliases,
-    }
-
     user_auth_state_key = "github_user"
 
     @default("login_service")
@@ -99,38 +94,8 @@ class GitHubOAuthenticator(OAuthenticator):
     def _userdata_url_default(self):
         return f"{self.github_api}/user"
 
-    # deprecated names
-    github_client_id = Unicode(
-        config=True,
-        help="""
-        DEPRECATED
-        """,
-    )
-
-    def _github_client_id_changed(self, name, old, new):
-        self.log.warning("github_client_id is deprecated, use client_id")
-        self.client_id = new
-
-    github_client_secret = Unicode(
-        config=True,
-        help="""
-        DEPRECATED
-        """,
-    )
-
-    def _github_client_secret_changed(self, name, old, new):
-        self.log.warning("github_client_secret is deprecated, use client_secret")
-        self.client_secret = new
-
     client_id_env = 'GITHUB_CLIENT_ID'
     client_secret_env = 'GITHUB_CLIENT_SECRET'
-
-    github_organization_whitelist = Set(
-        config=True,
-        help="""
-        Deprecated, use `GitHubOAuthenticator.allowed_organizations`
-        """,
-    )
 
     allowed_organizations = Set(
         config=True,
@@ -166,6 +131,24 @@ class GitHubOAuthenticator(OAuthenticator):
         persisted via `enable_auth_state`. For more information, see
         https://jupyterhub.readthedocs.io/en/stable/reference/authenticators.html#authentication-state.
         """,
+    )
+
+    # _deprecated_oauth_aliases is used by deprecation logic in OAuthenticator
+    _deprecated_oauth_aliases = {
+        "github_client_id": ("client_id", "0.1.0"),
+        "github_client_secret": ("client_secret", "0.1.0"),
+        "github_organization_whitelist": ("allowed_organizations", "0.12.0"),
+        **OAuthenticator._deprecated_oauth_aliases,
+    }
+    github_client_id = Unicode(
+        config=True, help="Deprecated, use :attr:`.GitHubOAuthenticator.client_id`."
+    )
+    github_client_secret = Unicode(
+        config=True, help="Deprecated, use :attr:`.GitHubOAuthenticator.client_secret`."
+    )
+    github_organization_whitelist = Set(
+        config=True,
+        help="Deprecated, use :attr:`.GitHubOAuthenticator.allowed_organizations`.",
     )
 
     async def check_allowed(self, username, auth_model):

--- a/oauthenticator/github.py
+++ b/oauthenticator/github.py
@@ -145,7 +145,7 @@ class GitHubOAuthenticator(OAuthenticator):
         help="""
         .. deprecated:: 0.1
 
-           Use :attr:`.GitHubOAuthenticator.client_id`.
+           Use :attr:`client_id`.
         """,
     )
     github_client_secret = Unicode(
@@ -153,7 +153,7 @@ class GitHubOAuthenticator(OAuthenticator):
         help="""
         .. deprecated:: 0.1
 
-           Use :attr:`.GitHubOAuthenticator.client_secret`.
+           Use :attr:`client_secret`.
         """,
     )
     github_organization_whitelist = Set(
@@ -161,7 +161,7 @@ class GitHubOAuthenticator(OAuthenticator):
         help="""
         .. deprecated:: 0.12
 
-           Use :attr:`.GitHubOAuthenticator.allowed_organizations`.
+           Use :attr:`allowed_organizations`.
         """,
     )
 

--- a/oauthenticator/github.py
+++ b/oauthenticator/github.py
@@ -141,14 +141,16 @@ class GitHubOAuthenticator(OAuthenticator):
         **OAuthenticator._deprecated_oauth_aliases,
     }
     github_client_id = Unicode(
-        config=True, help="Deprecated, use :attr:`.GitHubOAuthenticator.client_id`."
+        config=True,
+        help="Deprecated in 0.1, use :attr:`.GitHubOAuthenticator.client_id`.",
     )
     github_client_secret = Unicode(
-        config=True, help="Deprecated, use :attr:`.GitHubOAuthenticator.client_secret`."
+        config=True,
+        help="Deprecated in 0.1, use :attr:`.GitHubOAuthenticator.client_secret`.",
     )
     github_organization_whitelist = Set(
         config=True,
-        help="Deprecated, use :attr:`.GitHubOAuthenticator.allowed_organizations`.",
+        help="Deprecated in 0.12, use :attr:`.GitHubOAuthenticator.allowed_organizations`.",
     )
 
     async def check_allowed(self, username, auth_model):

--- a/oauthenticator/github.py
+++ b/oauthenticator/github.py
@@ -142,15 +142,27 @@ class GitHubOAuthenticator(OAuthenticator):
     }
     github_client_id = Unicode(
         config=True,
-        help="Deprecated in 0.1, use :attr:`.GitHubOAuthenticator.client_id`.",
+        help="""
+        .. deprecated:: 0.1
+
+           Use :attr:`.GitHubOAuthenticator.client_id`.
+        """,
     )
     github_client_secret = Unicode(
         config=True,
-        help="Deprecated in 0.1, use :attr:`.GitHubOAuthenticator.client_secret`.",
+        help="""
+        .. deprecated:: 0.1
+
+           Use :attr:`.GitHubOAuthenticator.client_secret`.
+        """,
     )
     github_organization_whitelist = Set(
         config=True,
-        help="Deprecated in 0.12, use :attr:`.GitHubOAuthenticator.allowed_organizations`.",
+        help="""
+        .. deprecated:: 0.12
+
+           Use :attr:`.GitHubOAuthenticator.allowed_organizations`.
+        """,
     )
 
     async def check_allowed(self, username, auth_model):

--- a/oauthenticator/gitlab.py
+++ b/oauthenticator/gitlab.py
@@ -136,7 +136,7 @@ class GitLabOAuthenticator(OAuthenticator):
         help="""
         .. deprecated:: 0.12
 
-           Use :attr:`.GitLabOAuthenticator.allowed_gitlab_groups`.
+           Use :attr:`allowed_gitlab_groups`.
         """,
     )
     gitlab_project_id_whitelist = Set(
@@ -144,7 +144,7 @@ class GitLabOAuthenticator(OAuthenticator):
         help="""
         .. deprecated:: 0.12
 
-           Use :attr:`.GitLabOAuthenticator.allowed_project_ids`.
+           Use :attr:`allowed_project_ids`.
         """,
     )
 

--- a/oauthenticator/gitlab.py
+++ b/oauthenticator/gitlab.py
@@ -133,11 +133,19 @@ class GitLabOAuthenticator(OAuthenticator):
     }
     gitlab_group_whitelist = Set(
         config=True,
-        help="Deprecated in 0.12, use :attr:`.GitLabOAuthenticator.allowed_gitlab_groups`.",
+        help="""
+        .. deprecated:: 0.12
+
+           Use :attr:`.GitLabOAuthenticator.allowed_gitlab_groups`.
+        """,
     )
     gitlab_project_id_whitelist = Set(
         config=True,
-        help="Deprecated in 0.12, use :attr:`.GitLabOAuthenticator.allowed_project_ids`.",
+        help="""
+        .. deprecated:: 0.12
+
+           Use :attr:`.GitLabOAuthenticator.allowed_project_ids`.
+        """,
     )
 
     gitlab_version = None

--- a/oauthenticator/gitlab.py
+++ b/oauthenticator/gitlab.py
@@ -21,12 +21,6 @@ def _api_headers(access_token):
 
 
 class GitLabOAuthenticator(OAuthenticator):
-    _deprecated_oauth_aliases = {
-        "gitlab_group_whitelist": ("allowed_gitlab_groups", "0.12.0"),
-        "gitlab_project_id_whitelist": ("allowed_project_ids", "0.12.0"),
-        **OAuthenticator._deprecated_oauth_aliases,
-    }
-
     user_auth_state_key = "gitlab_user"
     client_id_env = 'GITLAB_CLIENT_ID'
     client_secret_env = 'GITLAB_CLIENT_SECRET'
@@ -108,13 +102,6 @@ class GitLabOAuthenticator(OAuthenticator):
     def _userdata_url_default(self):
         return f"{self.gitlab_api}/user"
 
-    gitlab_group_whitelist = Set(
-        config=True,
-        help="""
-        Deprecated, use `GitLabOAuthenticator.allowed_gitlab_groups`
-        """,
-    )
-
     allowed_gitlab_groups = Set(
         config=True,
         help="""
@@ -123,13 +110,6 @@ class GitLabOAuthenticator(OAuthenticator):
         Note that for each group allowed, an additional REST API call needs to
         be made when a user is signing in. To reduce the risk of JupyterHub
         being rate limited, don't specify too many.
-        """,
-    )
-
-    gitlab_project_id_whitelist = Set(
-        config=True,
-        help="""
-        Deprecated, use `GitLabOAuthenticator.allowed_project_ids`
         """,
     )
 
@@ -143,6 +123,21 @@ class GitLabOAuthenticator(OAuthenticator):
         be made when a user is signing in. To reduce the risk of JupyterHub
         being rate limited, don't specify too many.
         """,
+    )
+
+    # _deprecated_oauth_aliases is used by deprecation logic in OAuthenticator
+    _deprecated_oauth_aliases = {
+        "gitlab_group_whitelist": ("allowed_gitlab_groups", "0.12.0"),
+        "gitlab_project_id_whitelist": ("allowed_project_ids", "0.12.0"),
+        **OAuthenticator._deprecated_oauth_aliases,
+    }
+    gitlab_group_whitelist = Set(
+        config=True,
+        help="Deprecated, use :attr:`.GitLabOAuthenticator.allowed_gitlab_groups`.",
+    )
+    gitlab_project_id_whitelist = Set(
+        config=True,
+        help="Deprecated, use :attr:`.GitLabOAuthenticator.allowed_project_ids`.",
     )
 
     gitlab_version = None
@@ -248,5 +243,4 @@ class GitLabOAuthenticator(OAuthenticator):
 
 
 class LocalGitLabOAuthenticator(LocalAuthenticator, GitLabOAuthenticator):
-
     """A version that mixes in local system user creation"""

--- a/oauthenticator/gitlab.py
+++ b/oauthenticator/gitlab.py
@@ -133,11 +133,11 @@ class GitLabOAuthenticator(OAuthenticator):
     }
     gitlab_group_whitelist = Set(
         config=True,
-        help="Deprecated, use :attr:`.GitLabOAuthenticator.allowed_gitlab_groups`.",
+        help="Deprecated in 0.12, use :attr:`.GitLabOAuthenticator.allowed_gitlab_groups`.",
     )
     gitlab_project_id_whitelist = Set(
         config=True,
-        help="Deprecated, use :attr:`.GitLabOAuthenticator.allowed_project_ids`.",
+        help="Deprecated in 0.12, use :attr:`.GitLabOAuthenticator.allowed_project_ids`.",
     )
 
     gitlab_version = None

--- a/oauthenticator/google.py
+++ b/oauthenticator/google.py
@@ -146,7 +146,7 @@ class GoogleOAuthenticator(OAuthenticator, GoogleOAuth2Mixin):
     }
     google_group_whitelist = Dict(
         config=True,
-        help="Deprecated, use :attr:`.GoogleOAuthenticator.allowed_google_groups`.",
+        help="Deprecated in 0.12, use :attr:`.GoogleOAuthenticator.allowed_google_groups`.",
     )
 
     async def update_auth_model(self, auth_model):

--- a/oauthenticator/google.py
+++ b/oauthenticator/google.py
@@ -12,11 +12,6 @@ from .oauth2 import OAuthenticator
 
 
 class GoogleOAuthenticator(OAuthenticator, GoogleOAuth2Mixin):
-    _deprecated_oauth_aliases = {
-        "google_group_whitelist": ("allowed_google_groups", "0.12.0"),
-        **OAuthenticator._deprecated_oauth_aliases,
-    }
-
     user_auth_state_key = "google_user"
 
     @default("login_service")
@@ -83,13 +78,6 @@ class GoogleOAuthenticator(OAuthenticator, GoogleOAuth2Mixin):
         """,
     )
 
-    google_group_whitelist = Dict(
-        config=True,
-        help="""
-        Deprecated, use `GoogleOAuthenticator.allowed_google_groups`
-        """,
-    )
-
     allowed_google_groups = Dict(
         Set(Unicode()),
         config=True,
@@ -150,6 +138,16 @@ class GoogleOAuthenticator(OAuthenticator, GoogleOAuth2Mixin):
                 return []
             return [proposal.value.lower()]
         return [hd.lower() for hd in proposal.value]
+
+    # _deprecated_oauth_aliases is used by deprecation logic in OAuthenticator
+    _deprecated_oauth_aliases = {
+        "google_group_whitelist": ("allowed_google_groups", "0.12.0"),
+        **OAuthenticator._deprecated_oauth_aliases,
+    }
+    google_group_whitelist = Dict(
+        config=True,
+        help="Deprecated, use :attr:`.GoogleOAuthenticator.allowed_google_groups`.",
+    )
 
     async def update_auth_model(self, auth_model):
         """

--- a/oauthenticator/google.py
+++ b/oauthenticator/google.py
@@ -149,7 +149,7 @@ class GoogleOAuthenticator(OAuthenticator, GoogleOAuth2Mixin):
         help="""
         .. deprecated:: 0.12
 
-           Use :attr:`.GoogleOAuthenticator.allowed_google_groups`.
+           Use :attr:`allowed_google_groups`.
         """,
     )
 

--- a/oauthenticator/google.py
+++ b/oauthenticator/google.py
@@ -146,7 +146,11 @@ class GoogleOAuthenticator(OAuthenticator, GoogleOAuth2Mixin):
     }
     google_group_whitelist = Dict(
         config=True,
-        help="Deprecated in 0.12, use :attr:`.GoogleOAuthenticator.allowed_google_groups`.",
+        help="""
+        .. deprecated:: 0.12
+
+           Use :attr:`.GoogleOAuthenticator.allowed_google_groups`.
+        """,
     )
 
     async def update_auth_model(self, auth_model):


### PR DESCRIPTION
Some classes had quite a bit of no longer relevant config, and since they also had long help strings it was a bit tricky to overview effectively what was relevant. With this PR I've:

- relocated `_deprecated_oauth_aliases` list of deprecated config and the deprecated/removed config to the end of config declarations
- reduced help strings of deprecated/removed config to ``"[Deprecated|Removed], use :attr:`.<class>.<new_config>`"`` strings

## Code refactoring preview

![image](https://github.com/jupyterhub/oauthenticator/assets/3837114/d79ce948-d91f-48d2-8d50-984909274be0)

## Config reference docs preview

![image](https://github.com/jupyterhub/oauthenticator/assets/3837114/2fedbf82-5a7c-432b-8737-c29c945a1c66)