### PR TITLE
Move group management from generic to base oauthenticator

### DIFF
--- a/oauthenticator/generic.py
+++ b/oauthenticator/generic.py
@@ -32,6 +32,19 @@ class GenericOAuthenticator(OAuthenticator):
         """,
     )
 
+    # Initialize value of auth_model_groups_key based on what is in claim_groups_key
+    @default('auth_model_groups_key')
+    def _auth_model_groups_key_default(self):
+        if callable(self.claim_groups_key):
+            # Automatically wrap the claim_gorups_key call so it gets what it thinks it should get
+            return lambda auth_model: self.claim_groups_key(
+                auth_model["auth_state"][self.user_auth_state_key]
+            )
+        else:
+            return f"auth_state.{self.user_auth_state_key}.{self.claim_groups_key}"
+
+
+    # propagate any changes to claim_groups_key to auth_model_groups_key
     @observe("claim_groups_key")
     def _claim_groups_key_changed(self, change):
         if callable(change.new):

--- a/oauthenticator/generic.py
+++ b/oauthenticator/generic.py
@@ -3,12 +3,11 @@ A JupyterHub authenticator class for use with any OAuth2 based identity provider
 """
 
 import os
-from functools import reduce
 
 from jupyterhub.auth import LocalAuthenticator
 from jupyterhub.traitlets import Callable
 from tornado.httpclient import AsyncHTTPClient
-from traitlets import Bool, Dict, Set, Unicode, Union, default, observe
+from traitlets import Bool, Dict, Unicode, Union, default, observe
 
 from .oauth2 import OAuthenticator
 
@@ -37,9 +36,13 @@ class GenericOAuthenticator(OAuthenticator):
     def _claim_groups_key_changed(self, change):
         if callable(change.new):
             # Automatically wrap the claim_gorups_key call so it gets what it thinks it should get
-            self.auth_model_groups_key = lambda auth_model: self.claim_groups_key(auth_model["auth_state"][self.user_auth_state_key])
+            self.auth_model_groups_key = lambda auth_model: self.claim_groups_key(
+                auth_model["auth_state"][self.user_auth_state_key]
+            )
         else:
-            self.auth_model_groups_key = f"auth_state.{self.user_auth_state_key}.{self.claim_groups_key}"
+            self.auth_model_groups_key = (
+                f"auth_state.{self.user_auth_state_key}.{self.claim_groups_key}"
+            )
 
     @default("http_client")
     def _default_http_client(self):

--- a/oauthenticator/generic.py
+++ b/oauthenticator/generic.py
@@ -44,7 +44,7 @@ class GenericOAuthenticator(OAuthenticator):
         # Emit a deprecation warning directly, without using _deprecated_oauth_aliases,
         # as it is not a direct replacement for this functionality
         self.log.warning(
-            "{cls}.claim_groups_key is deprecated since OAuthenticatort 16.4, use {cls}.auth_state_groups_key instead".format(
+            "{cls}.claim_groups_key is deprecated since OAuthenticator 16.4, use {cls}.auth_state_groups_key instead".format(
                 cls=self.__class__.__name__,
             )
         )

--- a/oauthenticator/generic.py
+++ b/oauthenticator/generic.py
@@ -43,7 +43,6 @@ class GenericOAuthenticator(OAuthenticator):
         else:
             return f"auth_state.{self.user_auth_state_key}.{self.claim_groups_key}"
 
-
     # propagate any changes to claim_groups_key to auth_model_groups_key
     @observe("claim_groups_key")
     def _claim_groups_key_changed(self, change):

--- a/oauthenticator/generic.py
+++ b/oauthenticator/generic.py
@@ -21,12 +21,12 @@ class GenericOAuthenticator(OAuthenticator):
         [Unicode(os.environ.get('OAUTH2_GROUPS_KEY', 'groups')), Callable()],
         config=True,
         help="""
-        .. deprecated:: 16.4
+        .. deprecated:: 17.0
 
         Use :attr:`auth_state_groups_key` instead.
 
 
-        .. versionchanged:: 16.4
+        .. versionchanged:: 17.0
 
         :attr:`manage_groups` is now required to be `True` to use this functionality
         """,
@@ -49,7 +49,7 @@ class GenericOAuthenticator(OAuthenticator):
         # Emit a deprecation warning directly, without using _deprecated_oauth_aliases,
         # as it is not a direct replacement for this functionality
         self.log.warning(
-            "{cls}.claim_groups_key is deprecated since OAuthenticator 16.4, use {cls}.auth_state_groups_key instead".format(
+            "{cls}.claim_groups_key is deprecated since OAuthenticator 17.0, use {cls}.auth_state_groups_key instead".format(
                 cls=self.__class__.__name__,
             )
         )

--- a/oauthenticator/generic.py
+++ b/oauthenticator/generic.py
@@ -44,8 +44,9 @@ class GenericOAuthenticator(OAuthenticator):
         # Emit a deprecation warning directly, without using _deprecated_oauth_aliases,
         # as it is not a direct replacement for this functionality
         self.log.warning(
-            "{cls}.claim_groups_key is deprecated since OAuthenticatort 16.4, use {cls}.auth_state_groups_key instead",
-            cls=self.__class__.__name__,
+            "{cls}.claim_groups_key is deprecated since OAuthenticatort 16.4, use {cls}.auth_state_groups_key instead".format(
+                cls=self.__class__.__name__,
+            )
         )
         if callable(change.new):
             # Automatically wrap the claim_gorups_key call so it gets what it thinks it should get

--- a/oauthenticator/generic.py
+++ b/oauthenticator/generic.py
@@ -32,28 +32,28 @@ class GenericOAuthenticator(OAuthenticator):
         """,
     )
 
-    # Initialize value of auth_model_groups_key based on what is in claim_groups_key
-    @default('auth_model_groups_key')
-    def _auth_model_groups_key_default(self):
+    # Initialize value of auth_state_groups_key based on what is in claim_groups_key
+    @default('auth_state_groups_key')
+    def _auth_state_groups_key_default(self):
         if callable(self.claim_groups_key):
             # Automatically wrap the claim_gorups_key call so it gets what it thinks it should get
-            return lambda auth_model: self.claim_groups_key(
-                auth_model["auth_state"][self.user_auth_state_key]
+            return lambda auth_state: self.claim_groups_key(
+                auth_state[self.user_auth_state_key]
             )
         else:
-            return f"auth_state.{self.user_auth_state_key}.{self.claim_groups_key}"
+            return f"{self.user_auth_state_key}.{self.claim_groups_key}"
 
-    # propagate any changes to claim_groups_key to auth_model_groups_key
+    # propagate any changes to claim_groups_key to auth_state_groups_key
     @observe("claim_groups_key")
     def _claim_groups_key_changed(self, change):
         if callable(change.new):
             # Automatically wrap the claim_gorups_key call so it gets what it thinks it should get
-            self.auth_model_groups_key = lambda auth_model: self.claim_groups_key(
-                auth_model["auth_state"][self.user_auth_state_key]
+            self.auth_state_groups_key = lambda auth_state: self.claim_groups_key(
+                auth_state[self.user_auth_state_key]
             )
         else:
-            self.auth_model_groups_key = (
-                f"auth_state.{self.user_auth_state_key}.{self.claim_groups_key}"
+            self.auth_state_groups_key = (
+                f"{self.user_auth_state_key}.{self.claim_groups_key}"
             )
 
     @default("http_client")

--- a/oauthenticator/generic.py
+++ b/oauthenticator/generic.py
@@ -31,7 +31,7 @@ class GenericOAuthenticator(OAuthenticator):
     @default('auth_state_groups_key')
     def _auth_state_groups_key_default(self):
         if callable(self.claim_groups_key):
-            # Automatically wrap the claim_gorups_key call so it gets what it thinks it should get
+            # Automatically wrap the claim_groups_key call so it gets what it thinks it should get
             return lambda auth_state: self.claim_groups_key(
                 auth_state[self.user_auth_state_key]
             )

--- a/oauthenticator/generic.py
+++ b/oauthenticator/generic.py
@@ -21,14 +21,9 @@ class GenericOAuthenticator(OAuthenticator):
         [Unicode(os.environ.get('OAUTH2_GROUPS_KEY', 'groups')), Callable()],
         config=True,
         help="""
-        Userdata groups claim key from returned json for USERDATA_URL.
+        .. deprecated:: 16.4
 
-        Can be a string key name (use periods for nested keys), or a callable
-        that accepts the returned json (as a dict) and returns the groups list.
-
-        This configures how group membership in the upstream provider is determined
-        for use by `allowed_groups`, `admin_groups`, etc. If `manage_groups` is True,
-        this will also determine users' _JupyterHub_ group membership.
+        Use :attr:`auth_state_groups_key` instead.
         """,
     )
 
@@ -46,6 +41,12 @@ class GenericOAuthenticator(OAuthenticator):
     # propagate any changes to claim_groups_key to auth_state_groups_key
     @observe("claim_groups_key")
     def _claim_groups_key_changed(self, change):
+        # Emit a deprecation warning directly, without using _deprecated_oauth_aliases,
+        # as it is not a direct replacement for this functionality
+        self.log.warning(
+            "{cls}.claim_groups_key is deprecated since OAuthenticatort 16.4, use {cls}.auth_state_groups_key instead",
+            cls=self.__class__.__name__
+        )
         if callable(change.new):
             # Automatically wrap the claim_gorups_key call so it gets what it thinks it should get
             self.auth_state_groups_key = lambda auth_state: self.claim_groups_key(

--- a/oauthenticator/generic.py
+++ b/oauthenticator/generic.py
@@ -45,7 +45,7 @@ class GenericOAuthenticator(OAuthenticator):
         # as it is not a direct replacement for this functionality
         self.log.warning(
             "{cls}.claim_groups_key is deprecated since OAuthenticatort 16.4, use {cls}.auth_state_groups_key instead",
-            cls=self.__class__.__name__
+            cls=self.__class__.__name__,
         )
         if callable(change.new):
             # Automatically wrap the claim_gorups_key call so it gets what it thinks it should get

--- a/oauthenticator/generic.py
+++ b/oauthenticator/generic.py
@@ -24,6 +24,11 @@ class GenericOAuthenticator(OAuthenticator):
         .. deprecated:: 16.4
 
         Use :attr:`auth_state_groups_key` instead.
+
+
+        .. versionchanged:: 16.4
+
+        :attr:`manage_groups` is now required to be `True` to use this functionality
         """,
     )
 
@@ -48,6 +53,13 @@ class GenericOAuthenticator(OAuthenticator):
                 cls=self.__class__.__name__,
             )
         )
+
+        if change.new:
+            if not self.manage_groups:
+                raise ValueError(
+                    f'{change.owner.__class__.__name__}.{change.name} requires {change.owner.__class__.__name__}.manage_groups to also be set'
+                )
+
         if callable(change.new):
             # Automatically wrap the claim_gorups_key call so it gets what it thinks it should get
             self.auth_state_groups_key = lambda auth_state: self.claim_groups_key(

--- a/oauthenticator/oauth2.py
+++ b/oauthenticator/oauth2.py
@@ -1077,8 +1077,7 @@ class OAuthenticator(Authenticator):
         Returns a set of groups the user belongs to based on auth_state_groups_key
         and provided auth_state.
 
-        - If auth_state_groups_key is a callable, it is meant to return the groups
-          directly.
+        - If auth_state_groups_key is a callable, it returns the list of groups directly.
         - If auth_state_groups_key is a nested dictionary key like
           "permissions.groups", this function returns
           auth_state["permissions"]["groups"].

--- a/oauthenticator/oauth2.py
+++ b/oauthenticator/oauth2.py
@@ -1113,7 +1113,6 @@ class OAuthenticator(Authenticator):
         Called by the :meth:`oauthenticator.OAuthenticator.authenticate`
         """
         if self.manage_groups or self.admin_groups:
-            user_info = auth_model["auth_state"][self.user_auth_state_key]
             user_groups = self.get_user_groups(auth_model)
 
         if self.manage_groups:

--- a/oauthenticator/oauth2.py
+++ b/oauthenticator/oauth2.py
@@ -1210,8 +1210,7 @@ class OAuthenticator(Authenticator):
 
         # allow users who are members of allowed_groups
         if self.allowed_groups:
-            user_info = auth_model["auth_state"][self.user_auth_state_key]
-            user_groups = self.get_user_groups(user_info)
+            user_groups = self.get_user_groups(auth_model)
             if any(user_groups & self.allowed_groups):
                 return True
 

--- a/oauthenticator/oauth2.py
+++ b/oauthenticator/oauth2.py
@@ -20,7 +20,7 @@ from tornado.auth import OAuth2Mixin
 from tornado.httpclient import AsyncHTTPClient, HTTPClientError, HTTPRequest
 from tornado.httputil import url_concat
 from tornado.log import app_log
-from traitlets import Any, Bool, Callable, Dict, List, Unicode, Union, default, validate
+from traitlets import Any, Bool, Callable, Dict, List, Unicode, Union, default, Set, validate
 
 
 def guess_callback_uri(protocol, host, hub_server_url):
@@ -315,6 +315,27 @@ class OAuthenticator(Authenticator):
            user.
         """,
     )
+
+    allowed_groups = Set(
+        Unicode(),
+        config=True,
+        help="""
+        Allow members of selected groups to log in.
+        """,
+    )
+
+    admin_groups = Set(
+        Unicode(),
+        config=True,
+        help="""
+        Allow members of selected groups to sign in and consider them as
+        JupyterHub admins.
+
+        If this is set and a user isn't part of one of these groups or listed in
+        `admin_users`, a user signing in will have their admin status revoked.
+        """,
+    )
+
 
     authorize_url = Unicode(
         config=True,
@@ -1040,6 +1061,18 @@ class OAuthenticator(Authenticator):
 
         Called by the :meth:`oauthenticator.OAuthenticator.authenticate`
         """
+        if self.manage_groups or self.admin_groups:
+            user_info = auth_model["auth_state"][self.user_auth_state_key]
+            user_groups = self.get_user_groups(user_info)
+
+        if self.manage_groups:
+            auth_model["groups"] = sorted(user_groups)
+
+        if self.admin_groups:
+            if not auth_model["admin"]:
+                # auth_model["admin"] being True means the user was in admin_users
+                # so their group membership should not affect their admin status
+                auth_model["admin"] = bool(user_groups & self.admin_groups)
         return auth_model
 
     async def authenticate(self, handler, data=None, **kwargs):
@@ -1124,6 +1157,13 @@ class OAuthenticator(Authenticator):
         # automatically with existing users if it was configured truthy
         if username in self.allowed_users:
             return True
+
+        # allow users who are members of allowed_groups
+        if self.allowed_groups:
+            user_info = auth_model["auth_state"][self.user_auth_state_key]
+            user_groups = self.get_user_groups(user_info)
+            if any(user_groups & self.allowed_groups):
+                return True
 
         # users should be explicitly allowed via config, otherwise they aren't
         return False

--- a/oauthenticator/oauth2.py
+++ b/oauthenticator/oauth2.py
@@ -1076,16 +1076,16 @@ class OAuthenticator(Authenticator):
 
     def get_user_groups(self, auth_model: dict):
         """
-        Returns a set of groups the user belongs to based on claim_groups_key
+        Returns a set of groups the user belongs to based on auth_model_groups_key
         and provided auth_model.
 
-        - If claim_groups_key is a callable, it is meant to return the groups
+        - If auth_model_groups_key is a callable, it is meant to return the groups
           directly.
-        - If claim_groups_key is a nested dictionary key like
+        - If auth_model_groups_key is a nested dictionary key like
           "permissions.groups", this function returns
           auth_model["permissions"]["groups"].
         """
-        if callable(self.claim_groups_key):
+        if callable(self.auth_model_groups_key):
             return set(self.auth_model_groups_key(auth_model))
         try:
             return set(

--- a/oauthenticator/oauth2.py
+++ b/oauthenticator/oauth2.py
@@ -31,6 +31,7 @@ from traitlets import (
     Unicode,
     Union,
     default,
+    observe,
     validate,
 )
 
@@ -365,7 +366,7 @@ class OAuthenticator(Authenticator):
         """,
     )
 
-    # @observe calls are set in __init__
+    @observe("allowed_groups", "admin_groups", "auth_state_groups_key")
     def _requires_manage_groups(self, change):
         """
         Validate that group management keys are only set when manage_groups is also True
@@ -1278,10 +1279,6 @@ class OAuthenticator(Authenticator):
                 self._deprecated_oauth_trait, names=list(self._deprecated_oauth_aliases)
             )
 
-        self.observe(
-            self._requires_manage_groups,
-            names=("auth_state_groups_key", "admin_groups", "allowed_groups"),
-        )
         super().__init__(**kwargs)
 
 

--- a/oauthenticator/oauth2.py
+++ b/oauthenticator/oauth2.py
@@ -7,8 +7,8 @@ Founded based on work by Kyle Kelley (@rgbkrk)
 import base64
 import json
 import os
-from functools import reduce
 import uuid
+from functools import reduce
 from urllib.parse import quote, urlencode, urlparse, urlunparse
 
 import jwt
@@ -21,7 +21,18 @@ from tornado.auth import OAuth2Mixin
 from tornado.httpclient import AsyncHTTPClient, HTTPClientError, HTTPRequest
 from tornado.httputil import url_concat
 from tornado.log import app_log
-from traitlets import Any, Bool, Callable, Dict, List, Unicode, Union, default, Set, validate
+from traitlets import (
+    Any,
+    Bool,
+    Callable,
+    Dict,
+    List,
+    Set,
+    Unicode,
+    Union,
+    default,
+    validate,
+)
 
 
 def guess_callback_uri(protocol, host, hub_server_url):
@@ -1077,7 +1088,9 @@ class OAuthenticator(Authenticator):
         if callable(self.claim_groups_key):
             return set(self.auth_model_groups_key(auth_model))
         try:
-            return set(reduce(dict.get, self.auth_model_groups_key.split("."), auth_model))
+            return set(
+                reduce(dict.get, self.auth_model_groups_key.split("."), auth_model)
+            )
         except TypeError:
             self.log.error(
                 f"The auth_model_groups_key {self.auth_model_groups_key} does not exist in the auth_model. Available keys are: {auth_model.keys()}"

--- a/oauthenticator/tests/test_generic.py
+++ b/oauthenticator/tests/test_generic.py
@@ -368,9 +368,13 @@ async def test_generic_claim_groups_key_nested_strings(
     assert auth_model["admin"]
 
 
-async def test_generic_auth_state_groups_key_callable(get_authenticator, generic_client):
+async def test_generic_auth_state_groups_key_callable(
+    get_authenticator, generic_client
+):
     c = Config()
-    c.GenericOAuthenticator.auth_state_groups_key = lambda auth_state: auth_state["oauth_user"]["policies"]["roles"]
+    c.GenericOAuthenticator.auth_state_groups_key = lambda auth_state: auth_state[
+        "oauth_user"
+    ]["policies"]["roles"]
     c.GenericOAuthenticator.allowed_groups = ["super_user"]
     authenticator = get_authenticator(config=c)
 

--- a/oauthenticator/tests/test_generic.py
+++ b/oauthenticator/tests/test_generic.py
@@ -368,6 +368,35 @@ async def test_generic_claim_groups_key_nested_strings(
     assert auth_model["admin"]
 
 
+async def test_generic_auth_model_groups_key_callable(get_authenticator, generic_client):
+    c = Config()
+    c.GenericOAuthenticator.auth_model_groups_key = lambda r: r["auth_state"]["oauth_user"]["policies"]["roles"]
+    c.GenericOAuthenticator.allowed_groups = ["super_user"]
+    authenticator = get_authenticator(config=c)
+
+    handled_user_model = user_model("user1", policies={"roles": ["super_user"]})
+    handler = generic_client.handler_for_user(handled_user_model)
+    auth_model = await authenticator.get_authenticated_user(handler, None)
+
+    assert auth_model
+
+
+async def test_generic_auth_model_groups_key_nested_strings(
+    get_authenticator, generic_client
+):
+    c = Config()
+    c.GenericOAuthenticator.auth_model_groups_key = "auth_state.oauth_user.permissions.groups"
+    c.GenericOAuthenticator.admin_groups = ["super_user"]
+    authenticator = get_authenticator(config=c)
+
+    handled_user_model = user_model("user1", permissions={"groups": ["super_user"]})
+    handler = generic_client.handler_for_user(handled_user_model)
+    auth_model = await authenticator.get_authenticated_user(handler, None)
+
+    assert auth_model
+    assert auth_model["admin"]
+
+
 @mark.parametrize(
     "name, allowed",
     [

--- a/oauthenticator/tests/test_generic.py
+++ b/oauthenticator/tests/test_generic.py
@@ -368,9 +368,9 @@ async def test_generic_claim_groups_key_nested_strings(
     assert auth_model["admin"]
 
 
-async def test_generic_auth_model_groups_key_callable(get_authenticator, generic_client):
+async def test_generic_auth_state_groups_key_callable(get_authenticator, generic_client):
     c = Config()
-    c.GenericOAuthenticator.auth_model_groups_key = lambda r: r["auth_state"]["oauth_user"]["policies"]["roles"]
+    c.GenericOAuthenticator.auth_state_groups_key = lambda auth_state: auth_state["oauth_user"]["policies"]["roles"]
     c.GenericOAuthenticator.allowed_groups = ["super_user"]
     authenticator = get_authenticator(config=c)
 
@@ -381,11 +381,11 @@ async def test_generic_auth_model_groups_key_callable(get_authenticator, generic
     assert auth_model
 
 
-async def test_generic_auth_model_groups_key_nested_strings(
+async def test_generic_auth_state_groups_key_nested_strings(
     get_authenticator, generic_client
 ):
     c = Config()
-    c.GenericOAuthenticator.auth_model_groups_key = "auth_state.oauth_user.permissions.groups"
+    c.GenericOAuthenticator.auth_state_groups_key = "oauth_user.permissions.groups"
     c.GenericOAuthenticator.admin_groups = ["super_user"]
     authenticator = get_authenticator(config=c)
 

--- a/oauthenticator/tests/test_openshift.py
+++ b/oauthenticator/tests/test_openshift.py
@@ -37,10 +37,20 @@ def user_model():
         ("03", {"allowed_users": {"not-test-user"}}, False, None),
         ("04", {"admin_users": {"user1"}}, True, True),
         ("05", {"admin_users": {"not-test-user"}}, False, None),
-        ("06", {"allowed_groups": {"group1"}}, True, None),
-        ("07", {"allowed_groups": {"test-user-not-in-group"}}, False, None),
-        ("08", {"admin_groups": {"group1"}}, True, True),
-        ("09", {"admin_groups": {"test-user-not-in-group"}}, False, False),
+        ("06", {"allowed_groups": {"group1"}, "manage_groups": True}, True, None),
+        (
+            "07",
+            {"allowed_groups": {"test-user-not-in-group"}, "manage_groups": True},
+            False,
+            None,
+        ),
+        ("08", {"admin_groups": {"group1"}, "manage_groups": True}, True, True),
+        (
+            "09",
+            {"admin_groups": {"test-user-not-in-group"}, "manage_groups": True},
+            False,
+            False,
+        ),
         # allow config, some combinations of two tested
         (
             "10",
@@ -65,6 +75,7 @@ def user_model():
             {
                 "allowed_groups": {"group1"},
                 "admin_groups": {"group1"},
+                "manage_groups": True,
             },
             True,
             True,
@@ -74,6 +85,7 @@ def user_model():
             {
                 "allowed_groups": {"group1"},
                 "admin_groups": {"test-user-not-in-group"},
+                "manage_groups": True,
             },
             True,
             False,
@@ -83,6 +95,7 @@ def user_model():
             {
                 "allowed_groups": {"test-user-not-in-group"},
                 "admin_groups": {"group1"},
+                "manage_groups": True,
             },
             True,
             True,
@@ -92,6 +105,7 @@ def user_model():
             {
                 "allowed_groups": {"test-user-not-in-group"},
                 "admin_groups": {"test-user-not-in-group"},
+                "manage_groups": True,
             },
             False,
             False,
@@ -101,6 +115,7 @@ def user_model():
             {
                 "admin_users": {"user1"},
                 "admin_groups": {"group1"},
+                "manage_groups": True,
             },
             True,
             True,
@@ -110,6 +125,7 @@ def user_model():
             {
                 "admin_users": {"user1"},
                 "admin_groups": {"test-user-not-in-group"},
+                "manage_groups": True,
             },
             True,
             True,
@@ -119,6 +135,7 @@ def user_model():
             {
                 "admin_users": {"not-test-user"},
                 "admin_groups": {"group1"},
+                "manage_groups": True,
             },
             True,
             True,
@@ -128,6 +145,7 @@ def user_model():
             {
                 "admin_users": {"not-test-user"},
                 "admin_groups": {"test-user-not-in-group"},
+                "manage_groups": True,
             },
             False,
             False,


### PR DESCRIPTION
## Motivating use cases

External identity providers providing JupyterHub memberships is an extremely useful feature that should be present not just for `GenericOAuthenticator` but for all authenticators. But to do so in helpful ways, this PR considers two motivating use cases:

1. A hub using `Auth0OAuthenticator`. In Auth0, `scope`s granted are what is used to provide the notion of 'can the user perform this task?', which can be used as group membership. This is what auth0 recommends, there is currently no other way to do 'groups' in Auth0. `scope` is inside `auth_model`, but *not* `auth_state`, since `scope` is granted each time the user is logged in.
2. In `GitHubOAuthenticator`, we put the list of teams the user is in inside `auth_state`. This is the perfect piece of information to use for group membership.
3. `oauth_user` gets put inside `auth_state`, and in general `auth_state` is a good place for this kinda group information to be in. Authenticators can put arbitrary stuff inside `auth_state` and use them as they wish.


## Approaches considered and rejected

1. Each authenticator figures out how groups work within it. This was tried out in https://github.com/jupyterhub/oauthenticator/pull/739, and rejected by @minrk in https://github.com/jupyterhub/oauthenticator/pull/735#issuecomment-2041996689. I agree with this rejection.
2. Allow group information to be picked up from the `auth_model` with a `auth_model_groups_key`. This would be same as the current `claim_groups_key`, but pick from the entire `auth_model` instead of just from the returned user object. This was the tack this PR was taking, primarily because I thought we needed it to handle use case 1 mentioned earlier. But turns out I was wrong - I had thought that  `scope` was part of `auth_model` but not `auth_state`, but we do! And regardless, I also realized we don't expose `auth_model` *anywhere*, but we *do* expose `auth_state`. And I had a TODO for 'document what is in `auth_model`', and while trying to do that, decided we shouldn't expose that to configurable tweaks like this *for now*. So that was reverted in b337015306f51a8a9ea8e95924a7562bfa1e56ba and a different approach was taken.

## Approach this PR takes

The general approach to group management is:

1. Authenticator puts something that may be relevant to group membership inside `auth_state`.
2. There's an `auth_state_groups_key` that can be either a callable or dotted specification that generates a list of groups from something in `auth_state`.

This handles case (2) because list of teams is already in `auth_state`. And can handle (1) by us putting `scope` in some form inside `auth_state`. This also provides a clear extensible mechanism in the future for all group management - get it into `auth_state` (where it can be used for anything), and pick that out with `auth_state_groups_key`.

## Backwards compatibility

- The existing `claim_groups_key` behavior is preserved, by being passed on to `auth_state_groups_key` in the base. It has been marked as deprecated. This is not a backwards compatibility break.
- All group related functionality now **requires** `manage_groups` to be `True`, which was not the case earlier. Before this, if `manage_groups` is false but any of the group related authorization functionality (`allowed_groups` and `admin_groups`) is used, they control group related behavior **but don't show up as JupyterHub groups**. This causes confusion, as the 'groups' field in the admin panel will be empty, and possible other group related behavior (such as future profile list filtering, for example) would *not* respect these groups. We basically would end up with *two* group concepts - First class JupyterHub groups (which will show up in admin panel, API, can be *edited* by admins, etc) as well as second class 'Authenticator' groups (which are only used for authorization and 'disappear' after that). I think this is unnecessary complication, and this is a good time to remove this distinction. Now, any kind of group related authorization functionality *requires* `manage_groups` to be `True`, and we are back to having only one notion of 'group'. We also remove the confusing part where you may have `allowed_groups` set to something, manually modify the groups the user is a part of in JupyterHub admin, and it silently has no effect. This is a *breaking change* for people who used groups functionality but set `manage_groups` to be `False`. However, I think that usage is fairly minor, because of the confusing behavior it causes. I have added the 'breaking' label here regardless.
 
## Breaking change

- All group related functionality (`allowed_groups`, `admin_groups`, `claims_group_key` and `auth_state_groups_key`) now also requires `manage_groups` to be set to `True`

## TODO

- [x] Update docs to refer to new property
- [x] Reword the docstring for `auth_state_groups_key`

Fixes https://github.com/jupyterhub/oauthenticator/issues/709