### PR TITLE
Fix typo in authenticator class for google

### DIFF
--- a/docs/source/tutorials/provider-specific-setup/providers/google.md
+++ b/docs/source/tutorials/provider-specific-setup/providers/google.md
@@ -18,7 +18,7 @@ followed by `/hub/oauth_callback`.
 Your `jupyterhub_config.py` file should look something like this:
 
 ```python
-c.JupyterHub.authenticator_class = "okpy"
+c.JupyterHub.authenticator_class = "google"
 c.OAuthenticator.oauth_callback_url = "https://[your-domain]/hub/oauth_callback"
 c.OAuthenticator.client_id = "[your oauth2 application id]"
 c.OAuthenticator.client_secret = "[your oauth2 application secret]"


### PR DESCRIPTION
The provider specific setup for Google has a typo and currently points to the okpy provider.