### PR TITLE
[Generic] breaking fix: change basic_auth default to False

### DIFF
--- a/oauthenticator/generic.py
+++ b/oauthenticator/generic.py
@@ -76,10 +76,6 @@ class GenericOAuthenticator(OAuthenticator):
         help="Require valid tls certificates in HTTP requests",
     )
 
-    @default("basic_auth")
-    def _basic_auth_default(self):
-        return os.environ.get('OAUTH2_BASIC_AUTH', 'True').lower() in {'true', '1'}
-
     @default("http_client")
     def _default_http_client(self):
         return AsyncHTTPClient(

--- a/oauthenticator/oauth2.py
+++ b/oauthenticator/oauth2.py
@@ -473,7 +473,28 @@ class OAuthenticator(Authenticator):
         os.environ.get("OAUTH2_BASIC_AUTH", "False").lower() in {"true", "1"},
         config=True,
         help="""
-        Whether or not to use basic authentication for access token request
+        Whether or to use HTTP Basic authentication instead of form based
+        authentication in requests to :attr:`token_url`.
+
+        When using HTTP Basic authentication, a HTTP header is set with the
+        :attr:`client_id` and :attr:`client_secret` encoded in it.
+
+        When using form based authentication, the `client_id` and
+        `client_secret` is put in the HTTP POST request's body.
+
+        .. versionchanged:: 16.0.0
+
+           This configuration now toggles between HTTP Basic authentication and
+           form based authentication when working against the `token_url`.
+
+           Previously when this was configured True, both would be used contrary
+           to a recommendation in `OAuth 2.0 documentation
+           <https://www.rfc-editor.org/rfc/rfc6749#section-2.3.1>`_.
+
+        .. versionchanged:: 16.0.2
+
+           The default value for this configuration for GenericOAuthenticator
+           changed from True to False.
         """,
     )
 

--- a/oauthenticator/oauth2.py
+++ b/oauthenticator/oauth2.py
@@ -408,7 +408,7 @@ class OAuthenticator(Authenticator):
     userdata_params = Dict(
         config=True,
         help="""
-        Userdata params to get user data login information
+        Userdata params to get user data login information.
         """,
     )
 
@@ -417,7 +417,9 @@ class OAuthenticator(Authenticator):
         os.environ.get("OAUTH2_USERDATA_REQUEST_TYPE", "header"),
         config=True,
         help="""
-        Method for sending access token in userdata request. Supported methods: header, url. Default: header
+        Method for sending access token in userdata request.
+
+        Supported methods: header, url.
         """,
     )
 
@@ -425,7 +427,8 @@ class OAuthenticator(Authenticator):
     token_params = Dict(
         config=True,
         help="""
-        Extra parameters for first POST request exchanging the OAuth code for an Access Token
+        Extra parameters for first POST request exchanging the OAuth code for an
+        Access Token
         """,
     )
 


### PR DESCRIPTION
The 16.0.0 release included a breaking change that wasn't documented.

The changed behavior in 16.0.0 was that `basic_auth` when set to True (only for GenericOAuthenticator by default) would no longer post `client_id` and `client_secret` in the HTTP POST request body when accessing `token_url` - in accordance with a OAuth2 standard recommendation.

For users of GenericOAuthenticator against KeyCloak, not receiving the `client_id` and `client_secret` in the POST request body caused it to no longer function as reported in #646. So in that case the HTTP Basic authentication header was irrelevant and the non-breaking default would have been to have `basic_auth` changed to False.

In this PR I make  `basic_auth` is configured False by default for GenericOAuthenticator, no longer breaking use against KeyCloak deployments as they were configured, and aligning the GenericOAuthenticator default with all other classes default.

- Closes #646