### PR TITLE
test: simplify by removing `token_request_style` parameter for mock function

### DIFF
--- a/oauthenticator/tests/mocks.py
+++ b/oauthenticator/tests/mocks.py
@@ -104,7 +104,6 @@ def setup_oauth_mock(
     access_token_path,
     user_path=None,
     token_type='Bearer',
-    token_request_style='post',
 ):
     """setup the mock client for OAuth
 
@@ -127,9 +126,6 @@ def setup_oauth_mock(
         user_path (str): The path for requesting  (e.g. /user)
         token_type (str): the token_type field for the provider
     """
-
-    if user_path is None and token_request_style != "jwt":
-        raise TypeError("user_path is required unless token_request_style is jwt")
 
     client.oauth_codes = oauth_codes = {}
     client.access_tokens = access_tokens = {}
@@ -165,7 +161,7 @@ def setup_oauth_mock(
             'access_token': token,
             'token_type': token_type,
         }
-        if token_request_style == 'jwt':
+        if 'id_token' in user:
             model['id_token'] = user['id_token']
         return model
 

--- a/oauthenticator/tests/test_azuread.py
+++ b/oauthenticator/tests/test_azuread.py
@@ -22,7 +22,6 @@ def azure_client(client):
         client,
         host=['login.microsoftonline.com'],
         access_token_path=re.compile('^/[^/]+/oauth2/token$'),
-        token_request_style='jwt',
     )
     return client
 

--- a/oauthenticator/tests/test_generic.py
+++ b/oauthenticator/tests/test_generic.py
@@ -46,7 +46,6 @@ def generic_client_variant(client, userdata_from_id_token):
         host='generic.horse',
         access_token_path='/oauth/access_token',
         user_path='/oauth/userinfo',
-        token_request_style='jwt' if userdata_from_id_token else 'post',
     )
     return client
 


### PR DESCRIPTION
An idea from @manics in another PR that I took further by removing the entire parameter `token_request_style` from `setup_oauth_mock`.