### PR TITLE
[Google, Globus, BitBucket] Ensure auth_state is JSON serializable (lists are, not sets)

### DIFF
--- a/oauthenticator/bitbucket.py
+++ b/oauthenticator/bitbucket.py
@@ -93,7 +93,7 @@ class BitbucketOAuthenticator(OAuthenticator):
 
         if self.allowed_teams:
             user_teams = set(auth_model["auth_state"].get("user_teams", []))
-            if any(user_teams & self.allowed_teams):
+            if user_teams & self.allowed_teams:
                 return True
 
         # users should be explicitly allowed via config, otherwise they aren't

--- a/oauthenticator/bitbucket.py
+++ b/oauthenticator/bitbucket.py
@@ -73,11 +73,13 @@ class BitbucketOAuthenticator(OAuthenticator):
         Fetch and store `user_teams` in auth state if `allowed_teams` is
         configured.
         """
+        user_teams = set()
         if self.allowed_teams:
             access_token = auth_model["auth_state"]["token_response"]["access_token"]
             token_type = auth_model["auth_state"]["token_response"]["token_type"]
             user_teams = await self._fetch_user_teams(access_token, token_type)
-            auth_model["auth_state"]["user_teams"] = user_teams
+        # sets are not JSONable, cast to list for auth_state
+        auth_model["auth_state"]["user_teams"] = list(user_teams)
 
         return auth_model
 
@@ -90,7 +92,7 @@ class BitbucketOAuthenticator(OAuthenticator):
             return True
 
         if self.allowed_teams:
-            user_teams = auth_model["auth_state"]["user_teams"]
+            user_teams = set(auth_model["auth_state"].get("user_teams", []))
             if any(user_teams & self.allowed_teams):
                 return True
 

--- a/oauthenticator/generic.py
+++ b/oauthenticator/generic.py
@@ -159,7 +159,7 @@ class GenericOAuthenticator(OAuthenticator):
             # admin status should in this case be True or False, not None
             user_info = auth_model["auth_state"][self.user_auth_state_key]
             user_groups = self.get_user_groups(user_info)
-            auth_model["admin"] = any(user_groups & self.admin_groups)
+            auth_model["admin"] = bool(user_groups & self.admin_groups)
 
         return auth_model
 

--- a/oauthenticator/globus.py
+++ b/oauthenticator/globus.py
@@ -314,7 +314,7 @@ class GlobusOAuthenticator(OAuthenticator):
 
         if self.allowed_globus_groups:
             user_groups = set(auth_model["auth_state"]["globus_groups"])
-            if any(user_groups & self.allowed_globus_groups):
+            if user_groups & self.allowed_globus_groups:
                 return True
             self.log.warning(f"{username} not in an allowed Globus Group")
 
@@ -344,7 +344,7 @@ class GlobusOAuthenticator(OAuthenticator):
 
         if self.admin_globus_groups:
             # admin status should in this case be True or False, not None
-            auth_model["admin"] = any(user_groups & self.admin_globus_groups)
+            auth_model["admin"] = bool(user_groups & self.admin_globus_groups)
 
         return auth_model
 

--- a/oauthenticator/globus.py
+++ b/oauthenticator/globus.py
@@ -313,7 +313,7 @@ class GlobusOAuthenticator(OAuthenticator):
             return True
 
         if self.allowed_globus_groups:
-            user_groups = auth_model["auth_state"]["globus_groups"]
+            user_groups = set(auth_model["auth_state"]["globus_groups"])
             if any(user_groups & self.allowed_globus_groups):
                 return True
             self.log.warning(f"{username} not in an allowed Globus Group")
@@ -335,7 +335,8 @@ class GlobusOAuthenticator(OAuthenticator):
         if self.allowed_globus_groups or self.admin_globus_groups:
             tokens = self.get_globus_tokens(auth_model["auth_state"]["token_response"])
             user_groups = await self._fetch_users_groups(tokens)
-        auth_model["auth_state"]["globus_groups"] = user_groups
+        # sets are not JSONable, cast to list for auth_state
+        auth_model["auth_state"]["globus_groups"] = list(user_groups)
 
         if auth_model["admin"]:
             # auth_model["admin"] being True means the user was in admin_users

--- a/oauthenticator/google.py
+++ b/oauthenticator/google.py
@@ -197,7 +197,7 @@ class GoogleOAuthenticator(OAuthenticator, GoogleOAuth2Mixin):
         if self.admin_google_groups:
             # admin status should in this case be True or False, not None
             admin_groups = self.admin_google_groups.get(user_domain, set())
-            auth_model["admin"] = any(user_groups & admin_groups)
+            auth_model["admin"] = bool(user_groups & admin_groups)
 
         return auth_model
 
@@ -242,7 +242,7 @@ class GoogleOAuthenticator(OAuthenticator, GoogleOAuth2Mixin):
         if self.allowed_google_groups:
             user_groups = set(user_info["google_groups"])
             allowed_groups = self.allowed_google_groups.get(user_domain, set())
-            if any(user_groups & allowed_groups):
+            if user_groups & allowed_groups:
                 return True
 
         # users should be explicitly allowed via config, otherwise they aren't

--- a/oauthenticator/google.py
+++ b/oauthenticator/google.py
@@ -186,10 +186,9 @@ class GoogleOAuthenticator(OAuthenticator, GoogleOAuth2Mixin):
 
         user_groups = set()
         if self.allowed_google_groups or self.admin_google_groups:
-            user_groups = user_info["google_groups"] = self._fetch_user_groups(
-                user_email, user_domain
-            )
-        user_info["google_groups"] = user_groups
+            user_groups = self._fetch_user_groups(user_email, user_domain)
+        # sets are not JSONable, cast to list for auth_state
+        user_info["google_groups"] = list(user_groups)
 
         if auth_model["admin"]:
             # auth_model["admin"] being True means the user was in admin_users
@@ -241,7 +240,7 @@ class GoogleOAuthenticator(OAuthenticator, GoogleOAuth2Mixin):
             return True
 
         if self.allowed_google_groups:
-            user_groups = user_info["google_groups"]
+            user_groups = set(user_info["google_groups"])
             allowed_groups = self.allowed_google_groups.get(user_domain, set())
             if any(user_groups & allowed_groups):
                 return True

--- a/oauthenticator/openshift.py
+++ b/oauthenticator/openshift.py
@@ -161,7 +161,7 @@ class OpenShiftOAuthenticator(OAuthenticator):
             # admin status should in this case be True or False, not None
             user_info = auth_model["auth_state"][self.user_auth_state_key]
             user_groups = set(user_info["groups"])
-            auth_model["admin"] = any(user_groups & self.admin_groups)
+            auth_model["admin"] = bool(user_groups & self.admin_groups)
 
         return auth_model
 
@@ -176,7 +176,7 @@ class OpenShiftOAuthenticator(OAuthenticator):
         if self.allowed_groups:
             user_info = auth_model["auth_state"][self.user_auth_state_key]
             user_groups = set(user_info["groups"])
-            if any(user_groups & self.allowed_groups):
+            if user_groups & self.allowed_groups:
                 return True
 
         # users should be explicitly allowed via config, otherwise they aren't

--- a/oauthenticator/tests/test_auth0.py
+++ b/oauthenticator/tests/test_auth0.py
@@ -1,3 +1,4 @@
+import json
 import logging
 from unittest.mock import Mock
 
@@ -86,6 +87,7 @@ async def test_auth0(
         assert set(auth_model) == {"name", "admin", "auth_state"}
         assert auth_model["admin"] == expect_admin
         auth_state = auth_model["auth_state"]
+        assert json.dumps(auth_state)
         assert "access_token" in auth_state
         user_info = auth_state[authenticator.user_auth_state_key]
         assert user_info == handled_user_model

--- a/oauthenticator/tests/test_azuread.py
+++ b/oauthenticator/tests/test_azuread.py
@@ -1,4 +1,5 @@
 """test azure ad"""
+import json
 import os
 import re
 import time
@@ -132,6 +133,7 @@ async def test_azuread(
         assert set(auth_model) == {"name", "admin", "auth_state"}
         assert auth_model["admin"] == expect_admin
         auth_state = auth_model["auth_state"]
+        assert json.dumps(auth_state)
         assert "access_token" in auth_state
         user_info = auth_state[authenticator.user_auth_state_key]
         assert user_info["aud"] == authenticator.client_id

--- a/oauthenticator/tests/test_bitbucket.py
+++ b/oauthenticator/tests/test_bitbucket.py
@@ -1,3 +1,4 @@
+import json
 import logging
 
 from pytest import fixture, mark, raises
@@ -103,6 +104,7 @@ async def test_bitbucket(
         assert set(auth_model) == {"name", "admin", "auth_state"}
         assert auth_model["admin"] == expect_admin
         auth_state = auth_model["auth_state"]
+        assert json.dumps(auth_state)
         assert "access_token" in auth_state
         user_info = auth_state[authenticator.user_auth_state_key]
         assert user_info == handled_user_model

--- a/oauthenticator/tests/test_cilogon.py
+++ b/oauthenticator/tests/test_cilogon.py
@@ -92,6 +92,7 @@ async def test_cilogon(
         assert set(auth_model) == {"name", "admin", "auth_state"}
         assert auth_model["admin"] == expect_admin
         auth_state = auth_model["auth_state"]
+        assert json.dumps(auth_state)
         assert "access_token" in auth_state
         assert "token_response" in auth_state
         user_info = auth_state[authenticator.user_auth_state_key]

--- a/oauthenticator/tests/test_generic.py
+++ b/oauthenticator/tests/test_generic.py
@@ -1,3 +1,4 @@
+import json
 from functools import partial
 
 from pytest import fixture, mark
@@ -175,6 +176,7 @@ async def test_generic(
         assert set(auth_model) == {"name", "admin", "auth_state"}
         assert auth_model["admin"] == expect_admin
         auth_state = auth_model["auth_state"]
+        assert json.dumps(auth_state)
         assert "access_token" in auth_state
         assert "oauth_user" in auth_state
         assert "refresh_token" in auth_state

--- a/oauthenticator/tests/test_github.py
+++ b/oauthenticator/tests/test_github.py
@@ -90,6 +90,7 @@ async def test_github(
         assert set(auth_model) == {"name", "admin", "auth_state"}
         assert auth_model["admin"] == expect_admin
         auth_state = auth_model["auth_state"]
+        assert json.dumps(auth_state)
         assert "access_token" in auth_state
         user_info = auth_state[authenticator.user_auth_state_key]
         assert user_info == handled_user_model

--- a/oauthenticator/tests/test_gitlab.py
+++ b/oauthenticator/tests/test_gitlab.py
@@ -110,6 +110,7 @@ async def test_gitlab(
         assert set(auth_model) == {"name", "admin", "auth_state"}
         assert auth_model["admin"] == expect_admin
         auth_state = auth_model["auth_state"]
+        assert json.dumps(auth_state)
         assert "access_token" in auth_state
         user_info = auth_state[authenticator.user_auth_state_key]
         assert user_info == handled_user_model
@@ -215,6 +216,7 @@ async def test_allowed_groups(gitlab_client, paginate):
     handler = gitlab_client.handler_for_user(handled_user_model)
     auth_model = await authenticator.get_authenticated_user(handler, None)
     assert auth_model
+    assert json.dumps(auth_model["auth_state"])
 
     handled_user_model = user_model("user-not-in-group")
     handler = gitlab_client.handler_for_user(handled_user_model)
@@ -299,6 +301,7 @@ async def test_allowed_project_ids(gitlab_client):
     handler = gitlab_client.handler_for_user(developer_user_model)
     auth_model = await authenticator.get_authenticated_user(handler, None)
     assert auth_model
+    assert json.dumps(auth_model["auth_state"])
 
     # Forbidden, project doesn't exist
     authenticator.allowed_project_ids = [0]
@@ -311,6 +314,7 @@ async def test_allowed_project_ids(gitlab_client):
     handler = gitlab_client.handler_for_user(developer_user_model)
     auth_model = await authenticator.get_authenticated_user(handler, None)
     assert auth_model
+    assert json.dumps(auth_model["auth_state"])
 
 
 @mark.parametrize(

--- a/oauthenticator/tests/test_globus.py
+++ b/oauthenticator/tests/test_globus.py
@@ -309,7 +309,7 @@ async def test_globus(
         user_info = auth_state[authenticator.user_auth_state_key]
         assert auth_model["name"] == user_info[authenticator.username_claim]
         if authenticator.allowed_globus_groups or authenticator.admin_globus_groups:
-            assert auth_state["globus_groups"] == {"group1"}
+            assert auth_state["globus_groups"] == ["group1"]
     else:
         assert auth_model == None
 

--- a/oauthenticator/tests/test_globus.py
+++ b/oauthenticator/tests/test_globus.py
@@ -303,6 +303,7 @@ async def test_globus(
         assert set(auth_model) == {"name", "admin", "auth_state"}
         assert auth_model["admin"] == expect_admin
         auth_state = auth_model["auth_state"]
+        assert json.dumps(auth_state)
         assert "tokens" in auth_state
         assert "transfer.api.globus.org" in auth_state["tokens"]
         user_info = auth_state[authenticator.user_auth_state_key]

--- a/oauthenticator/tests/test_google.py
+++ b/oauthenticator/tests/test_google.py
@@ -182,7 +182,7 @@ async def test_google(
         user_info = auth_state[authenticator.user_auth_state_key]
         assert auth_model["name"] == user_info[authenticator.username_claim]
         if authenticator.allowed_google_groups or authenticator.admin_google_groups:
-            assert user_info["google_groups"] == {"group1"}
+            assert user_info["google_groups"] == ["group1"]
     else:
         assert auth_model == None
 

--- a/oauthenticator/tests/test_google.py
+++ b/oauthenticator/tests/test_google.py
@@ -1,4 +1,5 @@
 import hashlib
+import json
 import logging
 import re
 from unittest import mock
@@ -176,6 +177,7 @@ async def test_google(
         assert set(auth_model) == {"name", "admin", "auth_state"}
         assert auth_model["admin"] == expect_admin
         auth_state = auth_model["auth_state"]
+        assert json.dumps(auth_state)
         assert "access_token" in auth_state
         user_info = auth_state[authenticator.user_auth_state_key]
         assert auth_model["name"] == user_info[authenticator.username_claim]

--- a/oauthenticator/tests/test_mediawiki.py
+++ b/oauthenticator/tests/test_mediawiki.py
@@ -104,6 +104,7 @@ async def test_mediawiki(
         assert set(auth_model) == {"name", "admin", "auth_state"}
         assert auth_model["admin"] == expect_admin
         auth_state = auth_model["auth_state"]
+        assert json.dumps(auth_state)
         assert "ACCESS_TOKEN_KEY" in auth_state
         assert "ACCESS_TOKEN_SECRET" in auth_state
         user_info = auth_state[authenticator.user_auth_state_key]

--- a/oauthenticator/tests/test_okpy.py
+++ b/oauthenticator/tests/test_okpy.py
@@ -1,3 +1,5 @@
+import json
+
 from pytest import fixture, mark
 from traitlets.config import Config
 
@@ -78,6 +80,7 @@ async def test_okpy(
         assert set(auth_model) == {"name", "admin", "auth_state"}
         assert auth_model["admin"] == expect_admin
         auth_state = auth_model["auth_state"]
+        assert json.dumps(auth_state)
         assert "access_token" in auth_state
         user_info = auth_state[authenticator.user_auth_state_key]
         assert user_info == handled_user_model

--- a/oauthenticator/tests/test_openshift.py
+++ b/oauthenticator/tests/test_openshift.py
@@ -1,3 +1,5 @@
+import json
+
 import pytest
 from traitlets.config import Config
 
@@ -157,6 +159,7 @@ async def test_openshift(
         assert auth_model["name"] == handled_user_model["metadata"]["name"]
         assert auth_model["admin"] == expect_admin
         auth_state = auth_model["auth_state"]
+        assert json.dumps(auth_state)
         assert "access_token" in auth_state
         user_info = auth_state[authenticator.user_auth_state_key]
         assert user_info == handled_user_model


### PR DESCRIPTION
This PR adds a test to ensure the `auth_state` is set to a serializable object, because if it isn't, then use of `c.Authenticator.enable_auth_state = True` will cause JupyterHub to error with a broken assumption.

This PR doesn't resolve the situation. The situation is caused by a change for various group related fields from list to set in the 16.0.0 release. The change was meant to reduce back and forth casting and confusion stemming from config being Set based but info about groups/teams ended up list based.

## Fix implementation brainstorming

I think there are various strategies to consider to resolve this caused by putting `set` objects under `auth_state`.

1. To always cast back and forth between set/list when writing/reading from `auth_state`
2. To change config of Set type to List type if that relates to avoiding all set based `auth_state` without needing to cast back and forth
3. To not put set based content under `auth_state`, but in `auth_model` (then it won't be persisted)

I'm leaning on going for 1 or 2. To evaluate if 2 is an alternative, we should know if the traitlet based List type can accept being passed at set also. Probably towards 1?

## Action points - help wanted

I'm on vacation so if someone wants to resolve this by completing this PR by pushing commits or opening another one, please go for it! Make a comment that you are in case I'll end up wanting to work this during my vacation.

- [x] Fix failing tests for BitBucket
- [x] Fix failing tests for Globus
- [x] Fix failing tests for Google

closes #667