### PR TITLE
Move allowed_groups and admin_groups to base authenticator

### DIFF
--- a/oauthenticator/generic.py
+++ b/oauthenticator/generic.py
@@ -8,7 +8,7 @@ from functools import reduce
 from jupyterhub.auth import LocalAuthenticator
 from jupyterhub.traitlets import Callable
 from tornado.httpclient import AsyncHTTPClient
-from traitlets import Bool, Dict, Set, Unicode, Union, default
+from traitlets import Bool, Dict, Unicode, Union, default
 
 from .oauth2 import OAuthenticator
 

--- a/oauthenticator/oauth2.py
+++ b/oauthenticator/oauth2.py
@@ -20,7 +20,18 @@ from tornado.auth import OAuth2Mixin
 from tornado.httpclient import AsyncHTTPClient, HTTPClientError, HTTPRequest
 from tornado.httputil import url_concat
 from tornado.log import app_log
-from traitlets import Any, Bool, Callable, Dict, List, Unicode, Union, default, Set, validate
+from traitlets import (
+    Any,
+    Bool,
+    Callable,
+    Dict,
+    List,
+    Set,
+    Unicode,
+    Union,
+    default,
+    validate,
+)
 
 
 def guess_callback_uri(protocol, host, hub_server_url):
@@ -335,7 +346,6 @@ class OAuthenticator(Authenticator):
         `admin_users`, a user signing in will have their admin status revoked.
         """,
     )
-
 
     authorize_url = Unicode(
         config=True,


### PR DESCRIPTION
A simplification of https://github.com/jupyterhub/oauthenticator/pull/735, moving 2 of the 3 traitlets. This is a straight up move, without any functional breaking changes.

- `admin_groups` allows setting members of some groups as admins.
- `allowed_groups` allows setting what groups should be allowed to login.

Both of these are more useful with claim_groups_key, as that allows an *external* party to drive group memberships. Without that, I guess primarily this depends on membership within the JupyterHub admin UI.

Splitting this up helps us get this moving faster, as figuring out how to move `claim_groups_key` is going to be slightly more involved.