### PR TITLE
Add changelog for v16.3.1

### DIFF
--- a/docs/source/reference/changelog.md
+++ b/docs/source/reference/changelog.md
@@ -29,7 +29,6 @@ See [our definition of contributors](https://github-activity.readthedocs.io/en/l
 
 @consideRatio ([activity](https://github.com/search?q=repo%3Ajupyterhub%2Foauthenticator+involves%3AconsideRatio+updated%3A2024-03-20..2024-06-11&type=Issues)) | @manics ([activity](https://github.com/search?q=repo%3Ajupyterhub%2Foauthenticator+involves%3Amanics+updated%3A2024-03-20..2024-06-11&type=Issues)) | @minrk ([activity](https://github.com/search?q=repo%3Ajupyterhub%2Foauthenticator+involves%3Aminrk+updated%3A2024-03-20..2024-06-11&type=Issues)) | @yuvipanda ([activity](https://github.com/search?q=repo%3Ajupyterhub%2Foauthenticator+involves%3Ayuvipanda+updated%3A2024-03-20..2024-06-11))
 
-
 ### 16.3.0 - 2024-03-20
 
 ```{important}

--- a/docs/source/reference/changelog.md
+++ b/docs/source/reference/changelog.md
@@ -6,6 +6,30 @@ command line for details.
 
 ## [Unreleased]
 
+### 16.3.1 - 2024-06-11
+
+```{important}
+This release includes a security patch for `GlobusOAuthenticator`.
+See [GHSA-gprj-3p75-f996](https://github.com/jupyterhub/oauthenticator/security/advisories/GHSA-gprj-3p75-f996)
+for details.
+```
+
+([full changelog](https://github.com/jupyterhub/oauthenticator/compare/16.3.0...16.3.1))
+
+#### New features added
+
+- [All] Add `allowed_scopes` to all authenticators to allow some users based on granted scopes [#719](https://github.com/jupyterhub/oauthenticator/pull/719) ([@yuvipanda](https://github.com/yuvipanda/), [@consideRatio](https://github.com/consideRatio), [@manics](https://github.com/manics), [@minrk])
+
+#### Contributors to this release
+
+The following people contributed discussions, new ideas, code and documentation contributions, and review.
+See [our definition of contributors](https://github-activity.readthedocs.io/en/latest/#how-does-this-tool-define-contributions-in-the-reports).
+
+([GitHub contributors page for this release](https://github.com/jupyterhub/oauthenticator/graphs/contributors?from=2024-03-20&to=2024-06-11&type=c))
+
+@consideRatio ([activity](https://github.com/search?q=repo%3Ajupyterhub%2Foauthenticator+involves%3AconsideRatio+updated%3A2024-03-20..2024-06-11&type=Issues)) | @manics ([activity](https://github.com/search?q=repo%3Ajupyterhub%2Foauthenticator+involves%3Amanics+updated%3A2024-03-20..2024-06-11&type=Issues)) | @minrk ([activity](https://github.com/search?q=repo%3Ajupyterhub%2Foauthenticator+involves%3Aminrk+updated%3A2024-03-20..2024-06-11&type=Issues)) | @yuvipanda ([activity](https://github.com/search?q=repo%3Ajupyterhub%2Foauthenticator+involves%3Ayuvipanda+updated%3A2024-03-20..2024-06-11))
+
+
 ### 16.3.0 - 2024-03-20
 
 ```{important}

--- a/oauthenticator/oauth2.py
+++ b/oauthenticator/oauth2.py
@@ -1051,9 +1051,6 @@ class OAuthenticator(Authenticator):
           (optional), and auth_state (optional)
 
         Subclasses should not override this method.
-
-        ref: https://jupyterhub.readthedocs.io/en/stable/reference/authenticators.html#authenticator-authenticate-method
-        ref: https://github.com/jupyterhub/jupyterhub/blob/4.0.0/jupyterhub/auth.py#L581-L611
         """
         # build the parameters to be used in the request exchanging the oauth code for the access token
         access_token_params = self.build_access_tokens_request_params(handler, data)


### PR DESCRIPTION
While trying to get a fix out for https://github.com/jupyterhub/oauthenticator/security/advisories/GHSA-gprj-3p75-f996, instead of making a backported release, I released from main. This was a mistake, but not a costly one. As I start doing more releases, I'll get better.

I could not get github-activity to work, so I manually constructed the changelog to the best of my ability. I reported the issue upstream in https://github.com/executablebooks/github-activity/issues/96.