### PR TITLE
handle auth_model is None in google, globus

### DIFF
--- a/oauthenticator/globus.py
+++ b/oauthenticator/globus.py
@@ -291,6 +291,11 @@ class GlobusOAuthenticator(OAuthenticator):
         Overrides the OAuthenticator.check_allowed to also allow users part of
         `allowed_globus_groups`.
         """
+        # A workaround for JupyterHub < 5.0 described in
+        # https://github.com/jupyterhub/oauthenticator/issues/621
+        if auth_model is None:
+            return True
+
         # before considering allowing a username by being recognized in a list
         # of usernames or similar, we must ensure that the authenticated user is
         # from an allowed identity provider domain.

--- a/oauthenticator/google.py
+++ b/oauthenticator/google.py
@@ -207,6 +207,11 @@ class GoogleOAuthenticator(OAuthenticator, GoogleOAuth2Mixin):
         Overrides the OAuthenticator.check_allowed to also allow users part of
         `allowed_google_groups`.
         """
+        # A workaround for JupyterHub < 5.0 described in
+        # https://github.com/jupyterhub/oauthenticator/issues/621
+        if auth_model is None:
+            return True
+
         # before considering allowing a username by being recognized in a list
         # of usernames or similar, we must ensure that the authenticated user
         # has a verified email and is part of hosted_domain if configured.

--- a/oauthenticator/oauth2.py
+++ b/oauthenticator/oauth2.py
@@ -463,7 +463,7 @@ class OAuthenticator(Authenticator):
         config=True,
         help="""
         Callback URL to use.
-        
+
         When registering an OAuth2 application with an identity provider, this
         is typically called the redirect url.
 
@@ -994,7 +994,7 @@ class OAuthenticator(Authenticator):
         method and return True when this method returns True or if a user is
         allowed via the additional config.
         """
-        # A workaround for JupyterHub<=4.0.1, described in
+        # A workaround for JupyterHub < 5.0 described in
         # https://github.com/jupyterhub/oauthenticator/issues/621
         if auth_model is None:
             return True

--- a/oauthenticator/tests/test_generic.py
+++ b/oauthenticator/tests/test_generic.py
@@ -238,3 +238,18 @@ async def test_generic_claim_groups_key_nested_strings(
 
     assert auth_model
     assert auth_model["admin"]
+
+
+@mark.parametrize(
+    "name, allowed",
+    [
+        ("allowed", True),
+        ("notallowed", False),
+    ],
+)
+async def test_check_allowed_no_auth_state(get_authenticator, name, allowed):
+    authenticator = get_authenticator(allowed_users={"allowed"})
+    # allow check always gets called with no auth model during Hub startup
+    # these are previously-allowed users who should pass until subsequent
+    # this check is removed in JupyterHub 5
+    assert await authenticator.check_allowed(name, None)

--- a/oauthenticator/tests/test_globus.py
+++ b/oauthenticator/tests/test_globus.py
@@ -313,6 +313,21 @@ async def test_globus(
         assert auth_model == None
 
 
+@mark.parametrize(
+    "name, allowed",
+    [
+        ("allowed", True),
+        ("notallowed", False),
+    ],
+)
+async def test_check_allowed_no_auth_state(name, allowed):
+    authenticator = GlobusOAuthenticator(allowed_users={"allowed"})
+    # allow check always gets called with no auth model during Hub startup
+    # these are previously-allowed users who should pass until subsequent
+    # this check is removed in JupyterHub 5
+    assert await authenticator.check_allowed(name, None)
+
+
 async def test_globus_pre_spawn_start(mock_globus_user):
     authenticator = GlobusOAuthenticator()
     spawner = Mock()

--- a/oauthenticator/tests/test_google.py
+++ b/oauthenticator/tests/test_google.py
@@ -209,6 +209,21 @@ async def test_hosted_domain_single_entry(google_client):
     assert exc.value.status_code == 403
 
 
+@mark.parametrize(
+    "name, allowed",
+    [
+        ("allowed", True),
+        ("notallowed", False),
+    ],
+)
+async def test_check_allowed_no_auth_state(google_client, name, allowed):
+    authenticator = GoogleOAuthenticator(allowed_users={"allowed"})
+    # allow check always gets called with no auth model during Hub startup
+    # these are previously-allowed users who should pass until subsequent
+    # this check is removed in JupyterHub 5
+    assert await authenticator.check_allowed(name, None)
+
+
 async def test_hosted_domain_multiple_entries(google_client):
     """
     Tests that sign in is restricted to the listed domains and that the username


### PR DESCRIPTION
these both have pre-super checks, which means they don't inherit the short-circuit from the base class

closes #663 