### PR TITLE
[CILogon] Rename allowed_idps to idps (deprecation, not removal)

### DIFF
--- a/docs/source/tutorials/provider-specific-setup/providers/cilogon.md
+++ b/docs/source/tutorials/provider-specific-setup/providers/cilogon.md
@@ -21,4 +21,4 @@ c.OAuthenticator.client_secret = "[your oauth2 application secret]"
 CILogonOAuthenticator expands OAuthenticator with the following required config,
 read more about it in the configuration reference:
 
-- {attr}`.CILogonOAuthenticator.allowed_idps`
+- {attr}`.CILogonOAuthenticator.idps`

--- a/oauthenticator/schemas/cilogon-schema.yaml
+++ b/oauthenticator/schemas/cilogon-schema.yaml
@@ -1,5 +1,5 @@
 # This JSONSchema is used to validate the values in the
-# CILogonOAuthenticator.allowed_idps dictionary.
+# CILogonOAuthenticator.idps dictionary.
 #
 $schema: http://json-schema.org/draft-07/schema#
 type: object

--- a/oauthenticator/tests/test_cilogon.py
+++ b/oauthenticator/tests/test_cilogon.py
@@ -436,7 +436,7 @@ async def test_cilogon(
         ),
     ],
 )
-async def test_cilogon_allowed_idps(
+async def test_cilogon_idps(
     cilogon_client,
     test_variation_id,
     idp_config,
@@ -484,7 +484,7 @@ async def test_cilogon_allowed_idps(
             {"idp_whitelist": ["dummy"]},
             {},
             logging.ERROR,
-            "CILogonOAuthenticator.idp_whitelist is deprecated in CILogonOAuthenticator 0.12.0, use CILogonOAuthenticator.allowed_idps instead",
+            "CILogonOAuthenticator.idp_whitelist is deprecated in CILogonOAuthenticator 0.12.0, use CILogonOAuthenticator.idps instead",
         ),
         (
             "idp",
@@ -498,28 +498,47 @@ async def test_cilogon_allowed_idps(
             {"strip_idp_domain": True},
             {},
             logging.ERROR,
-            "CILogonOAuthenticator.strip_idp_domain is deprecated in CILogonOAuthenticator 15.0.0, use CILogonOAuthenticator.allowed_idps instead",
+            "CILogonOAuthenticator.strip_idp_domain is deprecated in CILogonOAuthenticator 15.0.0, use CILogonOAuthenticator.idps instead",
         ),
         (
             "shown_idps",
             {"shown_idps": ["dummy"]},
             {},
             logging.ERROR,
-            "CILogonOAuthenticator.shown_idps is deprecated in CILogonOAuthenticator 16.0.0, use CILogonOAuthenticator.allowed_idps instead",
+            "CILogonOAuthenticator.shown_idps is deprecated in CILogonOAuthenticator 16.0.0, use CILogonOAuthenticator.idps instead",
         ),
         (
             "username_claim",
             {"username_claim": "dummy"},
             {},
             logging.ERROR,
-            "CILogonOAuthenticator.username_claim is deprecated in CILogonOAuthenticator 16.0.0, use CILogonOAuthenticator.allowed_idps instead",
+            "CILogonOAuthenticator.username_claim is deprecated in CILogonOAuthenticator 16.0.0, use CILogonOAuthenticator.idps instead",
         ),
         (
             "additional_username_claims",
             {"additional_username_claims": ["dummy"]},
             {},
             logging.ERROR,
-            "CILogonOAuthenticator.additional_username_claims is deprecated in CILogonOAuthenticator 16.0.0, use CILogonOAuthenticator.allowed_idps instead",
+            "CILogonOAuthenticator.additional_username_claims is deprecated in CILogonOAuthenticator 16.0.0, use CILogonOAuthenticator.idps instead",
+        ),
+        (
+            "allowed_idps",
+            {
+                "allowed_idps": {
+                    "https://github.com/login/oauth/authorize": {
+                        "username_derivation": {"username_claim": "email"}
+                    }
+                }
+            },
+            {
+                "idps": {
+                    "https://github.com/login/oauth/authorize": {
+                        "username_derivation": {"username_claim": "email"}
+                    }
+                }
+            },
+            logging.WARNING,
+            "CILogonOAuthenticator.allowed_idps is deprecated in CILogonOAuthenticator 16.1.0, use CILogonOAuthenticator.idps instead",
         ),
     ],
 )
@@ -555,7 +574,7 @@ async def test_deprecated_config(
     assert expected_log_tuple in captured_log_tuples
 
 
-async def test_config_allowed_idps_wrong_type(caplog):
+async def test_config_idps_wrong_type(caplog):
     """
     Test alllowed_idps is a dict
     """
@@ -566,7 +585,7 @@ async def test_config_allowed_idps_wrong_type(caplog):
         CILogonOAuthenticator(config=c)
 
 
-async def test_config_allowed_idps_required_username_derivation(caplog):
+async def test_config_idps_required_username_derivation(caplog):
     # Test username_derivation is a required field of allowed_idps
     c = Config()
     c.CILogonOAuthenticator.allowed_idps = {
@@ -577,7 +596,7 @@ async def test_config_allowed_idps_required_username_derivation(caplog):
         CILogonOAuthenticator(config=c)
 
 
-async def test_config_allowed_idps_invalid_entity_id(caplog):
+async def test_config_idps_invalid_entity_id(caplog):
     """
     Test allowed_idps keys cannot be domains, but only valid CILogon entity ids,
     i.e. only fully formed URLs
@@ -606,7 +625,7 @@ async def test_config_allowed_idps_invalid_entity_id(caplog):
     assert expected_deprecation_error in log_msgs
 
 
-async def test_config_allowed_idps_invalid_type(caplog):
+async def test_config_idps_invalid_type(caplog):
     c = Config()
     c.CILogonOAuthenticator.allowed_idps = {
         'https://github.com/login/oauth/authorize': 'should-be-a-dict'
@@ -615,7 +634,7 @@ async def test_config_allowed_idps_invalid_type(caplog):
         CILogonOAuthenticator(config=c)
 
 
-async def test_config_allowed_idps_unrecognized_options(caplog):
+async def test_config_idps_unrecognized_options(caplog):
     c = Config()
     c.CILogonOAuthenticator.allowed_idps = {
         'https://github.com/login/oauth/authorize': {
@@ -626,7 +645,7 @@ async def test_config_allowed_idps_unrecognized_options(caplog):
         CILogonOAuthenticator(config=c)
 
 
-async def test_config_allowed_idps_domain_required(caplog):
+async def test_config_idps_domain_required(caplog):
     c = Config()
     c.CILogonOAuthenticator.allowed_idps = {
         'https://github.com/login/oauth/authorize': {
@@ -640,7 +659,7 @@ async def test_config_allowed_idps_domain_required(caplog):
         CILogonOAuthenticator(config=c)
 
 
-async def test_config_allowed_idps_prefix_required(caplog):
+async def test_config_idps_prefix_required(caplog):
     c = Config()
     c.CILogonOAuthenticator.allowed_idps = {
         'https://github.com/login/oauth/authorize': {

--- a/oauthenticator/tests/test_cilogon.py
+++ b/oauthenticator/tests/test_cilogon.py
@@ -115,7 +115,7 @@ async def test_cilogon(
     print(f"Running test variation id {test_variation_id}")
     c = Config()
     c.CILogonOAuthenticator = Config(class_config)
-    c.CILogonOAuthenticator.allowed_idps = {
+    c.CILogonOAuthenticator.idps = {
         "https://some-idp.com/login/oauth/authorize": {
             "username_derivation": {
                 "username_claim": "name",
@@ -449,7 +449,7 @@ async def test_cilogon_idps(
     c = Config()
     c.CILogonOAuthenticator = Config(class_config)
     test_idp = "https://some-idp.com/login/oauth/authorize"
-    c.CILogonOAuthenticator.allowed_idps = {
+    c.CILogonOAuthenticator.idps = {
         test_idp: idp_config,
     }
     authenticator = CILogonOAuthenticator(config=c)
@@ -533,12 +533,13 @@ async def test_cilogon_idps(
             {
                 "idps": {
                     "https://github.com/login/oauth/authorize": {
-                        "username_derivation": {"username_claim": "email"}
+                        'allowed_domains': [],
+                        "username_derivation": {"username_claim": "email"},
                     }
                 }
             },
             logging.WARNING,
-            "CILogonOAuthenticator.allowed_idps is deprecated in CILogonOAuthenticator 16.1.0, use CILogonOAuthenticator.idps instead",
+            "CILogonOAuthenticator.allowed_idps is deprecated in CILogonOAuthenticator 17.4.0, use CILogonOAuthenticator.idps instead",
         ),
     ],
 )
@@ -579,16 +580,16 @@ async def test_config_idps_wrong_type(caplog):
     Test alllowed_idps is a dict
     """
     c = Config()
-    c.CILogonOAuthenticator.allowed_idps = ['pink']
+    c.CILogonOAuthenticator.idps = ['pink']
 
     with raises(TraitError):
         CILogonOAuthenticator(config=c)
 
 
 async def test_config_idps_required_username_derivation(caplog):
-    # Test username_derivation is a required field of allowed_idps
+    # Test username_derivation is a required field of idps
     c = Config()
-    c.CILogonOAuthenticator.allowed_idps = {
+    c.CILogonOAuthenticator.idps = {
         'https://github.com/login/oauth/authorize': {},
     }
 
@@ -598,11 +599,11 @@ async def test_config_idps_required_username_derivation(caplog):
 
 async def test_config_idps_invalid_entity_id(caplog):
     """
-    Test allowed_idps keys cannot be domains, but only valid CILogon entity ids,
+    Test idps keys cannot be domains, but only valid CILogon entity ids,
     i.e. only fully formed URLs
     """
     c = Config()
-    c.CILogonOAuthenticator.allowed_idps = {
+    c.CILogonOAuthenticator.idps = {
         'uni.edu': {
             'username_derivation': {
                 'username_claim': 'email',
@@ -627,7 +628,7 @@ async def test_config_idps_invalid_entity_id(caplog):
 
 async def test_config_idps_invalid_type(caplog):
     c = Config()
-    c.CILogonOAuthenticator.allowed_idps = {
+    c.CILogonOAuthenticator.idps = {
         'https://github.com/login/oauth/authorize': 'should-be-a-dict'
     }
     with raises(ValidationError, match="'should-be-a-dict' is not of type 'object'"):
@@ -636,7 +637,7 @@ async def test_config_idps_invalid_type(caplog):
 
 async def test_config_idps_unrecognized_options(caplog):
     c = Config()
-    c.CILogonOAuthenticator.allowed_idps = {
+    c.CILogonOAuthenticator.idps = {
         'https://github.com/login/oauth/authorize': {
             'username_derivation': {'a': 1, 'b': 2}
         }
@@ -647,7 +648,7 @@ async def test_config_idps_unrecognized_options(caplog):
 
 async def test_config_idps_domain_required(caplog):
     c = Config()
-    c.CILogonOAuthenticator.allowed_idps = {
+    c.CILogonOAuthenticator.idps = {
         'https://github.com/login/oauth/authorize': {
             'username_derivation': {
                 'username_claim': 'email',
@@ -661,7 +662,7 @@ async def test_config_idps_domain_required(caplog):
 
 async def test_config_idps_prefix_required(caplog):
     c = Config()
-    c.CILogonOAuthenticator.allowed_idps = {
+    c.CILogonOAuthenticator.idps = {
         'https://github.com/login/oauth/authorize': {
             'username_derivation': {
                 'username_claim': 'email',
@@ -678,7 +679,7 @@ async def test_config_scopes_validation():
     Test that required scopes are appended if not configured.
     """
     c = Config()
-    c.CILogonOAuthenticator.allowed_idps = {
+    c.CILogonOAuthenticator.idps = {
         'https://some-idp.com/login/oauth/authorize': {
             'username_derivation': {
                 'username_claim': 'email',
@@ -694,14 +695,14 @@ async def test_config_scopes_validation():
     assert authenticator.scope == expected_scopes
 
 
-async def test_allowed_idps_username_derivation_actions(cilogon_client):
+async def test_idps_username_derivation_actions(cilogon_client):
     """
-    Tests all `allowed_idps[].username_derivation.action` config choices:
+    Tests all `idps[].username_derivation.action` config choices:
     `strip_idp_domain`, `prefix`, and no action specified.
     """
     c = Config()
     c.CILogonOAuthenticator.allow_all = True
-    c.CILogonOAuthenticator.allowed_idps = {
+    c.CILogonOAuthenticator.idps = {
         'https://strip-idp-domain.example.com/login/oauth/authorize': {
             'default': True,
             'username_derivation': {
@@ -773,7 +774,7 @@ async def test_allowed_idps_username_derivation_actions(cilogon_client):
 
 
 @mark.parametrize(
-    "test_variation_id,allowed_idps,expected_return_value",
+    "test_variation_id,idps,expected_return_value",
     [
         (
             "default-specified",
@@ -807,7 +808,5 @@ async def test_allowed_idps_username_derivation_actions(cilogon_client):
         ),
     ],
 )
-async def test__get_selected_idp_param(
-    test_variation_id, allowed_idps, expected_return_value
-):
-    assert _get_select_idp_param(allowed_idps) == expected_return_value
+async def test__get_selected_idp_param(test_variation_id, idps, expected_return_value):
+    assert _get_select_idp_param(idps) == expected_return_value


### PR DESCRIPTION
- Fixes #683

Note that the tests passes for the first commit that runs tests against the old name, but also for the last commit that runs tests against the new name. Like this, I feel quite confident we haven't messed up our deprecation logic, and that makes me confident enough to suggest this name change.

![image](https://github.com/user-attachments/assets/2200bbc9-6a25-4120-b9e9-97989c657421)