### PR TITLE
Various fixes for allowed_groups and admin_groups

### DIFF
--- a/docs/source/tutorials/general-setup.md
+++ b/docs/source/tutorials/general-setup.md
@@ -60,7 +60,9 @@ projects' authenticator classes.
    - {attr}`.OAuthenticator.allow_all`
    - {attr}`.OAuthenticator.allow_existing_users`
    - {attr}`.OAuthenticator.allowed_users`
+   - {attr}`.OAuthenticator.allowed_groups`
    - {attr}`.OAuthenticator.admin_users`
+   - {attr}`.OAuthenticator.admin_groups`
 
    Your authenticator class may have unique config, so in the end it can look
    something like this:

--- a/docs/source/tutorials/provider-specific-setup/providers/azuread.md
+++ b/docs/source/tutorials/provider-specific-setup/providers/azuread.md
@@ -42,7 +42,7 @@ c.JupyterHub.authenticator_class = "azuread"
 # {...} other settings (see above)
 
 c.AzureAdOAuthenticator.manage_groups = True
-c.AzureAdOAuthenticator.auth_state_groups_key = 'user.groups'
+c.AzureAdOAuthenticator.auth_state_groups_key = "user.groups"  # this is the default
 ```
 
 This requires Azure AD to be configured to include the group-membership in the access token.

--- a/docs/source/tutorials/provider-specific-setup/providers/azuread.md
+++ b/docs/source/tutorials/provider-specific-setup/providers/azuread.md
@@ -35,8 +35,6 @@ be relevant to read more about in the configuration reference:
 ## Loading user groups
 
 The `AzureAdOAuthenticator` can load the group-membership of users from the access token.
-This is done by setting the `AzureAdOAuthenticator.groups_claim` to the name of the claim that contains the
-group-membership.
 
 ```python
 c.JupyterHub.authenticator_class = "azuread"
@@ -44,7 +42,7 @@ c.JupyterHub.authenticator_class = "azuread"
 # {...} other settings (see above)
 
 c.AzureAdOAuthenticator.manage_groups = True
-c.AzureAdOAuthenticator.user_groups_claim = 'groups'  # this is the default
+c.AzureAdOAuthenticator.auth_state_groups_key = 'user.groups'
 ```
 
 This requires Azure AD to be configured to include the group-membership in the access token.

--- a/docs/source/tutorials/provider-specific-setup/providers/generic.md
+++ b/docs/source/tutorials/provider-specific-setup/providers/generic.md
@@ -35,7 +35,7 @@ c.GenericOAuthenticator.userdata_url = "https://accounts.example.com/auth/realms
 #
 c.GenericOAuthenticator.scope = ["openid", "email", "groups"]
 c.GenericOAuthenticator.username_claim = "email"
-c.GenericOAuthenticator.auth_state_groups_key = "groups"
+c.GenericOAuthenticator.auth_state_groups_key = "oauth_user.groups"
 
 # Authorization
 # -------------

--- a/docs/source/tutorials/provider-specific-setup/providers/generic.md
+++ b/docs/source/tutorials/provider-specific-setup/providers/generic.md
@@ -35,7 +35,7 @@ c.GenericOAuthenticator.userdata_url = "https://accounts.example.com/auth/realms
 #
 c.GenericOAuthenticator.scope = ["openid", "email", "groups"]
 c.GenericOAuthenticator.username_claim = "email"
-c.GenericOAuthenticator.claim_groups_key = "groups"
+c.GenericOAuthenticator.auth_state_groups_key = "groups"
 
 # Authorization
 # -------------

--- a/oauthenticator/azuread.py
+++ b/oauthenticator/azuread.py
@@ -34,7 +34,7 @@ class AzureAdOAuthenticator(OAuthenticator):
 
     @default('auth_state_groups_key')
     def _auth_state_groups_key_default(self):
-        key = ""
+        key = "user.groups"
         if self.user_groups_claim:
             key = f"{self.user_auth_state_key}.{self.user_groups_claim}"
             cls = self.__class__.__name__

--- a/oauthenticator/azuread.py
+++ b/oauthenticator/azuread.py
@@ -39,7 +39,7 @@ class AzureAdOAuthenticator(OAuthenticator):
             key = f"{self.user_auth_state_key}.{self.user_groups_claim}"
             cls = self.__class__.__name__
             self.log.warning(
-                f"{cls}.user_groups_claim is deprecated in OAuthenticator 17. Use {cls}.auth_state_groups_key={key!r}"
+                f"{cls}.user_groups_claim is deprecated in OAuthenticator 17. Use {cls}.auth_state_groups_key = {key!r}"
             )
         return key
 

--- a/oauthenticator/azuread.py
+++ b/oauthenticator/azuread.py
@@ -23,14 +23,25 @@ class AzureAdOAuthenticator(OAuthenticator):
         return "name"
 
     user_groups_claim = Unicode(
-        "groups",
+        "",
         config=True,
         help="""
-        Name of claim containing user group memberships.
+        .. deprecated:: 17.0
 
-        Will populate JupyterHub groups if Authenticator.manage_groups is True.
+            Use :attr:`auth_state_groups_key` instead.
         """,
     )
+
+    @default('auth_state_groups_key')
+    def _auth_state_groups_key_default(self):
+        key = ""
+        if self.user_groups_claim:
+            key = f"{self.user_auth_state_key}.{self.user_groups_claim}"
+            cls = self.__class__.__name__
+            self.log.warning(
+                f"{cls}.user_groups_claim is deprecated in OAuthenticator 17. Use {cls}.auth_state_groups_key={key!r}"
+            )
+        return key
 
     tenant_id = Unicode(
         config=True,
@@ -54,15 +65,6 @@ class AzureAdOAuthenticator(OAuthenticator):
     @default("token_url")
     def _token_url_default(self):
         return f"https://login.microsoftonline.com/{self.tenant_id}/oauth2/token"
-
-    async def update_auth_model(self, auth_model, **kwargs):
-        auth_model = await super().update_auth_model(auth_model, **kwargs)
-
-        if getattr(self, "manage_groups", False):
-            user_info = auth_model["auth_state"][self.user_auth_state_key]
-            auth_model["groups"] = user_info[self.user_groups_claim]
-
-        return auth_model
 
     async def token_to_user(self, token_info):
         id_token = token_info['id_token']

--- a/oauthenticator/globus.py
+++ b/oauthenticator/globus.py
@@ -342,7 +342,7 @@ class GlobusOAuthenticator(OAuthenticator):
         to False makes it be revoked.
         """
         user_groups = set()
-        if self.allowed_globus_groups or self.admin_globus_groups:
+        if self.allowed_globus_groups or self.admin_globus_groups or self.manage_groups:
             tokens = self.get_globus_tokens(auth_model["auth_state"]["token_response"])
             user_groups = await self._fetch_users_groups(tokens)
         # sets are not JSONable, cast to list for auth_state

--- a/oauthenticator/tests/test_auth0.py
+++ b/oauthenticator/tests/test_auth0.py
@@ -64,17 +64,43 @@ def user_model():
             True,
         ),
         # common tests with allowed_groups and manage_groups
-        ("20", {"allowed_groups": {"group1"}, "manage_groups": True}, True, None),
+        (
+            "20",
+            {
+                "allowed_groups": {"group1"},
+                "auth_state_groups_key": "auth0_user.groups",
+                "manage_groups": True,
+            },
+            True,
+            None,
+        ),
         (
             "21",
-            {"allowed_groups": {"test-user-not-in-group"}, "manage_groups": True},
+            {
+                "allowed_groups": {"test-user-not-in-group"},
+                "auth_state_groups_key": "auth0_user.groups",
+                "manage_groups": True,
+            },
             False,
             None,
         ),
-        ("22", {"admin_groups": {"group1"}, "manage_groups": True}, True, True),
+        (
+            "22",
+            {
+                "admin_groups": {"group1"},
+                "auth_state_groups_key": "auth0_user.groups",
+                "manage_groups": True,
+            },
+            True,
+            True,
+        ),
         (
             "23",
-            {"admin_groups": {"test-user-not-in-group"}, "manage_groups": True},
+            {
+                "admin_groups": {"test-user-not-in-group"},
+                "auth_state_groups_key": "auth0_user.groups",
+                "manage_groups": True,
+            },
             False,
             False,
         ),
@@ -100,7 +126,10 @@ async def test_auth0(
 
     if expect_allowed:
         assert auth_model
-        assert set(auth_model) == {"name", "admin", "auth_state"}
+        if authenticator.manage_groups:
+            assert set(auth_model) == {"name", "admin", "auth_state", "groups"}
+        else:
+            assert set(auth_model) == {"name", "admin", "auth_state"}
         assert auth_model["admin"] == expect_admin
         auth_state = auth_model["auth_state"]
         assert json.dumps(auth_state)

--- a/oauthenticator/tests/test_auth0.py
+++ b/oauthenticator/tests/test_auth0.py
@@ -29,6 +29,7 @@ def user_model():
     return {
         "email": "user1@example.com",
         "name": "user1",
+        "groups": ["group1"],
     }
 
 
@@ -61,6 +62,21 @@ def user_model():
             },
             True,
             True,
+        ),
+        # common tests with allowed_groups and manage_groups
+        ("20", {"allowed_groups": {"group1"}, "manage_groups": True}, True, None),
+        (
+            "21",
+            {"allowed_groups": {"test-user-not-in-group"}, "manage_groups": True},
+            False,
+            None,
+        ),
+        ("22", {"admin_groups": {"group1"}, "manage_groups": True}, True, True),
+        (
+            "23",
+            {"admin_groups": {"test-user-not-in-group"}, "manage_groups": True},
+            False,
+            False,
         ),
     ],
 )

--- a/oauthenticator/tests/test_azuread.py
+++ b/oauthenticator/tests/test_azuread.py
@@ -134,17 +134,43 @@ def user_model(tenant_id, client_id, name):
             None,
         ),
         # common tests with allowed_groups and manage_groups
-        ("40", {"allowed_groups": {"group1"}, "manage_groups": True}, True, None),
+        (
+            "40",
+            {
+                "allowed_groups": {"group1"},
+                "auth_state_groups_key": "user.groups",
+                "manage_groups": True,
+            },
+            True,
+            None,
+        ),
         (
             "41",
-            {"allowed_groups": {"test-user-not-in-group"}, "manage_groups": True},
+            {
+                "allowed_groups": {"test-user-not-in-group"},
+                "auth_state_groups_key": "user.groups",
+                "manage_groups": True,
+            },
             False,
             None,
         ),
-        ("42", {"admin_groups": {"group1"}, "manage_groups": True}, True, True),
+        (
+            "42",
+            {
+                "admin_groups": {"group1"},
+                "auth_state_groups_key": "user.groups",
+                "manage_groups": True,
+            },
+            True,
+            True,
+        ),
         (
             "43",
-            {"admin_groups": {"test-user-not-in-group"}, "manage_groups": True},
+            {
+                "admin_groups": {"test-user-not-in-group"},
+                "auth_state_groups_key": "user.groups",
+                "manage_groups": True,
+            },
             False,
             False,
         ),

--- a/oauthenticator/tests/test_azuread.py
+++ b/oauthenticator/tests/test_azuread.py
@@ -1,6 +1,7 @@
 """test azure ad"""
 
 import json
+import logging
 import os
 import re
 import time
@@ -9,7 +10,7 @@ from unittest import mock
 
 import jwt
 import pytest
-from pytest import fixture, mark
+from pytest import fixture, mark, raises
 from traitlets.config import Config
 
 from ..azuread import AzureAdOAuthenticator
@@ -236,3 +237,47 @@ async def test_tenant_id_from_env():
     with mock.patch.dict(os.environ, {"AAD_TENANT_ID": tenant_id}):
         aad = AzureAdOAuthenticator()
         assert aad.tenant_id == tenant_id
+
+
+@mark.parametrize(
+    "test_variation_id,class_config,expect_config,expect_loglevel,expect_message",
+    [
+        (
+            "user_groups_claim",
+            {"user_groups_claim": "groups", "manage_groups": True},
+            {"auth_state_groups_key": "user.groups"},
+            logging.WARNING,
+            "AzureAdOAuthenticator.user_groups_claim is deprecated in OAuthenticator 17. Use AzureAdOAuthenticator.auth_state_groups_key = 'user.groups'",
+        ),
+    ],
+)
+async def test_deprecated_config(
+    caplog,
+    test_variation_id,
+    class_config,
+    expect_config,
+    expect_loglevel,
+    expect_message,
+):
+    """
+    Tests that a warning is emitted when using a deprecated config and that
+    configuring the old config ends up configuring the new config.
+    """
+    print(f"Running test variation id {test_variation_id}")
+    c = Config()
+    c.AzureAdOAuthenticator = Config(class_config)
+
+    test_logger = logging.getLogger('testlog')
+    if expect_loglevel == logging.ERROR:
+        with raises(ValueError, match=expect_message):
+            AzureAdOAuthenticator(config=c, log=test_logger)
+    else:
+        authenticator = AzureAdOAuthenticator(config=c, log=test_logger)
+        for key, value in expect_config.items():
+            assert getattr(authenticator, key) == value
+
+    captured_log_tuples = caplog.record_tuples
+    print(captured_log_tuples)
+
+    expected_log_tuple = (test_logger.name, expect_loglevel, expect_message)
+    assert expected_log_tuple in captured_log_tuples

--- a/oauthenticator/tests/test_azuread.py
+++ b/oauthenticator/tests/test_azuread.py
@@ -119,7 +119,11 @@ def user_model(tenant_id, client_id, name):
         # test user_groups_claim
         (
             "30",
-            {"allow_all": True, "manage_groups": True},
+            {
+                "allow_all": True,
+                "auth_state_groups_key": "user.groups",
+                "manage_groups": True,
+            },
             True,
             None,
         ),
@@ -128,7 +132,7 @@ def user_model(tenant_id, client_id, name):
             {
                 "allow_all": True,
                 "manage_groups": True,
-                "user_groups_claim": "grp",
+                "auth_state_groups_key": "user.grp",
             },
             True,
             None,
@@ -220,9 +224,11 @@ async def test_azuread(
         assert auth_model["name"] == user_info[authenticator.username_claim]
         if manage_groups:
             groups = auth_model['groups']
-            assert groups == user_info[authenticator.user_groups_claim]
+            assert (
+                groups == user_info[authenticator.auth_state_groups_key.rsplit(".")[-1]]
+            )
     else:
-        assert auth_model == None
+        assert auth_model is None
 
 
 async def test_tenant_id_from_env():

--- a/oauthenticator/tests/test_azuread.py
+++ b/oauthenticator/tests/test_azuread.py
@@ -117,12 +117,12 @@ def user_model(tenant_id, client_id, name):
             True,
             None,
         ),
-        # test user_groups_claim
+        # test user_groups_claim (deprecated)
         (
             "30",
             {
                 "allow_all": True,
-                "auth_state_groups_key": "user.groups",
+                "user_groups_claim": "groups",
                 "manage_groups": True,
             },
             True,
@@ -133,7 +133,7 @@ def user_model(tenant_id, client_id, name):
             {
                 "allow_all": True,
                 "manage_groups": True,
-                "auth_state_groups_key": "user.grp",
+                "user_groups_claim": "grp",
             },
             True,
             None,
@@ -143,7 +143,6 @@ def user_model(tenant_id, client_id, name):
             "40",
             {
                 "allowed_groups": {"group1"},
-                "auth_state_groups_key": "user.groups",
                 "manage_groups": True,
             },
             True,
@@ -153,7 +152,6 @@ def user_model(tenant_id, client_id, name):
             "41",
             {
                 "allowed_groups": {"test-user-not-in-group"},
-                "auth_state_groups_key": "user.groups",
                 "manage_groups": True,
             },
             False,
@@ -163,7 +161,6 @@ def user_model(tenant_id, client_id, name):
             "42",
             {
                 "admin_groups": {"group1"},
-                "auth_state_groups_key": "user.groups",
                 "manage_groups": True,
             },
             True,
@@ -173,7 +170,6 @@ def user_model(tenant_id, client_id, name):
             "43",
             {
                 "admin_groups": {"test-user-not-in-group"},
-                "auth_state_groups_key": "user.groups",
                 "manage_groups": True,
             },
             False,

--- a/oauthenticator/tests/test_azuread.py
+++ b/oauthenticator/tests/test_azuread.py
@@ -49,6 +49,7 @@ def user_model(tenant_id, client_id, name):
                 "96000b2c-7333-4f6e-a2c3-e7608fa2d131",
                 "a992b3d5-1966-4af4-abed-6ef021417be4",
                 "ceb90a42-030f-44f1-a0c7-825b572a3b07",
+                "group1",
             ],
             # different from 'groups' for tests
             "grp": [
@@ -131,6 +132,21 @@ def user_model(tenant_id, client_id, name):
             },
             True,
             None,
+        ),
+        # common tests with allowed_groups and manage_groups
+        ("40", {"allowed_groups": {"group1"}, "manage_groups": True}, True, None),
+        (
+            "41",
+            {"allowed_groups": {"test-user-not-in-group"}, "manage_groups": True},
+            False,
+            None,
+        ),
+        ("42", {"admin_groups": {"group1"}, "manage_groups": True}, True, True),
+        (
+            "43",
+            {"admin_groups": {"test-user-not-in-group"}, "manage_groups": True},
+            False,
+            False,
         ),
     ],
 )

--- a/oauthenticator/tests/test_bitbucket.py
+++ b/oauthenticator/tests/test_bitbucket.py
@@ -45,6 +45,7 @@ def user_model(username):
     """
     return {
         "username": username,
+        "groups": ["group1"],
     }
 
 
@@ -81,17 +82,43 @@ def user_model(username):
             True,
         ),
         # common tests with allowed_groups and manage_groups
-        ("20", {"allowed_groups": {"group1"}, "manage_groups": True}, True, None),
+        (
+            "20",
+            {
+                "allowed_groups": {"group1"},
+                "auth_state_groups_key": "bitbucket_user.groups",
+                "manage_groups": True,
+            },
+            True,
+            None,
+        ),
         (
             "21",
-            {"allowed_groups": {"test-user-not-in-group"}, "manage_groups": True},
+            {
+                "allowed_groups": {"test-user-not-in-group"},
+                "auth_state_groups_key": "bitbucket_user.groups",
+                "manage_groups": True,
+            },
             False,
             None,
         ),
-        ("22", {"admin_groups": {"group1"}, "manage_groups": True}, True, True),
+        (
+            "22",
+            {
+                "admin_groups": {"group1"},
+                "auth_state_groups_key": "bitbucket_user.groups",
+                "manage_groups": True,
+            },
+            True,
+            True,
+        ),
         (
             "23",
-            {"admin_groups": {"test-user-not-in-group"}, "manage_groups": True},
+            {
+                "admin_groups": {"test-user-not-in-group"},
+                "auth_state_groups_key": "bitbucket_user.groups",
+                "manage_groups": True,
+            },
             False,
             False,
         ),
@@ -116,7 +143,10 @@ async def test_bitbucket(
 
     if expect_allowed:
         assert auth_model
-        assert set(auth_model) == {"name", "admin", "auth_state"}
+        if authenticator.manage_groups:
+            assert set(auth_model) == {"name", "admin", "auth_state", "groups"}
+        else:
+            assert set(auth_model) == {"name", "admin", "auth_state"}
         assert auth_model["admin"] == expect_admin
         auth_state = auth_model["auth_state"]
         assert json.dumps(auth_state)

--- a/oauthenticator/tests/test_bitbucket.py
+++ b/oauthenticator/tests/test_bitbucket.py
@@ -80,6 +80,21 @@ def user_model(username):
             True,
             True,
         ),
+        # common tests with allowed_groups and manage_groups
+        ("20", {"allowed_groups": {"group1"}, "manage_groups": True}, True, None),
+        (
+            "21",
+            {"allowed_groups": {"test-user-not-in-group"}, "manage_groups": True},
+            False,
+            None,
+        ),
+        ("22", {"admin_groups": {"group1"}, "manage_groups": True}, True, True),
+        (
+            "23",
+            {"admin_groups": {"test-user-not-in-group"}, "manage_groups": True},
+            False,
+            False,
+        ),
     ],
 )
 async def test_bitbucket(

--- a/oauthenticator/tests/test_cilogon.py
+++ b/oauthenticator/tests/test_cilogon.py
@@ -63,17 +63,43 @@ def user_model(username, username_claim, **kwargs):
             True,
         ),
         # common tests with allowed_groups and manage_groups
-        ("20", {"allowed_groups": {"group1"}, "manage_groups": True}, True, None),
+        (
+            "20",
+            {
+                "allowed_groups": {"group1"},
+                "auth_state_groups_key": "cilogon_user.groups",
+                "manage_groups": True,
+            },
+            True,
+            None,
+        ),
         (
             "21",
-            {"allowed_groups": {"test-user-not-in-group"}, "manage_groups": True},
+            {
+                "allowed_groups": {"test-user-not-in-group"},
+                "auth_state_groups_key": "cilogon_user.groups",
+                "manage_groups": True,
+            },
             False,
             None,
         ),
-        ("22", {"admin_groups": {"group1"}, "manage_groups": True}, True, True),
+        (
+            "22",
+            {
+                "admin_groups": {"group1"},
+                "auth_state_groups_key": "cilogon_user.groups",
+                "manage_groups": True,
+            },
+            True,
+            True,
+        ),
         (
             "23",
-            {"admin_groups": {"test-user-not-in-group"}, "manage_groups": True},
+            {
+                "admin_groups": {"test-user-not-in-group"},
+                "auth_state_groups_key": "cilogon_user.groups",
+                "manage_groups": True,
+            },
             False,
             False,
         ),
@@ -104,7 +130,10 @@ async def test_cilogon(
 
     if expect_allowed:
         assert auth_model
-        assert set(auth_model) == {"name", "admin", "auth_state"}
+        if authenticator.manage_groups:
+            assert set(auth_model) == {"name", "admin", "auth_state", "groups"}
+        else:
+            assert set(auth_model) == {"name", "admin", "auth_state"}
         assert auth_model["admin"] == expect_admin
         auth_state = auth_model["auth_state"]
         assert json.dumps(auth_state)
@@ -432,7 +461,10 @@ async def test_cilogon_allowed_idps(
 
     if expect_allowed:
         assert auth_model
-        assert set(auth_model) == {"name", "admin", "auth_state"}
+        if authenticator.manage_groups:
+            assert set(auth_model) == {"name", "admin", "auth_state", "groups"}
+        else:
+            assert set(auth_model) == {"name", "admin", "auth_state"}
         assert auth_model["admin"] == expect_admin
         auth_state = auth_model["auth_state"]
         assert json.dumps(auth_state)

--- a/oauthenticator/tests/test_cilogon.py
+++ b/oauthenticator/tests/test_cilogon.py
@@ -27,6 +27,7 @@ def user_model(username, username_claim, **kwargs):
     return {
         username_claim: username,
         "idp": "https://some-idp.com/login/oauth/authorize",
+        "groups": ["group1"],
         **kwargs,
     }
 
@@ -60,6 +61,21 @@ def user_model(username, username_claim, **kwargs):
             },
             True,
             True,
+        ),
+        # common tests with allowed_groups and manage_groups
+        ("20", {"allowed_groups": {"group1"}, "manage_groups": True}, True, None),
+        (
+            "21",
+            {"allowed_groups": {"test-user-not-in-group"}, "manage_groups": True},
+            False,
+            None,
+        ),
+        ("22", {"admin_groups": {"group1"}, "manage_groups": True}, True, True),
+        (
+            "23",
+            {"admin_groups": {"test-user-not-in-group"}, "manage_groups": True},
+            False,
+            False,
         ),
     ],
 )

--- a/oauthenticator/tests/test_generic.py
+++ b/oauthenticator/tests/test_generic.py
@@ -104,20 +104,6 @@ def get_authenticator_variant(generic_client, userdata_from_id_token):
         ("03", {"allowed_users": {"not-test-user"}}, False, None),
         ("04", {"admin_users": {"user1"}}, True, True),
         ("05", {"admin_users": {"not-test-user"}}, False, None),
-        ("06", {"allowed_groups": {"group1"}, "manage_groups": True}, True, None),
-        (
-            "07",
-            {"allowed_groups": {"test-user-not-in-group"}, "manage_groups": True},
-            False,
-            None,
-        ),
-        ("08", {"admin_groups": {"group1"}, "manage_groups": True}, True, True),
-        (
-            "09",
-            {"admin_groups": {"test-user-not-in-group"}, "manage_groups": True},
-            False,
-            False,
-        ),
         # allow config, some combinations of two tested
         (
             "10",
@@ -227,6 +213,21 @@ def get_authenticator_variant(generic_client, userdata_from_id_token):
             },
             True,
             None,
+        ),
+        # common tests with allowed_groups and manage_groups
+        ("20", {"allowed_groups": {"group1"}, "manage_groups": True}, True, None),
+        (
+            "21",
+            {"allowed_groups": {"test-user-not-in-group"}, "manage_groups": True},
+            False,
+            None,
+        ),
+        ("22", {"admin_groups": {"group1"}, "manage_groups": True}, True, True),
+        (
+            "23",
+            {"admin_groups": {"test-user-not-in-group"}, "manage_groups": True},
+            False,
+            False,
         ),
     ],
 )

--- a/oauthenticator/tests/test_github.py
+++ b/oauthenticator/tests/test_github.py
@@ -21,6 +21,7 @@ def user_model(username):
         'id': 5,
         'login': username,
         'name': 'Hoban Washburn',
+        "groups": ["group1"],
     }
 
 
@@ -65,6 +66,21 @@ def github_client(client):
             },
             True,
             True,
+        ),
+        # common tests with allowed_groups and manage_groups
+        ("20", {"allowed_groups": {"group1"}, "manage_groups": True}, True, None),
+        (
+            "21",
+            {"allowed_groups": {"test-user-not-in-group"}, "manage_groups": True},
+            False,
+            None,
+        ),
+        ("22", {"admin_groups": {"group1"}, "manage_groups": True}, True, True),
+        (
+            "23",
+            {"admin_groups": {"test-user-not-in-group"}, "manage_groups": True},
+            False,
+            False,
         ),
     ],
 )

--- a/oauthenticator/tests/test_github.py
+++ b/oauthenticator/tests/test_github.py
@@ -68,17 +68,43 @@ def github_client(client):
             True,
         ),
         # common tests with allowed_groups and manage_groups
-        ("20", {"allowed_groups": {"group1"}, "manage_groups": True}, True, None),
+        (
+            "20",
+            {
+                "allowed_groups": {"group1"},
+                "auth_state_groups_key": "github_user.groups",
+                "manage_groups": True,
+            },
+            True,
+            None,
+        ),
         (
             "21",
-            {"allowed_groups": {"test-user-not-in-group"}, "manage_groups": True},
+            {
+                "allowed_groups": {"test-user-not-in-group"},
+                "auth_state_groups_key": "github_user.groups",
+                "manage_groups": True,
+            },
             False,
             None,
         ),
-        ("22", {"admin_groups": {"group1"}, "manage_groups": True}, True, True),
+        (
+            "22",
+            {
+                "admin_groups": {"group1"},
+                "auth_state_groups_key": "github_user.groups",
+                "manage_groups": True,
+            },
+            True,
+            True,
+        ),
         (
             "23",
-            {"admin_groups": {"test-user-not-in-group"}, "manage_groups": True},
+            {
+                "admin_groups": {"test-user-not-in-group"},
+                "auth_state_groups_key": "github_user.groups",
+                "manage_groups": True,
+            },
             False,
             False,
         ),
@@ -103,7 +129,10 @@ async def test_github(
 
     if expect_allowed:
         assert auth_model
-        assert set(auth_model) == {"name", "admin", "auth_state"}
+        if authenticator.manage_groups:
+            assert set(auth_model) == {"name", "admin", "auth_state", "groups"}
+        else:
+            assert set(auth_model) == {"name", "admin", "auth_state"}
         assert auth_model["admin"] == expect_admin
         auth_state = auth_model["auth_state"]
         assert json.dumps(auth_state)

--- a/oauthenticator/tests/test_gitlab.py
+++ b/oauthenticator/tests/test_gitlab.py
@@ -88,17 +88,43 @@ def mock_api_version(client, version):
             True,
         ),
         # common tests with allowed_groups and manage_groups
-        ("20", {"allowed_groups": {"group1"}, "manage_groups": True}, True, None),
+        (
+            "20",
+            {
+                "allowed_groups": {"group1"},
+                "auth_state_groups_key": "gitlab_user.groups",
+                "manage_groups": True,
+            },
+            True,
+            None,
+        ),
         (
             "21",
-            {"allowed_groups": {"test-user-not-in-group"}, "manage_groups": True},
+            {
+                "allowed_groups": {"test-user-not-in-group"},
+                "auth_state_groups_key": "gitlab_user.groups",
+                "manage_groups": True,
+            },
             False,
             None,
         ),
-        ("22", {"admin_groups": {"group1"}, "manage_groups": True}, True, True),
+        (
+            "22",
+            {
+                "admin_groups": {"group1"},
+                "auth_state_groups_key": "gitlab_user.groups",
+                "manage_groups": True,
+            },
+            True,
+            True,
+        ),
         (
             "23",
-            {"admin_groups": {"test-user-not-in-group"}, "manage_groups": True},
+            {
+                "admin_groups": {"test-user-not-in-group"},
+                "auth_state_groups_key": "gitlab_user.groups",
+                "manage_groups": True,
+            },
             False,
             False,
         ),
@@ -123,7 +149,10 @@ async def test_gitlab(
 
     if expect_allowed:
         assert auth_model
-        assert set(auth_model) == {"name", "admin", "auth_state"}
+        if authenticator.manage_groups:
+            assert set(auth_model) == {"name", "admin", "auth_state", "groups"}
+        else:
+            assert set(auth_model) == {"name", "admin", "auth_state"}
         assert auth_model["admin"] == expect_admin
         auth_state = auth_model["auth_state"]
         assert json.dumps(auth_state)

--- a/oauthenticator/tests/test_gitlab.py
+++ b/oauthenticator/tests/test_gitlab.py
@@ -28,6 +28,7 @@ def user_model(username):
     return {
         "username": username,
         "id": id,
+        "groups": ["group1"],
     }
 
 
@@ -85,6 +86,21 @@ def mock_api_version(client, version):
             },
             True,
             True,
+        ),
+        # common tests with allowed_groups and manage_groups
+        ("20", {"allowed_groups": {"group1"}, "manage_groups": True}, True, None),
+        (
+            "21",
+            {"allowed_groups": {"test-user-not-in-group"}, "manage_groups": True},
+            False,
+            None,
+        ),
+        ("22", {"admin_groups": {"group1"}, "manage_groups": True}, True, True),
+        (
+            "23",
+            {"admin_groups": {"test-user-not-in-group"}, "manage_groups": True},
+            False,
+            False,
         ),
     ],
 )

--- a/oauthenticator/tests/test_globus.py
+++ b/oauthenticator/tests/test_globus.py
@@ -17,6 +17,7 @@ def user_model(username, **kwargs):
     """Return a user model"""
     return {
         "preferred_username": username,
+        "groups": ["group1"],
         **kwargs,
     }
 
@@ -276,6 +277,21 @@ def mock_globus_user(globus_tokens_by_resource_server):
                 "admin_users": {"not-test-user"},
                 "admin_globus_groups": {"test-user-not-in-group"},
             },
+            False,
+            False,
+        ),
+        # common tests with allowed_groups and manage_groups
+        ("20", {"allowed_groups": {"group1"}, "manage_groups": True}, True, None),
+        (
+            "21",
+            {"allowed_groups": {"test-user-not-in-group"}, "manage_groups": True},
+            False,
+            None,
+        ),
+        ("22", {"admin_groups": {"group1"}, "manage_groups": True}, True, True),
+        (
+            "23",
+            {"admin_groups": {"test-user-not-in-group"}, "manage_groups": True},
             False,
             False,
         ),

--- a/oauthenticator/tests/test_globus.py
+++ b/oauthenticator/tests/test_globus.py
@@ -281,17 +281,43 @@ def mock_globus_user(globus_tokens_by_resource_server):
             False,
         ),
         # common tests with allowed_groups and manage_groups
-        ("20", {"allowed_groups": {"group1"}, "manage_groups": True}, True, None),
+        (
+            "20",
+            {
+                "allowed_groups": {"group1"},
+                "auth_state_groups_key": "globus_user.groups",
+                "manage_groups": True,
+            },
+            True,
+            None,
+        ),
         (
             "21",
-            {"allowed_groups": {"test-user-not-in-group"}, "manage_groups": True},
+            {
+                "allowed_groups": {"test-user-not-in-group"},
+                "auth_state_groups_key": "globus_user.groups",
+                "manage_groups": True,
+            },
             False,
             None,
         ),
-        ("22", {"admin_groups": {"group1"}, "manage_groups": True}, True, True),
+        (
+            "22",
+            {
+                "admin_groups": {"group1"},
+                "auth_state_groups_key": "globus_user.groups",
+                "manage_groups": True,
+            },
+            True,
+            True,
+        ),
         (
             "23",
-            {"admin_groups": {"test-user-not-in-group"}, "manage_groups": True},
+            {
+                "admin_groups": {"test-user-not-in-group"},
+                "auth_state_groups_key": "globus_user.groups",
+                "manage_groups": True,
+            },
             False,
             False,
         ),
@@ -316,7 +342,10 @@ async def test_globus(
 
     if expect_allowed:
         assert auth_model
-        assert set(auth_model) == {"name", "admin", "auth_state"}
+        if authenticator.manage_groups:
+            assert set(auth_model) == {"name", "admin", "auth_state", "groups"}
+        else:
+            assert set(auth_model) == {"name", "admin", "auth_state"}
         assert auth_model["admin"] == expect_admin
         auth_state = auth_model["auth_state"]
         assert json.dumps(auth_state)

--- a/oauthenticator/tests/test_google.py
+++ b/oauthenticator/tests/test_google.py
@@ -153,17 +153,43 @@ def google_client(client):
             False,
         ),
         # common tests with allowed_groups and manage_groups
-        ("20", {"allowed_groups": {"group1"}, "manage_groups": True}, True, None),
+        (
+            "20",
+            {
+                "allowed_groups": {"group1"},
+                "auth_state_groups_key": "google_user.groups",
+                "manage_groups": True,
+            },
+            True,
+            None,
+        ),
         (
             "21",
-            {"allowed_groups": {"test-user-not-in-group"}, "manage_groups": True},
+            {
+                "allowed_groups": {"test-user-not-in-group"},
+                "auth_state_groups_key": "google_user.groups",
+                "manage_groups": True,
+            },
             False,
             None,
         ),
-        ("22", {"admin_groups": {"group1"}, "manage_groups": True}, True, True),
+        (
+            "22",
+            {
+                "admin_groups": {"group1"},
+                "auth_state_groups_key": "google_user.groups",
+                "manage_groups": True,
+            },
+            True,
+            True,
+        ),
         (
             "23",
-            {"admin_groups": {"test-user-not-in-group"}, "manage_groups": True},
+            {
+                "admin_groups": {"test-user-not-in-group"},
+                "auth_state_groups_key": "google_user.groups",
+                "manage_groups": True,
+            },
             False,
             False,
         ),
@@ -191,7 +217,10 @@ async def test_google(
 
     if expect_allowed:
         assert auth_model
-        assert set(auth_model) == {"name", "admin", "auth_state"}
+        if authenticator.manage_groups:
+            assert set(auth_model) == {"name", "admin", "auth_state", "groups"}
+        else:
+            assert set(auth_model) == {"name", "admin", "auth_state"}
         assert auth_model["admin"] == expect_admin
         auth_state = auth_model["auth_state"]
         assert json.dumps(auth_state)

--- a/oauthenticator/tests/test_google.py
+++ b/oauthenticator/tests/test_google.py
@@ -18,6 +18,7 @@ def user_model(email, username="user1", hd=None):
         'email': email,
         'custom': username,
         'verified_email': True,
+        'groups': ['group1'],
     }
     if hd:
         model['hd'] = hd
@@ -148,6 +149,21 @@ def google_client(client):
                 "admin_users": {"not-test-user"},
                 "admin_google_groups": {"example.com": {"test-user-not-in-group"}},
             },
+            False,
+            False,
+        ),
+        # common tests with allowed_groups and manage_groups
+        ("20", {"allowed_groups": {"group1"}, "manage_groups": True}, True, None),
+        (
+            "21",
+            {"allowed_groups": {"test-user-not-in-group"}, "manage_groups": True},
+            False,
+            None,
+        ),
+        ("22", {"admin_groups": {"group1"}, "manage_groups": True}, True, True),
+        (
+            "23",
+            {"admin_groups": {"test-user-not-in-group"}, "manage_groups": True},
             False,
             False,
         ),

--- a/oauthenticator/tests/test_mediawiki.py
+++ b/oauthenticator/tests/test_mediawiki.py
@@ -80,7 +80,7 @@ def mediawiki():
             "20",
             {
                 "allowed_groups": {"group1"},
-                "auth_state_groups_key": "mediawiki_user.groups",
+                "auth_state_groups_key": "MEDIAWIKI_USER_IDENTITY.groups",
                 "manage_groups": True,
             },
             True,
@@ -90,7 +90,7 @@ def mediawiki():
             "21",
             {
                 "allowed_groups": {"test-user-not-in-group"},
-                "auth_state_groups_key": "mediawiki_user.groups",
+                "auth_state_groups_key": "MEDIAWIKI_USER_IDENTITY.groups",
                 "manage_groups": True,
             },
             False,
@@ -100,7 +100,7 @@ def mediawiki():
             "22",
             {
                 "admin_groups": {"group1"},
-                "auth_state_groups_key": "mediawiki_user.groups",
+                "auth_state_groups_key": "MEDIAWIKI_USER_IDENTITY.groups",
                 "manage_groups": True,
             },
             True,
@@ -110,7 +110,7 @@ def mediawiki():
             "23",
             {
                 "admin_groups": {"test-user-not-in-group"},
-                "auth_state_groups_key": "mediawiki_user.groups",
+                "auth_state_groups_key": "MEDIAWIKI_USER_IDENTITY.groups",
                 "manage_groups": True,
             },
             False,
@@ -155,7 +155,7 @@ async def test_mediawiki(
         user_info = auth_state[authenticator.user_auth_state_key]
         assert auth_model["name"] == user_info[authenticator.username_claim]
     else:
-        assert auth_model == None
+        assert auth_model is None
 
 
 async def test_login_redirect(mediawiki):

--- a/oauthenticator/tests/test_mediawiki.py
+++ b/oauthenticator/tests/test_mediawiki.py
@@ -25,6 +25,7 @@ def mediawiki():
                 'iss': 'https://meta.wikimedia.org',
                 'iat': time.time(),
                 'nonce': request_nonce,
+                'groups': ['group1'],
             },
             'client_secret',
         ).encode()
@@ -73,6 +74,21 @@ def mediawiki():
             },
             True,
             True,
+        ),
+        # common tests with allowed_groups and manage_groups
+        ("20", {"allowed_groups": {"group1"}, "manage_groups": True}, True, None),
+        (
+            "21",
+            {"allowed_groups": {"test-user-not-in-group"}, "manage_groups": True},
+            False,
+            None,
+        ),
+        ("22", {"admin_groups": {"group1"}, "manage_groups": True}, True, True),
+        (
+            "23",
+            {"admin_groups": {"test-user-not-in-group"}, "manage_groups": True},
+            False,
+            False,
         ),
     ],
 )

--- a/oauthenticator/tests/test_mediawiki.py
+++ b/oauthenticator/tests/test_mediawiki.py
@@ -76,17 +76,43 @@ def mediawiki():
             True,
         ),
         # common tests with allowed_groups and manage_groups
-        ("20", {"allowed_groups": {"group1"}, "manage_groups": True}, True, None),
+        (
+            "20",
+            {
+                "allowed_groups": {"group1"},
+                "auth_state_groups_key": "mediawiki_user.groups",
+                "manage_groups": True,
+            },
+            True,
+            None,
+        ),
         (
             "21",
-            {"allowed_groups": {"test-user-not-in-group"}, "manage_groups": True},
+            {
+                "allowed_groups": {"test-user-not-in-group"},
+                "auth_state_groups_key": "mediawiki_user.groups",
+                "manage_groups": True,
+            },
             False,
             None,
         ),
-        ("22", {"admin_groups": {"group1"}, "manage_groups": True}, True, True),
+        (
+            "22",
+            {
+                "admin_groups": {"group1"},
+                "auth_state_groups_key": "mediawiki_user.groups",
+                "manage_groups": True,
+            },
+            True,
+            True,
+        ),
         (
             "23",
-            {"admin_groups": {"test-user-not-in-group"}, "manage_groups": True},
+            {
+                "admin_groups": {"test-user-not-in-group"},
+                "auth_state_groups_key": "mediawiki_user.groups",
+                "manage_groups": True,
+            },
             False,
             False,
         ),
@@ -117,7 +143,10 @@ async def test_mediawiki(
 
     if expect_allowed:
         assert auth_model
-        assert set(auth_model) == {"name", "admin", "auth_state"}
+        if authenticator.manage_groups:
+            assert set(auth_model) == {"name", "admin", "auth_state", "groups"}
+        else:
+            assert set(auth_model) == {"name", "admin", "auth_state"}
         assert auth_model["admin"] == expect_admin
         auth_state = auth_model["auth_state"]
         assert json.dumps(auth_state)

--- a/oauthenticator/tests/test_openshift.py
+++ b/oauthenticator/tests/test_openshift.py
@@ -141,7 +141,6 @@ def user_model():
             "20",
             {
                 "allowed_groups": {"group1"},
-                "auth_state_groups_key": "openshift_user.groups",
                 "manage_groups": True,
             },
             True,
@@ -151,7 +150,6 @@ def user_model():
             "21",
             {
                 "allowed_groups": {"test-user-not-in-group"},
-                "auth_state_groups_key": "openshift_user.groups",
                 "manage_groups": True,
             },
             False,
@@ -161,7 +159,6 @@ def user_model():
             "22",
             {
                 "admin_groups": {"group1"},
-                "auth_state_groups_key": "openshift_user.groups",
                 "manage_groups": True,
             },
             True,
@@ -171,7 +168,6 @@ def user_model():
             "23",
             {
                 "admin_groups": {"test-user-not-in-group"},
-                "auth_state_groups_key": "openshift_user.groups",
                 "manage_groups": True,
             },
             False,

--- a/oauthenticator/tests/test_openshift.py
+++ b/oauthenticator/tests/test_openshift.py
@@ -137,17 +137,43 @@ def user_model():
             False,
         ),
         # common tests with allowed_groups and manage_groups
-        ("20", {"allowed_groups": {"group1"}, "manage_groups": True}, True, None),
+        (
+            "20",
+            {
+                "allowed_groups": {"group1"},
+                "auth_state_groups_key": "openshift_user.groups",
+                "manage_groups": True,
+            },
+            True,
+            None,
+        ),
         (
             "21",
-            {"allowed_groups": {"test-user-not-in-group"}, "manage_groups": True},
+            {
+                "allowed_groups": {"test-user-not-in-group"},
+                "auth_state_groups_key": "openshift_user.groups",
+                "manage_groups": True,
+            },
             False,
             None,
         ),
-        ("22", {"admin_groups": {"group1"}, "manage_groups": True}, True, True),
+        (
+            "22",
+            {
+                "admin_groups": {"group1"},
+                "auth_state_groups_key": "openshift_user.groups",
+                "manage_groups": True,
+            },
+            True,
+            True,
+        ),
         (
             "23",
-            {"admin_groups": {"test-user-not-in-group"}, "manage_groups": True},
+            {
+                "admin_groups": {"test-user-not-in-group"},
+                "auth_state_groups_key": "openshift_user.groups",
+                "manage_groups": True,
+            },
             False,
             False,
         ),
@@ -174,7 +200,10 @@ async def test_openshift(
 
     if expect_allowed:
         assert auth_model
-        assert set(auth_model) == {"name", "admin", "auth_state"}
+        if authenticator.manage_groups:
+            assert set(auth_model) == {"name", "admin", "auth_state", "groups"}
+        else:
+            assert set(auth_model) == {"name", "admin", "auth_state"}
         assert auth_model["name"] == handled_user_model["metadata"]["name"]
         assert auth_model["admin"] == expect_admin
         auth_state = auth_model["auth_state"]

--- a/oauthenticator/tests/test_openshift.py
+++ b/oauthenticator/tests/test_openshift.py
@@ -37,20 +37,6 @@ def user_model():
         ("03", {"allowed_users": {"not-test-user"}}, False, None),
         ("04", {"admin_users": {"user1"}}, True, True),
         ("05", {"admin_users": {"not-test-user"}}, False, None),
-        ("06", {"allowed_groups": {"group1"}, "manage_groups": True}, True, None),
-        (
-            "07",
-            {"allowed_groups": {"test-user-not-in-group"}, "manage_groups": True},
-            False,
-            None,
-        ),
-        ("08", {"admin_groups": {"group1"}, "manage_groups": True}, True, True),
-        (
-            "09",
-            {"admin_groups": {"test-user-not-in-group"}, "manage_groups": True},
-            False,
-            False,
-        ),
         # allow config, some combinations of two tested
         (
             "10",
@@ -147,6 +133,21 @@ def user_model():
                 "admin_groups": {"test-user-not-in-group"},
                 "manage_groups": True,
             },
+            False,
+            False,
+        ),
+        # common tests with allowed_groups and manage_groups
+        ("20", {"allowed_groups": {"group1"}, "manage_groups": True}, True, None),
+        (
+            "21",
+            {"allowed_groups": {"test-user-not-in-group"}, "manage_groups": True},
+            False,
+            None,
+        ),
+        ("22", {"admin_groups": {"group1"}, "manage_groups": True}, True, True),
+        (
+            "23",
+            {"admin_groups": {"test-user-not-in-group"}, "manage_groups": True},
             False,
             False,
         ),


### PR DESCRIPTION
Ensures `allowed_groups` and `admin_groups` works as in all authenticator classes by adding tests and resolving some implementation details. The fixes are to unreleased changes, so this is considered a maintenance PR rather than bugfix.

- Fixes #756 