### PR TITLE
Require jupyterhub>=2.2

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -56,8 +56,8 @@ jobs:
 
       - name: Downgrade to oldest dependencies
         if: matrix.oldest_dependencies != ''
-        # take any dependencies in requirements.txt such as jupyterhub>=1.2 and
-        # transform them to jupyterhub==1.2 so we can run tests with the
+        # take any dependencies in requirements.txt such as jupyterhub>=2.2 and
+        # transform them to jupyterhub==2.2 so we can run tests with the
         # earliest-supported versions
         run: |
           cat requirements.txt | grep '>=' | sed -e 's@>=@==@g' > oldest-requirements.txt

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 # jsonschema is used for validating authenticator configurations
 jsonschema
-jupyterhub>=1.2
+jupyterhub>=2.2
 # requests is already required by JupyterHub, but explicitly ask for it since we use it
 requests
 # ruamel.yaml is used to read and write .yaml files.


### PR DESCRIPTION
This means we can add support for `manage_groups` without checking the JupyterHub version.

See https://github.com/jupyterhub/oauthenticator/pull/708/ which adds support for `manage_groups`, but requires conditionals in OAuthenticator and the tests.