### PR TITLE
Add userdata_from_id_token as alternative to userdata_url

### DIFF
--- a/oauthenticator/oauth2.py
+++ b/oauthenticator/oauth2.py
@@ -5,11 +5,11 @@ Founded based on work by Kyle Kelley (@rgbkrk)
 """
 import base64
 import json
-import jwt
 import os
 import uuid
 from urllib.parse import quote, urlencode, urlparse, urlunparse
 
+import jwt
 from jupyterhub.auth import Authenticator
 from jupyterhub.crypto import EncryptionUnavailable, InvalidToken, decrypt
 from jupyterhub.handlers import BaseHandler, LogoutHandler
@@ -885,7 +885,7 @@ class OAuthenticator(Authenticator):
             if not id_token:
                 raise web.HTTPError(
                     500,
-                    f"An id token was not returned: {token_info}\nPlease configure authenticator.userdata_url"
+                    f"An id token was not returned: {token_info}\nPlease configure authenticator.userdata_url",
                 )
             try:
                 # Here we parse the id token. Note that per OIDC spec (core v1.0 sect. 3.1.3.7.6) we can skip
@@ -893,11 +893,17 @@ class OAuthenticator(Authenticator):
                 # https). Google suggests all token validation may be skipped assuming the provider is trusted.
                 # https://openid.net/specs/openid-connect-core-1_0.html#IDTokenValidation
                 # https://developers.google.com/identity/openid-connect/openid-connect#obtainuserinfo
-                return jwt.decode(id_token,
-                                  audience=self.client_id,
-                                  options=dict(verify_signature=False, verify_aud=True, verify_exp=True))
+                return jwt.decode(
+                    id_token,
+                    audience=self.client_id,
+                    options=dict(
+                        verify_signature=False, verify_aud=True, verify_exp=True
+                    ),
+                )
             except Exception as err:
-                raise web.HTTPError(500, f"Unable to decode id token: {id_token}\n{err}")
+                raise web.HTTPError(
+                    500, f"Unable to decode id token: {id_token}\n{err}"
+                )
 
         access_token = token_info["access_token"]
         token_type = token_info["token_type"]

--- a/oauthenticator/tests/test_generic.py
+++ b/oauthenticator/tests/test_generic.py
@@ -1,7 +1,7 @@
 import json
-import jwt
 from functools import partial
 
+import jwt
 from pytest import fixture, mark
 from traitlets.config import Config
 
@@ -77,8 +77,12 @@ def get_authenticator_variant(generic_client, userdata_from_id_token):
     http_client can't be configured, only passed as argument to the constructor.
     """
     return partial(
-        _get_authenticator_for_id_token if userdata_from_id_token else _get_authenticator,
-        http_client=generic_client
+        (
+            _get_authenticator_for_id_token
+            if userdata_from_id_token
+            else _get_authenticator
+        ),
+        http_client=generic_client,
     )
 
 

--- a/oauthenticator/tests/test_generic.py
+++ b/oauthenticator/tests/test_generic.py
@@ -8,20 +8,23 @@ from traitlets.config import Config
 from ..generic import GenericOAuthenticator
 from .mocks import setup_oauth_mock
 
+client_id = "jupyterhub-oauth-client"
+
 
 def user_model(username, **kwargs):
     """Return a user model"""
     return {
         "username": username,
+        "aud": client_id,
         "scope": "basic",
         "groups": ["group1"],
         **kwargs,
     }
 
 
-@fixture(params=[True, False])
+@fixture(params=["id_token", "userdata_url"])
 def userdata_from_id_token(request):
-    return request.param
+    return request.param == "id_token"
 
 
 @fixture
@@ -51,6 +54,7 @@ def _get_authenticator(**kwargs):
     return GenericOAuthenticator(
         token_url='https://generic.horse/oauth/access_token',
         userdata_url='https://generic.horse/oauth/userinfo',
+        client_id=client_id,
         **kwargs,
     )
 
@@ -59,6 +63,7 @@ def _get_authenticator_for_id_token(**kwargs):
     return GenericOAuthenticator(
         token_url='https://generic.horse/oauth/access_token',
         userdata_from_id_token=True,
+        client_id=client_id,
         **kwargs,
     )
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,11 +1,11 @@
 # jsonschema is used for validating authenticator configurations
 jsonschema
 jupyterhub>=2.2
+# PyJWT is used for parsing id tokens
+pyjwt
 # requests is already required by JupyterHub, but explicitly ask for it since we use it
 requests
 # ruamel.yaml is used to read and write .yaml files.
 ruamel.yaml
 tornado
 traitlets
-# PyJWT is used for parsing id tokens
-pyjwt

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,8 @@
 jsonschema
 jupyterhub>=2.2
 # PyJWT is used for parsing id tokens
-pyjwt
+# and azuread
+pyjwt>=2
 # requests is already required by JupyterHub, but explicitly ask for it since we use it
 requests
 # ruamel.yaml is used to read and write .yaml files.

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,3 +7,5 @@ requests
 ruamel.yaml
 tornado
 traitlets
+# PyJWT is used for parsing id tokens
+pyjwt

--- a/setup.py
+++ b/setup.py
@@ -88,8 +88,6 @@ with open('requirements.txt') as f:
 
 
 setup_args['extras_require'] = {
-    # azuread is required for use of AzureADOAuthenticator
-    'azuread': ['pyjwt>=2'],
     # googlegroups is required for use of GoogleOAuthenticator configured with
     # either admin_google_groups and/or allowed_google_groups.
     'googlegroups': [
@@ -106,8 +104,6 @@ setup_args['extras_require'] = {
         'pytest-asyncio>=0.17,<0.23',
         'pytest-cov',
         'requests-mock',
-        # dependencies from azuread:
-        'pyjwt>=2',
         # dependencies from googlegroups:
         'google-api-python-client',
         'google-auth-oauthlib',


### PR DESCRIPTION
This PR adds support for extracting claims from the _id token_, instead of by exchanging the _access token_ with the _userinfo endpoint_. Addresses #487.

This is needed because some claims may only be available via the id token and not via the userinfo endpoint, for example, _AWS Cognito_ only provides the group membership claim via the id token (i.e., needed to complete support for #706).

For background, OAuth2 was a standard for obtaining an access token ("authorisation not authentication") and OIDC extended this in two ways: by standardising a userinfo endpoint and by accompanying the access token with an id token. (Note this is only the core of OIDC; _complete_ OIDC support also entails discovery mechanisms, etc.) To date, oauthenticator has always discarded the id token that it receives, and relied on the userinfo endpoint for performing authentication.

This PR requires the feature to be explicitly enabled by the admin, without introducing any additional config attribs. It uses a library which is already used [elsewhere](https://github.com/search?q=org%3Ajupyterhub+pyjwt&type=code) by JupyterHub.