### PR TITLE
Correcting Bearer Authorization header in OAuth2

### DIFF
--- a/oauthenticator/oauth2.py
+++ b/oauthenticator/oauth2.py
@@ -716,10 +716,17 @@ class OAuthenticator(Authenticator):
         Builds and returns the headers to be used in the userdata request.
         Called by the :meth:`oauthenticator.OAuthenticator.token_to_user`
         """
+
+        # token_type is case-sensitive, but the headers are
+        if token_type.lower() == "bearer":
+            auth_token_type = "Bearer"
+        else:
+            auth_token_type = token_type
+
         return {
             "Accept": "application/json",
             "User-Agent": "JupyterHub",
-            "Authorization": f"{token_type} {access_token}",
+            "Authorization": f"{auth_token_type} {access_token}",
         }
 
     def build_token_info_request_headers(self):

--- a/oauthenticator/oauth2.py
+++ b/oauthenticator/oauth2.py
@@ -717,7 +717,7 @@ class OAuthenticator(Authenticator):
         Called by the :meth:`oauthenticator.OAuthenticator.token_to_user`
         """
 
-        # token_type is case-sensitive, but the headers are
+        # token_type is case-insensitive, but the headers are case-sensitive
         if token_type.lower() == "bearer":
             auth_token_type = "Bearer"
         else:


### PR DESCRIPTION
Currently the value for the "Authorization" header is taken from the case-insensitive "token_type" field (RFC 6750) sent by the OAuth IDP. This PR corrects for this and matches the RFC 6749 requirement of having title-cased "Bearer".

References: https://github.com/jupyterhub/oauthenticator/issues/677 and https://github.com/jupyterhub/oauthenticator/issues/676