### PR TITLE
Drop next_url from authorize_redirect state param

### DIFF
--- a/oauthenticator/tests/mocks.py
+++ b/oauthenticator/tests/mocks.py
@@ -248,6 +248,10 @@ def mock_handler(Handler, uri='https://hub.example.com', method='GET', **setting
     return handler
 
 
+async def mock_login_user_coro():
+    return True
+
+
 async def no_code_test(authenticator):
     """Run a test to exercise no code in the request"""
     handler = Mock(spec=web.RequestHandler)


### PR DESCRIPTION
This addresses #659

I still want to add tests for the callback handler

I also dropped the log warnings when the url was "cleaned up" before saving to the cookie.

---

EDIT: fixes #659 - by writing this, the issue is closed when this PR is merged