### PR TITLE
Suggest possible config fix when correct scopes aren't requested

### DIFF
--- a/oauthenticator/oauth2.py
+++ b/oauthenticator/oauth2.py
@@ -770,7 +770,7 @@ class OAuthenticator(Authenticator):
         """
         username = user_info.get(self.username_claim, None)
         if not username:
-            message = (f"No {self.username_claim} found in {user_info}",)
+            message = (f"No {self.username_claim} found in {user_info}. Maybe the hub needs to be configured to request more scopes?",)
             self.log.error(message)
             raise ValueError(message)
 

--- a/oauthenticator/oauth2.py
+++ b/oauthenticator/oauth2.py
@@ -770,7 +770,9 @@ class OAuthenticator(Authenticator):
         """
         username = user_info.get(self.username_claim, None)
         if not username:
-            message = (f"No {self.username_claim} found in {user_info}. Maybe the hub needs to be configured to request more scopes?",)
+            message = (
+                f"No {self.username_claim} found in {user_info}. Maybe the hub needs to be configured to request more scopes?",
+            )
             self.log.error(message)
             raise ValueError(message)
 


### PR DESCRIPTION
If the hub config doesn't contain appropriate scopes to request from the provider, the token we retrieve may not have the key we are using as `username_claim`. This is the *most common* reason that `username_claim` is not present in the token. Add a simple debugging hint here to make lives of hub admins easier.