### PR TITLE
[CILogon] Add allow_all as a idp specific config

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -6,7 +6,6 @@
 autodoc-traits
 importlib_metadata>=3.6; python_version < '3.10'
 myst-parser
-sphinx>=2
 sphinx-autobuild
 sphinx-book-theme
 sphinx-copybutton

--- a/oauthenticator/schemas/cilogon-schema.yaml
+++ b/oauthenticator/schemas/cilogon-schema.yaml
@@ -7,6 +7,8 @@ additionalProperties: false
 required:
   - username_derivation
 properties:
+  allow_all:
+    type: boolean
   allowed_domains:
     type: array
     items:


### PR DESCRIPTION
- Fixes #682 by adding a `allow_all` sub-config next to `allowed_domains`.

Without this, a user may be forced to use OAUthenticator v15 to acquire a functionality where all users authenticated by an IDP are allowed, but not all users of another IDP. So in practice, this mitigates a feature regression - where something was possible in oauthenticator 15 that no longer was possible in oauthenticator 16.

Here is an example config where we allow all users from one IDP together with one github user being an admin user.

```python
c.CILogonOAuthenticator.allowed_idps = {
    "https://idpz.utorauth.utoronto.ca/shibboleth": {
        "username_derivation": {
            "username_claim": "email",
        },
        "allow_all": True,
    },
    "https://github.com/login/oauth/authorize": {
        "username_derivation": {
            "username_claim": "preferred_username",
        },
    },
}
c.Authenticator.admin_users = ["some-github-user1"]
```