### PR TITLE
add OAuthenticator.modify_auth_state_hook, allow get_user_groups / auth_state_groups_key to be async

### DIFF
--- a/oauthenticator/oauth2.py
+++ b/oauthenticator/oauth2.py
@@ -1184,12 +1184,12 @@ class OAuthenticator(Authenticator):
         """Call the modify_auth_state_hook"""
         try:
             auth_state = self.modify_auth_state_hook(self, auth_state)
+            if isawaitable(auth_state):
+                auth_state = await auth_state
         except Exception as e:
             # let hook errors raise, nothing in auth should suppress errors
             self.log.error(f"Error in modify_auth_state_hook: {e}")
             raise
-        if isawaitable(auth_state):
-            auth_state = await auth_state
         return auth_state
 
     async def authenticate(self, handler, data=None, **kwargs):


### PR DESCRIPTION
closes #750 

it feels a little weird to have `auth_state_groups_key` be a callable that actually fetches external info purely based on the config name, but it's what we have. Is there a better arrangement for adding more fields to the user model? e.g. something after `token_to_user`? I noted in #750 that _extending_ token_to_user would work. Should we have a _hook_ after token_to_user to allow additional modifications to the user model before things like groups get added, or is making this method/hook async enough?