### PR TITLE
[CILogon] Add idp config `allowed_domains_claim` for use with `allowed_domains`

### DIFF
--- a/oauthenticator/cilogon.py
+++ b/oauthenticator/cilogon.py
@@ -236,6 +236,11 @@ class CILogonOAuthenticator(OAuthenticator):
                     "See https://cilogon.org/idplist for the list of EntityIDs of each IDP."
                 )
 
+            # Make allowed_domains lowercase
+            idp_config["allowed_domains"] = [
+                ad.lower() for ad in idp_config.get("allowed_domains", [])
+            ]
+
         return idps
 
     skin = Unicode(

--- a/oauthenticator/schemas/cilogon-schema.yaml
+++ b/oauthenticator/schemas/cilogon-schema.yaml
@@ -13,6 +13,8 @@ properties:
     type: array
     items:
       type: string
+  allowed_domains_claim:
+    type: string
   username_derivation:
     type: object
     additionalProperties: false

--- a/oauthenticator/tests/test_cilogon.py
+++ b/oauthenticator/tests/test_cilogon.py
@@ -151,7 +151,7 @@ async def test_cilogon(
                 "username_derivation": {
                     "username_claim": "email",
                 },
-                "allowed_domains": ["allowed-domain.org"],
+                "allowed_domains": ["ALLOWED-domain.org"],
             },
             {},
             "user1@allowed-domain.org",
@@ -238,6 +238,20 @@ async def test_cilogon(
                     "username_claim": "email",
                 },
                 "allowed_domains": ["allowed-domain.org", "*.allowed-domain.org"],
+            },
+            {},
+            "user1@sub.allowed-domain.org",
+            True,
+            None,
+        ),
+        (
+            "B - allowed by allowed_domains and allowed_domains_claim",
+            {
+                "username_derivation": {
+                    "username_claim": "email",
+                },
+                "allowed_domains": ["allowed-domain.org", "*.allowed-domain.org"],
+                "allowed_domains_claim": "email",
             },
             {},
             "user1@sub.allowed-domain.org",


### PR DESCRIPTION
An opt-in non-breaking step along the way to address #547. The issue is perhaps best solved long term by doing the breaking change of letting `allowed_domains_claim` default to `"email"`.

### Change summary

- (unrelated bugfix) Makes `allowed_domains` no longer be case sensitive, and adds test case
- Adds `allowed_domains_claim` config (docs updated, schema updated, a test is added)
- Makes the specified claim able to directly specify a domain name, and not only indirectly via an email like string.