### PR TITLE
add example for deploying with mock-oauth2-server

### DIFF
--- a/examples/mock-provider/README.md
+++ b/examples/mock-provider/README.md
@@ -1,6 +1,6 @@
 # Generic OAuth with mock provider
 
-This example uses [mock-oauth2-server][] to launch a standalone local OAuth2 provider and configures GenericOAuthenticator to use it.
+This example uses [mock-oauth2-server] to launch a standalone local OAuth2 provider and configures GenericOAuthenticator to use it.
 
 mock-auth2-server implements OpenID Connect (OIDC), and can be used to test GenericOAuthenticator configurations for use with OIDC providers without needing to register your application with a real OAuth provider.
 

--- a/examples/mock-provider/README.md
+++ b/examples/mock-provider/README.md
@@ -1,0 +1,21 @@
+# Generic OAuth with mock provider
+
+This example uses [mock-oauth2-server][] to launch a standalone local OAuth2 provider and configures GenericOAuthenticator to use it.
+
+mock-auth2-server implements OpenID Connect (OIDC), and can be used to test GenericOAuthenticator configurations for use with OIDC providers without needing to register your application with a real OAuth provider.
+
+[mock-oauth2-server]: https://github.com/navikt/mock-oauth2-server
+
+To launch the oauth provider in a container:
+
+```
+docker run --rm -it -p 127.0.0.1:8080:8080 ghcr.io/navikt/mock-oauth2-server:2.1.1
+```
+
+Then launch JupyterHub:
+
+```
+jupyterhub
+```
+
+When you login, you will be presented with a form allowing you to specify the username, and (optionally) any additional fields that should be present in the `userinfo` response.

--- a/examples/mock-provider/jupyterhub_config.py
+++ b/examples/mock-provider/jupyterhub_config.py
@@ -1,0 +1,27 @@
+c = get_config()  # noqa
+
+c.JupyterHub.authenticator_class = "generic-oauth"
+
+# assumes oauth provider run with:
+# docker run --rm -it -p 127.0.0.1:8080:8080 ghcr.io/navikt/mock-oauth2-server:2.1.1
+
+provider = "http://127.0.0.1:8080/default"
+c.GenericOAuthenticator.authorize_url = f"{provider}/authorize"
+c.GenericOAuthenticator.token_url = f"{provider}/token"
+c.GenericOAuthenticator.userdata_url = f"{provider}/userinfo"
+c.GenericOAuthenticator.scope = ["openid", "somescope", "otherscope"]
+
+# these are the defaults. They can be configured at http://localhost:8080/default/debugger
+c.GenericOAuthenticator.client_id = "debugger"
+c.GenericOAuthenticator.client_secret = "someSecret"
+
+# 'sub' is the first field in the login form
+c.GenericOAuthenticator.username_claim = "sub"
+
+c.GenericOAuthenticator.allow_all = True
+c.GenericOAuthenticator.admin_users = {"admin"}
+
+# demo boilerplate
+c.JupyterHub.default_url = "/hub/home"
+c.JupyterHub.spawner_class = "simple"
+c.JupyterHub.ip = "127.0.0.1"


### PR DESCRIPTION
I found this quite useful for testing

We may want to integrate it with our actual tests at some point, but the example is enough to be useful.

This lets JupyterHub be deployed with a full 'real' OAuth provider without any external requirements.