### PR TITLE
Add `allowed_scopes` to all authenticators to allow some users based on granted scopes

### DIFF
--- a/oauthenticator/oauth2.py
+++ b/oauthenticator/oauth2.py
@@ -1048,6 +1048,7 @@ class OAuthenticator(Authenticator):
             granted_scopes = auth_model.get('auth_state', {}).get('scope', [])
             missing_scopes = set(self.required_scopes) - set(granted_scopes)
             if missing_scopes:
+                self.log.info(f"Denying access to user {username} - scopes {missing_scopes} were not granted")
                 return False
             else:
                 return True

--- a/oauthenticator/oauth2.py
+++ b/oauthenticator/oauth2.py
@@ -482,7 +482,9 @@ class OAuthenticator(Authenticator):
     def _required_scopes_validation(self, proposal):
         # required scopes must be a subset of requested scopes
         if set(proposal.value) - set(self.scope):
-            raise ValueError(f"Required Scopes must be a subset of Requested Scopes. {self.scope} is requested but {proposal.value} is required")
+            raise ValueError(
+                f"Required Scopes must be a subset of Requested Scopes. {self.scope} is requested but {proposal.value} is required"
+            )
         return proposal.value
 
     extra_authorize_params = Dict(

--- a/oauthenticator/oauth2.py
+++ b/oauthenticator/oauth2.py
@@ -268,6 +268,9 @@ class OAuthenticator(Authenticator):
         help="""
         Allow all authenticated users to login.
 
+        Note that if required_scopes is set, users who aren't granted the scopes
+        listed in that will still not be allowed to login.
+
         .. versionadded:: 16.0
         """,
     )

--- a/oauthenticator/oauth2.py
+++ b/oauthenticator/oauth2.py
@@ -1053,7 +1053,7 @@ class OAuthenticator(Authenticator):
             missing_scopes = set(self.required_scopes) - set(granted_scopes)
             if missing_scopes:
                 self.log.info(
-                    f"Denying access to user {username} - scopes {missing_scopes} were not granted"
+                    f"Denying access to user {username}. {self.scope} scopes were requested, {self.required_scopes} are required for authorization, but only {granted_scopes} were granted"
                 )
                 return False
             else:

--- a/oauthenticator/oauth2.py
+++ b/oauthenticator/oauth2.py
@@ -482,7 +482,7 @@ class OAuthenticator(Authenticator):
         # allowed scopes must be a subset of requested scopes
         if set(proposal.value) - set(self.scope):
             raise ValueError(
-                f"Allowed Scopes must be a subset of Requested Scopes. {self.scope} is requested but {proposal.value} is allowed"
+                f"Allowed scopes must be a subset of requested scopes. {self.scope} is requested but {proposal.value} is allowed"
             )
         return proposal.value
 

--- a/oauthenticator/oauth2.py
+++ b/oauthenticator/oauth2.py
@@ -1048,7 +1048,9 @@ class OAuthenticator(Authenticator):
             granted_scopes = auth_model.get('auth_state', {}).get('scope', [])
             missing_scopes = set(self.required_scopes) - set(granted_scopes)
             if missing_scopes:
-                self.log.info(f"Denying access to user {username} - scopes {missing_scopes} were not granted")
+                self.log.info(
+                    f"Denying access to user {username} - scopes {missing_scopes} were not granted"
+                )
                 return False
             else:
                 return True

--- a/oauthenticator/oauth2.py
+++ b/oauthenticator/oauth2.py
@@ -479,7 +479,7 @@ class OAuthenticator(Authenticator):
     )
 
     @validate('required_scopes')
-    def _required_scopes_validation(self, proposal: list[str]):
+    def _required_scopes_validation(self, proposal):
         # required scopes must be a subset of requested scopes
         if set(proposal.value) - set(self.scope):
             raise ValueError(f"Required Scopes must be a subset of Requested Scopes. {self.scope} is requested but {proposal.value} is required")

--- a/oauthenticator/oauth2.py
+++ b/oauthenticator/oauth2.py
@@ -470,6 +470,10 @@ class OAuthenticator(Authenticator):
         for a particular scope. If the scopes listed in this config are not granted,
         the user will not be allowed to log in.
 
+        The granted scopes will be part of the access token (fetched from self.token_url).
+        See https://datatracker.ietf.org/doc/html/rfc6749#section-3.3 for more
+        information.
+
         See the OAuth documentation of your OAuth provider for various options.
         """,
     )

--- a/oauthenticator/tests/mocks.py
+++ b/oauthenticator/tests/mocks.py
@@ -104,7 +104,7 @@ def setup_oauth_mock(
     user_path=None,
     token_type='Bearer',
     token_request_style='post',
-    scope=""
+    scope="",
 ):
     """setup the mock client for OAuth
 

--- a/oauthenticator/tests/mocks.py
+++ b/oauthenticator/tests/mocks.py
@@ -104,6 +104,7 @@ def setup_oauth_mock(
     user_path=None,
     token_type='Bearer',
     token_request_style='post',
+    scope=""
 ):
     """setup the mock client for OAuth
 
@@ -125,6 +126,7 @@ def setup_oauth_mock(
         access_token_path (str): The path for the access token request (e.g. /access_token)
         user_path (str): The path for requesting  (e.g. /user)
         token_type (str): the token_type field for the provider
+        scope (str): The scope field returned by the provider
     """
 
     if user_path is None and token_request_style != "jwt":
@@ -164,6 +166,8 @@ def setup_oauth_mock(
             'access_token': token,
             'token_type': token_type,
         }
+        if scope:
+            model['scope'] = scope
         if token_request_style == 'jwt':
             model['id_token'] = user['id_token']
         return model
@@ -175,6 +179,7 @@ def setup_oauth_mock(
             token = auth_header.split(None, 1)[1]
         else:
             query = parse_qs(urlparse(request.url).query)
+
             if 'access_token' in query:
                 token = query['access_token'][0]
             else:

--- a/oauthenticator/tests/test_generic.py
+++ b/oauthenticator/tests/test_generic.py
@@ -233,16 +233,6 @@ async def test_required_scopes_validation_scope_subset(
     with raises(ValueError, match=re.escape("Required Scopes must be a subset of Requested Scopes. ['a'] is requested but ['a', 'b'] is required")):
         get_authenticator(config=c)
 
-async def test_required_scopes_validation_no_allow_all(
-    get_authenticator
-):
-    c = Config()
-    # Test that we can't have allow all and required_scopes together
-    c.GenericOAuthenticator.required_scopes = ["a"]
-    c.GenericOAuthenticator.scope = ["a", "b"]
-    c.GenericOAuthenticator.allow_all = True
-    with raises(ValueError, match=re.escape("Required Scopes is mutually exclusive with allow_all. Unset one of those configuration properties")):
-        get_authenticator(config=c)
 
 async def test_generic_callable_username_key(get_authenticator, generic_client):
     c = Config()

--- a/oauthenticator/tests/test_generic.py
+++ b/oauthenticator/tests/test_generic.py
@@ -1,9 +1,9 @@
 import json
 import re
 from functools import partial
-from tornado import web
 
 from pytest import fixture, mark, raises
+from tornado import web
 from traitlets.config import Config
 
 from ..generic import GenericOAuthenticator
@@ -223,14 +223,18 @@ async def test_required_scopes(
         with raises(web.HTTPError):
             await authenticator.check_allowed(auth_model["name"], auth_model)
 
-async def test_required_scopes_validation_scope_subset(
-    get_authenticator
-):
+
+async def test_required_scopes_validation_scope_subset(get_authenticator):
     c = Config()
     # Test that if we require more scopes than we request, validation fails
     c.GenericOAuthenticator.required_scopes = ["a", "b"]
     c.GenericOAuthenticator.scope = ["a"]
-    with raises(ValueError, match=re.escape("Required Scopes must be a subset of Requested Scopes. ['a'] is requested but ['a', 'b'] is required")):
+    with raises(
+        ValueError,
+        match=re.escape(
+            "Required Scopes must be a subset of Requested Scopes. ['a'] is requested but ['a', 'b'] is required"
+        ),
+    ):
         get_authenticator(config=c)
 
 

--- a/oauthenticator/tests/test_generic.py
+++ b/oauthenticator/tests/test_generic.py
@@ -212,6 +212,7 @@ async def test_required_scopes(
     c = Config()
     c.GenericOAuthenticator.required_scopes = requested_scopes
     c.GenericOAuthenticator.scope = list(requested_scopes)
+    c.GenericOAuthenticator.allow_all = True
     authenticator = get_authenticator(config=c)
 
     handled_user_model = user_model("user1")

--- a/oauthenticator/tests/test_generic.py
+++ b/oauthenticator/tests/test_generic.py
@@ -219,15 +219,15 @@ async def test_allowed_scopes(
     assert allowed == await authenticator.check_allowed(auth_model["name"], auth_model)
 
 
-async def test_required_scopes_validation_scope_subset(get_authenticator):
+async def test_allowed_scopes_validation_scope_subset(get_authenticator):
     c = Config()
     # Test that if we require more scopes than we request, validation fails
-    c.GenericOAuthenticator.required_scopes = ["a", "b"]
+    c.GenericOAuthenticator.allowed_scopes = ["a", "b"]
     c.GenericOAuthenticator.scope = ["a"]
     with raises(
         ValueError,
         match=re.escape(
-            "Required Scopes must be a subset of Requested Scopes. ['a'] is requested but ['a', 'b'] is required"
+            "Allowed scopes must be a subset of requested scopes. ['a'] is requested but ['a', 'b'] is allowed"
         ),
     ):
         get_authenticator(config=c)

--- a/oauthenticator/tests/test_generic.py
+++ b/oauthenticator/tests/test_generic.py
@@ -25,7 +25,7 @@ def generic_client(client):
         host='generic.horse',
         access_token_path='/oauth/access_token',
         user_path='/oauth/userinfo',
-        scope='basic'
+        scope='basic',
     )
     return client
 
@@ -202,13 +202,11 @@ async def test_generic_data(get_authenticator, generic_client):
 
 
 @mark.parametrize(
-        ["requested_scopes", "allowed"],
-        [
-            (["advanced"], False),
-            (["basic"], True)
-        ]
+    ["requested_scopes", "allowed"], [(["advanced"], False), (["basic"], True)]
 )
-async def test_required_scopes(get_authenticator, generic_client, requested_scopes, allowed):
+async def test_required_scopes(
+    get_authenticator, generic_client, requested_scopes, allowed
+):
     c = Config()
     c.GenericOAuthenticator.required_scopes = requested_scopes
     c.GenericOAuthenticator.scope = list(requested_scopes)

--- a/oauthenticator/tests/test_generic.py
+++ b/oauthenticator/tests/test_generic.py
@@ -3,7 +3,6 @@ import re
 from functools import partial
 
 from pytest import fixture, mark, raises
-from tornado import web
 from traitlets.config import Config
 
 from ..generic import GenericOAuthenticator

--- a/oauthenticator/tests/test_generic.py
+++ b/oauthenticator/tests/test_generic.py
@@ -204,25 +204,20 @@ async def test_generic_data(get_authenticator, generic_client):
 
 
 @mark.parametrize(
-    ["requested_scopes", "allowed"], [(["advanced"], False), (["basic"], True)]
+    ["allowed_scopes", "allowed"], [(["advanced"], False), (["basic"], True)]
 )
-async def test_required_scopes(
-    get_authenticator, generic_client, requested_scopes, allowed
+async def test_allowed_scopes(
+    get_authenticator, generic_client, allowed_scopes, allowed
 ):
     c = Config()
-    c.GenericOAuthenticator.required_scopes = requested_scopes
-    c.GenericOAuthenticator.scope = list(requested_scopes)
-    c.GenericOAuthenticator.allow_all = True
+    c.GenericOAuthenticator.allowed_scopes = allowed_scopes
+    c.GenericOAuthenticator.scope = list(allowed_scopes)
     authenticator = get_authenticator(config=c)
 
     handled_user_model = user_model("user1")
     handler = generic_client.handler_for_user(handled_user_model)
     auth_model = await authenticator.authenticate(handler)
-    if allowed:
-        assert await authenticator.check_allowed(auth_model["name"], auth_model)
-    else:
-        with raises(web.HTTPError):
-            await authenticator.check_allowed(auth_model["name"], auth_model)
+    assert allowed == await authenticator.check_allowed(auth_model["name"], auth_model)
 
 
 async def test_required_scopes_validation_scope_subset(get_authenticator):


### PR DESCRIPTION
We can already control what scopes we ask for by setting 'scope'. However, OAuth2
[states](https://datatracker.ietf.org/doc/html/rfc6749#section-3.3) that not all the scopes requested may be granted, for whatever reason. This could be because the user choose not to give us the grant, or because the user themselves doesn't have access to grant us this scope (This is how Auth0 uses it for example -
https://auth0.com/docs/get-started/authentication-and-authorization-flow/authorization-code-flow/call-your-api-using-the-authorization-code-flow).

This PR adds an `allowed_scopes` property, which allows granting access to a subset of users based on the presence of a particular scope in the list of scopes granted. This can be used in addition to other authorization mechanisms to allow access to the hub.