### PR TITLE
breaking: add allow_existing_users config

### DIFF
--- a/docs/source/reference/changelog.md
+++ b/docs/source/reference/changelog.md
@@ -9,25 +9,28 @@ command line for details.
 ### Breaking changes
 
 - [All] Users are now authorized based on _either_ being part of
-  `Authenticator.admin_users`, `Authenticator.allowed_users`, an Authenticator
-  specific allowed group/team/organization, or if by being part of the existing
-  users if new config `OAuthenticator.allow_existing_users` is True.
+  {attr}`.OAuthenticator.admin_users`, {attr}`.OAuthenticator.allowed_users`, an
+  Authenticator specific allowed group/team/organization, or if by being part of
+  the existing users if new config {attr}`.OAuthenticator.allow_existing_users`
+  is True.
 - [All] Existing users (listed via `/hub/admin`) will now only be allowed if
-  `OAuthenticator.allow_existing_users` is True, while before this version they
-  were allowed if `Authenticator.allowed_users` was configured.
-- [Google] If `GoogleOAuthenticator.admin_google_groups` is configured, users
-  logging in not explicitly there or in `Authenticator.admin_users` will get
-  their admin status revoked.
-- [Generic, Google] `GenericOAuthenticator.allowed_groups`,
-  `GenericOAuthenticator.allowed_groups`
-  `GoogleOAuthenticator.allowed_google_groups`, and
-  `GoogleOAuthenticator.admin_google_groups` are now Set based configuration
-  instead of List based configuration. It is still possible to set these with
-  lists as as they are converted to sets automatically, but anyone reading and
-  adding entries must now use set logic and not list logic.
+  {attr}`.OAuthenticator.allow_existing_users` is True, while before this
+  version they were allowed if {attr}`.OAuthenticator.allowed_users` was
+  configured.
+- [Google] If {attr}`.GoogleOAuthenticator.admin_google_groups` is configured,
+  users logging in not explicitly there or in
+  {attr}`.OAuthenticator.admin_users` will get their admin status revoked.
+- [Generic, Google] {attr}`.GenericOAuthenticator.allowed_groups`,
+  {attr}`.GenericOAuthenticator.allowed_groups`
+  {attr}`.GoogleOAuthenticator.allowed_google_groups`, and
+  {attr}`.GoogleOAuthenticator.admin_google_groups` are now Set based
+  configuration instead of List based configuration. It is still possible to set
+  these with lists as as they are converted to sets automatically, but anyone
+  reading and adding entries must now use set logic and not list logic.
 - [Google] Authentication state's `google_groups` is now a set, not a list.
-- [CILogon] `allowed_idps` is now required config, and `shown_idps`,
-  `username_claim`, `additional_username_claims` must no longer be configured.
+- [CILogon] {attr}`.CILogonOAuthenticator.allowed_idps` is now required config,
+  and `shown_idps`, `username_claim`, `additional_username_claims` must no
+  longer be configured.
 
 (changelog:version-15)=
 

--- a/docs/source/reference/changelog.md
+++ b/docs/source/reference/changelog.md
@@ -10,8 +10,11 @@ command line for details.
 
 - [All] Users are now authorized based on _either_ being part of
   `Authenticator.admin_users`, `Authenticator.allowed_users`, an Authenticator
-  specific allowed team/group/organization, or declared in
-  `JupyterHub.load_roles` or `JupyterHub.load_groups`.
+  specific allowed group/team/organization, or if by being part of the existing
+  users if new config `OAuthenticator.allow_existing_users` is True.
+- [All] Existing users (listed via `/hub/admin`) will now only be allowed if
+  `OAuthenticator.allow_existing_users` is True, while before this version they
+  were allowed if `Authenticator.allowed_users` was configured.
 - [Google] If `GoogleOAuthenticator.admin_google_groups` is configured, users
   logging in not explicitly there or in `Authenticator.admin_users` will get
   their admin status revoked.

--- a/docs/source/tutorials/general-setup.md
+++ b/docs/source/tutorials/general-setup.md
@@ -58,6 +58,7 @@ projects' authenticator classes.
    reference.
 
    - {attr}`.OAuthenticator.allow_all`
+   - {attr}`.OAuthenticator.allow_existing_users`
    - {attr}`.OAuthenticator.allowed_users`
    - {attr}`.OAuthenticator.admin_users`
 
@@ -71,6 +72,7 @@ projects' authenticator classes.
    c.OAuthenticator.client_id = "1234-5678-9012-3456"
    c.OAuthenticator.client_secret = "abcd-edfg-ijkl-mnop"
 
+   c.OAuthenticator.allow_existing_users = True
    c.OAuthenticator.allowed_users = {"github-user-1", "github-user-2"}
    c.OAuthenticator.admin_users = {"github-user-3"}
 

--- a/oauthenticator/oauth2.py
+++ b/oauthenticator/oauth2.py
@@ -590,7 +590,7 @@ class OAuthenticator(Authenticator):
         """
         if not self.validate_username(user.name):
             raise ValueError("Invalid username: %s" % user.name)
-        if self.allow_existing_users:
+        if not self.allow_all and self.allow_existing_users:
             self.allowed_users.add(user.name)
 
     def login_url(self, base_url):

--- a/oauthenticator/oauth2.py
+++ b/oauthenticator/oauth2.py
@@ -257,13 +257,8 @@ class OAuthenticator(Authenticator):
         help="""
         Allow existing users to login.
 
-        With this enabled, JupyterHub admin users can visit `/hub/admin` or use
-        JupyterHub's REST API to add and remove users as a way to allow them
-        access.
-
-        The username for existing users must match the normalized username
-        returned by the authenticator. When creating users, only lowercase
-        letters should be used unless `MWOAuthenticator` is used.
+        An existing user is a user in JupyterHub's database of users, and it
+        includes all users that has previously logged in.
 
         .. warning::
 
@@ -272,11 +267,27 @@ class OAuthenticator(Authenticator):
            there because they have once been declared in config such as
            `allowed_users` or once been allowed to sign in.
 
+        .. warning::
+
+           When this is enabled and you are to remove access for one or more
+           users allowed via other config options, you must make sure that they
+           are not part of the database of users still. This can be tricky to do
+           if you stop allowing a group of externally managed users for example.
+
+        With this enabled, JupyterHub admin users can visit `/hub/admin` or use
+        JupyterHub's REST API to add and remove users as a way to allow them
+        access.
+
+        The username for existing users must match the normalized username
+        returned by the authenticator. When creating users, only lowercase
+        letters should be used unless `MWOAuthenticator` is used.
+
         .. note::
 
            Allowing existing users is done by adding existing users on startup
            and newly created users to the `allowed_users` set. Due to that, you
-           can't rely on this config to independently allow existing users.
+           can't rely on this config to independently allow existing users if
+           you for example would reset `allowed_users` after startup.
 
         .. versionadded:: 16.0
 

--- a/oauthenticator/tests/test_oauth2.py
+++ b/oauthenticator/tests/test_oauth2.py
@@ -1,6 +1,9 @@
 import re
 import uuid
-from unittest.mock import Mock
+from unittest.mock import Mock, PropertyMock
+
+from pytest import mark
+from traitlets.config import Config
 
 from ..oauth2 import (
     STATE_COOKIE_NAME,
@@ -65,3 +68,45 @@ async def test_httpfetch(client):
 
     r = await authenticator.httpfetch("http://example.org/a")
     assert r == ['http://example.org/a', 'GET', "proxy.example.org", 8080]
+
+
+@mark.parametrize(
+    "test_variation_id,class_config",
+    [
+        ("01", {"allow_existing_users": False}),
+        ("02", {"allow_existing_users": True}),
+    ],
+)
+async def test_add_user_override(
+    test_variation_id,
+    class_config,
+):
+    """
+    This test validates expectations on the Authenticator.add_user override
+    we've implemented in OAuthenticator in place to implement
+    allow_existing_users.
+
+    This is not fully testing the allow_existing_users config though, as we for
+    example are not validating the assumptions that the add_user hook is called
+    for each existing user at least once or that adjusting the allowed_users
+    list works well.
+    """
+    print(f"Running test variation id {test_variation_id}")
+    c = Config()
+    c.OAuthenticator = Config(class_config)
+    authenticator = OAuthenticator(config=c)
+
+    # prepare dummy user object with a name property
+    added_user = Mock()
+    added_user_name_property = PropertyMock(return_value="user1")
+    type(added_user).name = added_user_name_property
+
+    authenticator.add_user(added_user)
+
+    # assert that the user object's name property was accessed as expected, and
+    # that the allowed_users set was updated as expected
+    assert added_user_name_property.called
+    if authenticator.allow_existing_users:
+        assert added_user.name in authenticator.allowed_users
+    else:
+        assert added_user.name not in authenticator.allowed_users


### PR DESCRIPTION
Before the introduction of this config, existing jupyterhub users would when `allowed_users` was configured be allowed as well, but now they won't unless `allow_existing_users` is explicitly configured to True, and then they will be allowed independently if `allowed_users` was configured with any users or not.

## Checklist

- [x] Changelog breaking change entry added
- [x] Tests added
  Note that the test validates the `add_user` hook adds users to the `allowed_users` set if `allow_existing_users` is configured. So, we don't make a full end to end test where the authenticator authenticates and authorizes an existing user. We have tests for successful use of the `allowed_users` set though, so the part missing is testing the assumption that `add_user` is called by JupyterHub for existing users on startup and for newly created users, but that is a JuptyerHub promise for `Authenticator.add_user`.
- [x] Documentation updated

## Related

- Fixes #619
- Discussion about this in jupyterhub/jupyterhub, considering if we can add config like this in the Authenticator base class and if so how it should be named etc: https://github.com/jupyterhub/jupyterhub/issues/4483