### PR TITLE
fix f-string in basic auth

### DIFF
--- a/oauthenticator/oauth2.py
+++ b/oauthenticator/oauth2.py
@@ -735,7 +735,7 @@ class OAuthenticator(Authenticator):
 
         if self.basic_auth:
             b64key = base64.b64encode(
-                bytes("{self.client_id}:{self.client_secret}", "utf8")
+                bytes(f"{self.client_id}:{self.client_secret}", "utf8")
             )
             headers.update({"Authorization": f'Basic {b64key.decode("utf8")}'})
         return headers


### PR DESCRIPTION
A typo in  `build_token_info_request_headers(self)` will create a wrong header if basic auth is used. Using a f-sting instead of a regular string fixes that.