### PR TITLE
Centralize validate_server_cert in one place

### DIFF
--- a/oauthenticator/generic.py
+++ b/oauthenticator/generic.py
@@ -7,7 +7,6 @@ from functools import reduce
 
 from jupyterhub.auth import LocalAuthenticator
 from jupyterhub.traitlets import Callable
-from tornado.httpclient import AsyncHTTPClient
 from traitlets import Bool, Dict, Set, Unicode, Union, default
 
 from .oauth2 import OAuthenticator

--- a/oauthenticator/generic.py
+++ b/oauthenticator/generic.py
@@ -61,12 +61,6 @@ class GenericOAuthenticator(OAuthenticator):
         """,
     )
 
-    @default("http_client")
-    def _default_http_client(self):
-        return AsyncHTTPClient(
-            force_instance=True, defaults=dict(validate_cert=self.validate_server_cert)
-        )
-
     # _deprecated_oauth_aliases is used by deprecation logic in OAuthenticator
     _deprecated_oauth_aliases = {
         "username_key": ("username_claim", "16.0.0"),

--- a/oauthenticator/oauth2.py
+++ b/oauthenticator/oauth2.py
@@ -612,7 +612,9 @@ class OAuthenticator(Authenticator):
 
     @default("http_client")
     def _default_http_client(self):
-        return AsyncHTTPClient()
+        return AsyncHTTPClient(
+            force_instance=True, defaults=dict(validate_cert=self.validate_server_cert)
+        )
 
     async def fetch(self, req, label="fetching", parse_json=True, **kwargs):
         """Wrapper for http requests
@@ -878,7 +880,6 @@ class OAuthenticator(Authenticator):
             method="POST",
             headers=self.build_token_info_request_headers(),
             body=urlencode(params).encode("utf-8"),
-            validate_cert=self.validate_server_cert,
         )
 
         if "error_description" in token_info:
@@ -950,7 +951,6 @@ class OAuthenticator(Authenticator):
             "Fetching user info...",
             method="GET",
             headers=self.build_userdata_request_headers(access_token, token_type),
-            validate_cert=self.validate_server_cert,
         )
 
     def build_auth_state_dict(self, token_info, user_info):


### PR DESCRIPTION
This was currently being set in 2 places:

- Separately just for GenericOAuthneticator
- In each `httpfetch` call. This means future calls to `httpfetch` could accidentally leave this out.

This sets the default in one place so it's hard to miss.