### PR TITLE
[Google] Fix regression in v16 of no longer stripping username's domain if `hosted_domain` has a single entry

### DIFF
--- a/oauthenticator/google.py
+++ b/oauthenticator/google.py
@@ -112,7 +112,7 @@ class GoogleOAuthenticator(OAuthenticator, GoogleOAuth2Mixin):
 
         1. Restrict sign-in to a list of email domain names, such as
            `["mycollege.edu"]` or `["college1.edu", "college2.edu"]`.
-        2. If a single domain is specified, the username will be stripped.
+        2. If a single domain is specified, the username will be stripped to exclude the `@domain` part.
 
         Note that users with email domains in this list must still be allowed
         via another config, such as `allow_all`, `allowed_users`, or


### PR DESCRIPTION
This PR influences users with GoogleOAuthenticator that had configured `hosted_domain` with a single domain entry.

This PR is fixing a regression / undocumented breaking change introduced in oauthenticator 16.0.0 by returning things as they were before.

- Closes #660, thank you @taylorgibson for reporting this!!!