### PR TITLE
[Google] Add switch to strip domain from username

### DIFF
--- a/oauthenticator/google.py
+++ b/oauthenticator/google.py
@@ -118,7 +118,7 @@ class GoogleOAuthenticator(OAuthenticator, GoogleOAuth2Mixin):
 
     @default('strip_domain')
     def _strip_if_single_domain(self):
-        return len(self.hosted_domain) > 1
+        return len(self.hosted_domain) <= 1
 
     @validate('strip_domain')
     def _check_multiple_hosted_domain(self, strip_domain):

--- a/oauthenticator/google.py
+++ b/oauthenticator/google.py
@@ -106,7 +106,6 @@ class GoogleOAuthenticator(OAuthenticator, GoogleOAuth2Mixin):
     )
 
     strip_domain = Bool(
-        False,
         config=True,
         help="""
         Strip the username to exclude the `@domain` part.
@@ -116,6 +115,10 @@ class GoogleOAuthenticator(OAuthenticator, GoogleOAuth2Mixin):
             If multiple `hosted_domains` are specified, there is a chance of clashing usernames.
         """,
     )
+
+    @default('strip_domain')
+    def _strip_if_single_domain(self):
+        return len(self.hosted_domain) > 1
 
     @validate('strip_domain')
     def _check_multiple_hosted_domain(self, strip_domain):

--- a/oauthenticator/google.py
+++ b/oauthenticator/google.py
@@ -112,7 +112,8 @@ class GoogleOAuthenticator(OAuthenticator, GoogleOAuth2Mixin):
         Strip the username to exclude the `@domain` part.
 
         .. warning::
-        If multiple `hosted_domains` are specified, there is a chance of clashing usernames.
+
+            If multiple `hosted_domains` are specified, there is a chance of clashing usernames.
         """,
     )
 

--- a/oauthenticator/google.py
+++ b/oauthenticator/google.py
@@ -108,11 +108,13 @@ class GoogleOAuthenticator(OAuthenticator, GoogleOAuth2Mixin):
     strip_domain = Bool(
         config=True,
         help="""
-        Strip the username to exclude the `@domain` part.
+        Strip the username to exclude the `@domain` part. 
+        This happens by default when there is only one hosted domain specified
 
         .. warning::
 
-            If multiple `hosted_domains` are specified, there is a chance of clashing usernames.
+            If domains are stripped from usernames and multiple `hosted_domains` are specified, 
+            there is a chance of clashing usernames.
         """,
     )
 

--- a/oauthenticator/tests/test_google.py
+++ b/oauthenticator/tests/test_google.py
@@ -164,7 +164,6 @@ async def test_google(
     c = Config()
     c.GoogleOAuthenticator = Config(class_config)
     c.GoogleOAuthenticator.username_claim = "custom"
-    c.GoogleOAuthenticator.strip_domain = True
     authenticator = GoogleOAuthenticator(config=c)
 
     handled_user_model = user_model("user1@example.com", "user1")
@@ -202,7 +201,7 @@ async def test_google(
         ("06", "user1@other.org", "ok-hd.org", "user1@other.org", True, None),
     ],
 )
-async def test_hosted_domain_strip_domain(
+async def test_hosted_domain_single_entry(
     google_client,
     test_variation_id,
     user_email,
@@ -218,7 +217,6 @@ async def test_hosted_domain_strip_domain(
     """
     c = Config()
     c.GoogleOAuthenticator.hosted_domain = ["ok-hd.org"]
-    c.GoogleOAuthenticator.strip_domain = True
     c.GoogleOAuthenticator.admin_users = {"user1"}
     c.GoogleOAuthenticator.allowed_users = {"user2", "blocked", "user1@other.org"}
     c.GoogleOAuthenticator.blocked_users = {"blocked"}

--- a/oauthenticator/tests/test_google.py
+++ b/oauthenticator/tests/test_google.py
@@ -164,6 +164,7 @@ async def test_google(
     c = Config()
     c.GoogleOAuthenticator = Config(class_config)
     c.GoogleOAuthenticator.username_claim = "custom"
+    c.GoogleOAuthenticator.strip_domain = True
     authenticator = GoogleOAuthenticator(config=c)
 
     handled_user_model = user_model("user1@example.com", "user1")
@@ -201,7 +202,7 @@ async def test_google(
         ("06", "user1@other.org", "ok-hd.org", "user1@other.org", True, None),
     ],
 )
-async def test_hosted_domain_single_entry(
+async def test_hosted_domain_strip_domain(
     google_client,
     test_variation_id,
     user_email,
@@ -217,6 +218,7 @@ async def test_hosted_domain_single_entry(
     """
     c = Config()
     c.GoogleOAuthenticator.hosted_domain = ["ok-hd.org"]
+    c.GoogleOAuthenticator.strip_domain = True
     c.GoogleOAuthenticator.admin_users = {"user1"}
     c.GoogleOAuthenticator.allowed_users = {"user2", "blocked", "user1@other.org"}
     c.GoogleOAuthenticator.blocked_users = {"blocked"}


### PR DESCRIPTION
Taking a stab at #733. 

I added a switch to the Google OAuthenticator to explicitly indicate whether domains should be stripped, which by default is set to False. If set to True, domain names will be stripped, and if in addition there are multiple domains specified, a warning will be produced. Perhaps this should be an error instead?

Closes #733 