### PR TITLE
clarify what claim_groups_key is used for

### DIFF
--- a/oauthenticator/generic.py
+++ b/oauthenticator/generic.py
@@ -25,6 +25,10 @@ class GenericOAuthenticator(OAuthenticator):
 
         Can be a string key name (use periods for nested keys), or a callable
         that accepts the returned json (as a dict) and returns the groups list.
+
+        This configures how group membership in the upstream provider is determined
+        for use by `allowed_groups`, `admin_groups`, etc.
+        It has no effect on its own, and is not related to users' _JupyterHub_ group membership.
         """,
     )
 


### PR DESCRIPTION
and explicitly state that it's not related to JupyterHub groups, so it's clear and consistent with all other OAuthenticators.

This should alleviate some of the confusion in #706, but doesn't address the feature request of implementing `Authenticator.manage_groups` support, which is more general and should probably be implemented across OAuthenticator.