### PR TITLE
[Auth0] Allow redirecting to custom URL after logout

### DIFF
--- a/oauthenticator/auth0.py
+++ b/oauthenticator/auth0.py
@@ -50,7 +50,7 @@ class Auth0OAuthenticator(OAuthenticator):
         Must be explicitly added to the "Allowed Logout URLs" in the configuration
         for this Auth0 application. See https://auth0.com/docs/authenticate/login/logout/redirect-users-after-logout
         for more information.
-        """
+        """,
     )
 
     auth0_subdomain = Unicode(
@@ -73,7 +73,9 @@ class Auth0OAuthenticator(OAuthenticator):
         if self.logout_redirect_to_url:
             # If a redirectTo is set, we must also include the `client_id`
             # Auth0 expects `client_id` to be snake cased while `redirectTo` is camel cased
-            params = urlencode({"client_id": self.client_id, "redirectTo": self.logout_redirect_to_url})
+            params = urlencode(
+                {"client_id": self.client_id, "redirectTo": self.logout_redirect_to_url}
+            )
             url = f"{url}?{params}"
         return url
 

--- a/oauthenticator/tests/test_auth0.py
+++ b/oauthenticator/tests/test_auth0.py
@@ -96,10 +96,16 @@ async def test_auth0(
         assert auth_model == None
 
 
-@mark.parametrize(("logout_redirect_to_url", "redirect_url"), [
-    ("", f"https://{AUTH0_DOMAIN}/v2/logout"),
-    ("https://hub-url.com", f"https://{AUTH0_DOMAIN}/v2/logout?client_id=&redirectTo=https%3A%2F%2Fhub-url.com")
-])
+@mark.parametrize(
+    ("logout_redirect_to_url", "redirect_url"),
+    [
+        ("", f"https://{AUTH0_DOMAIN}/v2/logout"),
+        (
+            "https://hub-url.com",
+            f"https://{AUTH0_DOMAIN}/v2/logout?client_id=&redirectTo=https%3A%2F%2Fhub-url.com",
+        ),
+    ],
+)
 async def test_custom_logout(monkeypatch, logout_redirect_to_url, redirect_url):
     authenticator = Auth0OAuthenticator()
     authenticator.logout_redirect_to_url = logout_redirect_to_url


### PR DESCRIPTION
This can't be just done by setting logout_redirect_url unfortunately, as client_id is also required to be passed in here (see https://auth0.com/docs/authenticate/login/logout/redirect-users-after-logout).

While that could be done via a callable, this is much cleaner to do.