### PR TITLE
[CILogon] Fix missing schema entry for default under allowed_idps

### DIFF
--- a/oauthenticator/schemas/cilogon-schema.yaml
+++ b/oauthenticator/schemas/cilogon-schema.yaml
@@ -15,6 +15,8 @@ properties:
       type: string
   allowed_domains_claim:
     type: string
+  default:
+    type: boolean
   username_derivation:
     type: object
     additionalProperties: false

--- a/oauthenticator/tests/test_cilogon.py
+++ b/oauthenticator/tests/test_cilogon.py
@@ -636,6 +636,7 @@ async def test_allowed_idps_username_derivation_actions(cilogon_client):
     c.CILogonOAuthenticator.allow_all = True
     c.CILogonOAuthenticator.allowed_idps = {
         'https://strip-idp-domain.example.com/login/oauth/authorize': {
+            'default': True,
             'username_derivation': {
                 'username_claim': 'email',
                 'action': 'strip_idp_domain',


### PR DESCRIPTION
- Bugfix following #699. I forgot to add a schema entry so configuring this now fails.