### PR TITLE
[Google] Add `include_nested_groups` config

### DIFF
--- a/oauthenticator/google.py
+++ b/oauthenticator/google.py
@@ -391,7 +391,7 @@ class GoogleOAuthenticator(OAuthenticator, GoogleOAuth2Mixin):
 
         resp = self.service.groups().list(userKey=user_email).execute()
         user_groups = {
-            g['email'].split('@')[0] for g in resp.get('groups', [{'email': None}])
+            g['email'].split('@')[0] for g in resp.get('groups', []) if g.get('email')
         }
 
         # Recursively check for nested groups if allowed

--- a/oauthenticator/google.py
+++ b/oauthenticator/google.py
@@ -363,6 +363,7 @@ class GoogleOAuthenticator(OAuthenticator, GoogleOAuth2Mixin):
             cache_discovery=False,
             http=http,
         )
+
     def _setup_service(self, user_email_domain, http=None):
         """
         Set up the service client for Google API.
@@ -379,7 +380,14 @@ class GoogleOAuthenticator(OAuthenticator, GoogleOAuth2Mixin):
         )
         return service
 
-    def _fetch_user_groups(self, user_email, user_email_domain, http=None, checked_groups=None, processed_groups=None):
+    def _fetch_user_groups(
+        self,
+        user_email,
+        user_email_domain,
+        http=None,
+        checked_groups=None,
+        processed_groups=None,
+    ):
         """
         Return a set with the google groups a given user is a member of, including nested groups if allowed.
         """
@@ -398,22 +406,24 @@ class GoogleOAuthenticator(OAuthenticator, GoogleOAuth2Mixin):
 
         self.log.debug(f"Fetched groups for {user_email}: {user_groups}")
 
-        # Add the current user's groups to the checked groups
         checked_groups.update(user_groups)
-
         self.log.debug(f"Checked groups after update: {checked_groups}")
 
-        # Recursively check for nested groups if allowed
         if self.allow_nested_groups:
             for group in user_groups:
                 if group not in processed_groups:
-                    nested_groups = self._fetch_user_groups(group + "@" + user_email_domain, user_email_domain, http, checked_groups, processed_groups)
+                    nested_groups = self._fetch_user_groups(
+                        f"{group}@{user_email_domain}",
+                        user_email_domain,
+                        http,
+                        checked_groups,
+                        processed_groups,
+                    )
                     checked_groups.update(nested_groups)
                     processed_groups.add(group)
 
         self.log.debug(f"user_email {user_email} is a member of {checked_groups}")
         return checked_groups
-
 
 
 class LocalGoogleOAuthenticator(LocalAuthenticator, GoogleOAuthenticator):

--- a/oauthenticator/google.py
+++ b/oauthenticator/google.py
@@ -106,7 +106,6 @@ class GoogleOAuthenticator(OAuthenticator, GoogleOAuth2Mixin):
     )
 
     allow_nested_groups = Bool(
-        Set(Unicode()),
         config=True,
         help="""
         Allow members of nested Google groups to sign in.
@@ -387,10 +386,10 @@ class GoogleOAuthenticator(OAuthenticator, GoogleOAuth2Mixin):
         if checked_groups is None:
             checked_groups = set()
 
-        
-        service = self._setup_service(user_email_domain, http)
+        if not hasattr(self, 'service'):
+            self.service = self._setup_service(user_email_domain, http)
 
-        resp = service.groups().list(userKey=user_email).execute()
+        resp = self.service.groups().list(userKey=user_email).execute()
         user_groups = {
             g['email'].split('@')[0] for g in resp.get('groups', [{'email': None}])
         }

--- a/oauthenticator/google.py
+++ b/oauthenticator/google.py
@@ -393,17 +393,15 @@ class GoogleOAuthenticator(OAuthenticator, GoogleOAuth2Mixin):
         user_groups = {
             g['email'].split('@')[0] for g in resp.get('groups', [{'email': None}])
         }
-        print(user_groups)
 
         # Add the current user's groups to the checked groups
         checked_groups.update(user_groups)
 
         # Recursively check for nested groups if allowed
-        print(self.allow_nested_groups)
         if self.allow_nested_groups:
             for group in user_groups:
                 if group not in checked_groups:
-                    nested_groups = self._fetch_user_groups(group, user_email_domain, http, checked_groups)
+                    nested_groups = self._fetch_user_groups(group + user_email_domain, user_email_domain, http, checked_groups)
                     checked_groups.update(nested_groups)
 
         self.log.debug(f"user_email {user_email} is a member of {checked_groups}")

--- a/oauthenticator/google.py
+++ b/oauthenticator/google.py
@@ -408,16 +408,17 @@ class GoogleOAuthenticator(OAuthenticator, GoogleOAuth2Mixin):
 
         if self.allow_nested_groups:
             for group in member_groups:
-                if group not in processed_groups:
-                    processed_groups.add(group)
-                    nested_groups = self._fetch_member_groups(
-                        f"{group}@{user_email_domain}",
-                        user_email_domain,
-                        http,
-                        checked_groups,
-                        processed_groups,
-                    )
-                    checked_groups.update(nested_groups)
+                if group in processed_groups:
+                    continue
+                processed_groups.add(group)
+                nested_groups = self._fetch_member_groups(
+                    f"{group}@{user_email_domain}",
+                    user_email_domain,
+                    http,
+                    checked_groups,
+                    processed_groups,
+                )
+                checked_groups.update(nested_groups)
 
         self.log.debug(f"member_email {member_email} is a member of {checked_groups}")
         return checked_groups

--- a/oauthenticator/google.py
+++ b/oauthenticator/google.py
@@ -395,7 +395,7 @@ class GoogleOAuthenticator(OAuthenticator, GoogleOAuth2Mixin):
         }
 
         # Add the current user's groups to the checked groups
-        checked_groups.update(user_groups)
+        # checked_groups.update(user_groups)
 
         # Recursively check for nested groups if allowed
         if self.allow_nested_groups:

--- a/oauthenticator/google.py
+++ b/oauthenticator/google.py
@@ -393,11 +393,13 @@ class GoogleOAuthenticator(OAuthenticator, GoogleOAuth2Mixin):
         user_groups = {
             g['email'].split('@')[0] for g in resp.get('groups', [{'email': None}])
         }
+        print(user_groups)
 
         # Add the current user's groups to the checked groups
         checked_groups.update(user_groups)
 
         # Recursively check for nested groups if allowed
+        print(self.allow_nested_groups)
         if self.allow_nested_groups:
             for group in user_groups:
                 if group not in checked_groups:

--- a/oauthenticator/google.py
+++ b/oauthenticator/google.py
@@ -108,15 +108,8 @@ class GoogleOAuthenticator(OAuthenticator, GoogleOAuth2Mixin):
     allow_nested_groups = Bool(
         config=True,
         help="""
-        Allow members of nested Google groups to sign in and/or administer
-        TLJH. If `True` the authenticator will recursively check a user's 
-        group memberships and allow sign in and/or grant admin rights to
-        a user that is a member of a group that has nested membership in
-        any group in `allowed_google_groups` or `admin_google_groups`.
-
-        Use of this requires configuration of `gsuite_administrator`, and
-        `google_service_account_keys`, plus at least `allowed_google_groups` 
-        or `admin_google_groups`.
+        Include members of nested Google groups in `allowed_google_groups` and
+        `admin_google_groups` to sign in and/or administer JupyterHub.
         """,
     )
 

--- a/oauthenticator/google.py
+++ b/oauthenticator/google.py
@@ -408,12 +408,9 @@ class GoogleOAuthenticator(OAuthenticator, GoogleOAuth2Mixin):
         member_groups = {
             g['email'].split('@')[0] for g in resp.get('groups', []) if g.get('email')
         }
-
         self.log.debug(f"Fetched groups for {member_email}: {member_groups}")
 
         checked_groups.update(member_groups)
-        self.log.debug(f"Checked groups after update: {checked_groups}")
-
         self.log.debug(f"Checked groups after update: {checked_groups}")
 
         if self.allow_nested_groups:

--- a/oauthenticator/google.py
+++ b/oauthenticator/google.py
@@ -394,14 +394,11 @@ class GoogleOAuthenticator(OAuthenticator, GoogleOAuth2Mixin):
             g['email'].split('@')[0] for g in resp.get('groups', [{'email': None}])
         }
 
-        # Add the current user's groups to the checked groups
-        # checked_groups.update(user_groups)
-
         # Recursively check for nested groups if allowed
         if self.allow_nested_groups:
             for group in user_groups:
                 if group not in checked_groups:
-                    nested_groups = self._fetch_user_groups(group + user_email_domain, user_email_domain, http, checked_groups)
+                    nested_groups = self._fetch_user_groups(group + "@" + user_email_domain, user_email_domain, http, checked_groups)
                     checked_groups.update(nested_groups)
 
         self.log.debug(f"user_email {user_email} is a member of {checked_groups}")

--- a/oauthenticator/tests/test_google.py
+++ b/oauthenticator/tests/test_google.py
@@ -3,6 +3,7 @@ import json
 import logging
 import re
 from unittest import mock
+from unittest.mock import AsyncMock
 
 from pytest import fixture, mark, raises
 from traitlets.config import Config
@@ -380,3 +381,33 @@ async def test_deprecated_config(
 
     expected_log_tuple = (test_logger.name, expect_loglevel, expect_message)
     assert expected_log_tuple in captured_log_tuples
+
+
+@mark.asyncio
+async def test_nested_group_memberships():
+    mock_fetch_member_groups = AsyncMock(
+        return_value={'group1', 'nested_group1', 'nested_group2'}
+    )
+
+    authenticator = GoogleOAuthenticator()
+    authenticator._fetch_member_groups = mock_fetch_member_groups
+
+    user_info = {'name': 'testuser', 'email': 'testuser@example.com'}
+
+    result = await authenticator._fetch_member_groups(user_info['email'], 'example.com')
+    assert 'nested_group1' in result
+    assert 'nested_group2' in result
+
+
+@mark.asyncio
+async def test_user_not_in_nested_group():
+    mock_fetch_member_groups = AsyncMock(return_value={'group1', 'group2'})
+
+    authenticator = GoogleOAuthenticator()
+    authenticator._fetch_member_groups = mock_fetch_member_groups
+
+    user_info = {'name': 'testuser', 'email': 'testuser@example.com'}
+
+    result = await authenticator._fetch_member_groups(user_info['email'], 'example.com')
+    assert 'nested_group1' not in result
+    assert 'nested_group2' not in result

--- a/oauthenticator/tests/test_google.py
+++ b/oauthenticator/tests/test_google.py
@@ -211,7 +211,7 @@ async def test_google(
     handled_user_model = user_model("user1@example.com", "user1")
     handler = google_client.handler_for_user(handled_user_model)
     with mock.patch.object(
-        authenticator, "_fetch_user_groups", lambda *args: {"group1"}
+        authenticator, "_fetch_member_groups", lambda *args: {"group1"}
     ):
         auth_model = await authenticator.get_authenticated_user(handler, None)
 

--- a/oauthenticator/tests/test_google.py
+++ b/oauthenticator/tests/test_google.py
@@ -3,7 +3,6 @@ import json
 import logging
 import re
 from unittest import mock
-from unittest.mock import AsyncMock
 
 from pytest import fixture, mark, raises
 from traitlets.config import Config
@@ -257,7 +256,7 @@ async def test_hosted_domain_single_entry(
     expect_admin,
 ):
     """
-    Tests that sign in is restricted to the listed domain and that the username
+    Tests that sign in is restricted fetchto the listed domain and that the username
     represents the part before the `@domain.com` as expected when hosted_domain
     contains a single entry.
     """
@@ -381,33 +380,3 @@ async def test_deprecated_config(
 
     expected_log_tuple = (test_logger.name, expect_loglevel, expect_message)
     assert expected_log_tuple in captured_log_tuples
-
-
-@mark.asyncio
-async def test_nested_group_memberships():
-    mock_fetch_member_groups = AsyncMock(
-        return_value={'group1', 'nested_group1', 'nested_group2'}
-    )
-
-    authenticator = GoogleOAuthenticator()
-    authenticator._fetch_member_groups = mock_fetch_member_groups
-
-    user_info = {'name': 'testuser', 'email': 'testuser@example.com'}
-
-    result = await authenticator._fetch_member_groups(user_info['email'], 'example.com')
-    assert 'nested_group1' in result
-    assert 'nested_group2' in result
-
-
-@mark.asyncio
-async def test_user_not_in_nested_group():
-    mock_fetch_member_groups = AsyncMock(return_value={'group1', 'group2'})
-
-    authenticator = GoogleOAuthenticator()
-    authenticator._fetch_member_groups = mock_fetch_member_groups
-
-    user_info = {'name': 'testuser', 'email': 'testuser@example.com'}
-
-    result = await authenticator._fetch_member_groups(user_info['email'], 'example.com')
-    assert 'nested_group1' not in result
-    assert 'nested_group2' not in result

--- a/oauthenticator/tests/test_google.py
+++ b/oauthenticator/tests/test_google.py
@@ -256,7 +256,7 @@ async def test_hosted_domain_single_entry(
     expect_admin,
 ):
     """
-    Tests that sign in is restricted fetchto the listed domain and that the username
+    Tests that sign in is restricted to the listed domain and that the username
     represents the part before the `@domain.com` as expected when hosted_domain
     contains a single entry.
     """

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,3 @@
-aiohttp
 # jsonschema is used for validating authenticator configurations
 jsonschema
 jupyterhub>=2.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
+aiohttp
 # jsonschema is used for validating authenticator configurations
 jsonschema
 jupyterhub>=2.2


### PR DESCRIPTION
First go at this, closes #762.

`_fetch_user_groups` is now `_fetch_member_groups` since it now checks user _and_ group memberships in groups. I've updated some of the variable names from `user_*` to `member_*` to reflect this. Whether nested groups are taken into account is set by a new `allow_nested_groups` config option.

The Google Python APIs for this are quite limited and this causes some slowness in the login experience for those who are members of a lot of groups. 

I couldn't find where to update the [docs for this authenticator](https://oauthenticator.readthedocs.io/en/latest/reference/api/gen/oauthenticator.google.html#module-oauthenticator.google). When I try to suggest an edit on that page it goes to `reference/api/gen/oauthenticator.google.rst` which doesn't exist, I assume it's built elsewhere. If there's anywhere I can update this, let me know.

I am also not entirely sure how to go about adding a mock test for this case.

I'd love feedback on how to make this better. Thanks! 🚀 