### PR TITLE
Make `username_claim` callable in all Authenticators except CILogon, like it has been in Generic

### DIFF
--- a/oauthenticator/generic.py
+++ b/oauthenticator/generic.py
@@ -60,20 +60,6 @@ class GenericOAuthenticator(OAuthenticator):
         """,
     )
 
-    username_claim = Union(
-        [Unicode(os.environ.get('OAUTH2_USERNAME_KEY', 'username')), Callable()],
-        config=True,
-        help="""
-        When `userdata_url` returns a json response, the username will be taken
-        from this key.
-
-        Can be a string key name or a callable that accepts the returned
-        userdata json (as a dict) and returns the username.  The callable is
-        useful e.g. for extracting the username from a nested object in the
-        response.
-        """,
-    )
-
     @default("http_client")
     def _default_http_client(self):
         return AsyncHTTPClient(

--- a/oauthenticator/generic.py
+++ b/oauthenticator/generic.py
@@ -113,17 +113,6 @@ class GenericOAuthenticator(OAuthenticator):
         """,
     )
 
-    def user_info_to_username(self, user_info):
-        """
-        Overrides OAuthenticator.user_info_to_username to support the
-        GenericOAuthenticator unique feature of allowing username_claim to be a
-        callable function.
-        """
-        if callable(self.username_claim):
-            return self.username_claim(user_info)
-        else:
-            return super().user_info_to_username(user_info)
-
     def get_user_groups(self, user_info):
         """
         Returns a set of groups the user belongs to based on claim_groups_key

--- a/oauthenticator/oauth2.py
+++ b/oauthenticator/oauth2.py
@@ -18,7 +18,7 @@ from tornado.auth import OAuth2Mixin
 from tornado.httpclient import AsyncHTTPClient, HTTPClientError, HTTPRequest
 from tornado.httputil import url_concat
 from tornado.log import app_log
-from traitlets import Any, Bool, Dict, List, Unicode, default
+from traitlets import Any, Bool, Dict, List, Unicode, default, Union, Callable
 
 
 def guess_callback_uri(protocol, host, hub_server_url):
@@ -376,14 +376,17 @@ class OAuthenticator(Authenticator):
     def _userdata_url_default(self):
         return os.environ.get("OAUTH2_USERDATA_URL", "")
 
-    username_claim = Unicode(
-        "username",
+    username_claim = Union(
+        [Unicode(os.environ.get('OAUTH2_USERNAME_KEY', 'username')), Callable()],
         config=True,
         help="""
-        The key to get the JupyterHub username from in the data response to the
-        request made to :attr:`userdata_url`.
+        When `userdata_url` returns a json response, the username will be taken
+        from this key.
 
-        Examples include: email, username, nickname
+        Can be a string key name or a callable that accepts the returned
+        userdata json (as a dict) and returns the username.  The callable is
+        useful e.g. for extracting the username from a nested object in the
+        response or doing other post processing.
 
         What keys are available will depend on the scopes requested and the
         authenticator used.
@@ -768,7 +771,12 @@ class OAuthenticator(Authenticator):
 
         Called by the :meth:`oauthenticator.OAuthenticator.authenticate`
         """
-        username = user_info.get(self.username_claim, None)
+
+
+        if callable(self.username_claim):
+            username = self.username_claim(user_info)
+        else:
+            username = user_info.get(self.username_claim, None)
         if not username:
             message = (f"No {self.username_claim} found in {user_info}",)
             self.log.error(message)

--- a/oauthenticator/oauth2.py
+++ b/oauthenticator/oauth2.py
@@ -18,7 +18,7 @@ from tornado.auth import OAuth2Mixin
 from tornado.httpclient import AsyncHTTPClient, HTTPClientError, HTTPRequest
 from tornado.httputil import url_concat
 from tornado.log import app_log
-from traitlets import Any, Bool, Dict, List, Unicode, default, Union, Callable
+from traitlets import Any, Bool, Callable, Dict, List, Unicode, Union, default
 
 
 def guess_callback_uri(protocol, host, hub_server_url):
@@ -771,7 +771,6 @@ class OAuthenticator(Authenticator):
 
         Called by the :meth:`oauthenticator.OAuthenticator.authenticate`
         """
-
 
         if callable(self.username_claim):
             username = self.username_claim(user_info)

--- a/oauthenticator/tests/test_generic.py
+++ b/oauthenticator/tests/test_generic.py
@@ -187,12 +187,14 @@ async def test_generic(
     else:
         assert auth_model == None
 
+
 async def test_username_claim_callable(
     get_authenticator,
     generic_client,
 ):
     c = Config()
     c.GenericOAuthenticator = Config()
+
     def username_claim(user_info):
         username = user_info["sub"]
         if username.startswith("oauth2|cilogon"):
@@ -200,6 +202,7 @@ async def test_username_claim_callable(
             cilogon_sub_parts = cilogon_sub.split("/")
             username = f"oauth2|cilogon|{cilogon_sub_parts[3]}|{cilogon_sub_parts[5]}"
         return username
+
     c.GenericOAuthenticator.username_claim = username_claim
     c.GenericOAuthenticator.allow_all = True
     authenticator = get_authenticator(config=c)


### PR DESCRIPTION
While trying to use Auth0 for authentication in one of our hubs, we discovered that the most useful username_claim (`sub`) produces usernames that look like
`oauth2|cilogon|http://cilogon.org/servera/users/43431` (when using auth0 with CILogon). The last part of `sub` is generally whatever is passed on to auth0, so it's going to be different for different users.

I had thought `username_claim` was a callable, but turns out that's only true for GenericOAuthenticator. I think it's pretty useful for every authenticator, so I've just moved that functionality out to the base class instead. I also added a test to verify it works. The test is in GenericOAuthenticator because it was the easiest place to put it, but it works across authenticators. This also means it is fully backwards compatible.