### PR TITLE
[Google] Make looking up google groups far less blocking

### DIFF
--- a/oauthenticator/google.py
+++ b/oauthenticator/google.py
@@ -366,17 +366,17 @@ class GoogleOAuthenticator(OAuthenticator, GoogleOAuth2Mixin):
         http=None,
         checked_groups=None,
         processed_groups=None,
+        credentials=None,
     ):
         """
         Return a set with the google groups a given user/group is a member of, including nested groups if allowed.
         """
-        if not hasattr(self, 'credentials'):
-            self.credentials = await self._setup_credentials(user_email_domain)
 
+        credentials = credentials or await self._setup_credentials(user_email_domain)
         checked_groups = checked_groups or set()
         processed_groups = processed_groups or set()
 
-        headers = {'Authorization': f'Bearer {self.credentials.token}'}
+        headers = {'Authorization': f'Bearer {credentials.token}'}
         url = f'https://www.googleapis.com/admin/directory/v1/groups?userKey={member_email}'
         group_data = await self.httpfetch(
             url, headers=headers, label="fetching google groups"

--- a/oauthenticator/google.py
+++ b/oauthenticator/google.py
@@ -14,7 +14,7 @@ from .oauth2 import OAuthenticator
 
 class GoogleOAuthenticator(OAuthenticator, GoogleOAuth2Mixin):
     user_auth_state_key = "google_user"
-    _credentials = None
+    _service_credentials = None
 
     @default("login_service")
     def _login_service_default(self):
@@ -315,27 +315,29 @@ class GoogleOAuthenticator(OAuthenticator, GoogleOAuth2Mixin):
         # users should be explicitly allowed via config, otherwise they aren't
         return False
 
-    def _get_credentials(self, user_email_domain):
+    def _get_service_credentials(self, user_email_domain):
         """
         Returns the stored credentials or fetches and stores new ones.
 
         Checks if the credentials are valid before returning them. Refreshes
         if necessary and stores the refreshed credentials.
         """
-        if not self._credentials or not self._is_token_valid():
-            self._credentials = self._setup_credentials(user_email_domain)
+        if not self._service_credentials or not self._is_token_valid():
+            self._service_credentials = self._setup_service_credentials(
+                user_email_domain
+            )
 
-        return self._credentials
+        return self._service_credentials
 
     def _is_token_valid(self):
         """
         Checks if the stored token is valid.
         """
-        if not self._credentials:
+        if not self._service_credentials:
             return False
-        if not self._credentials.token:
+        if not self._service_credentials.token:
             return False
-        if self._credentials.expired:
+        if self._service_credentials.expired:
             return False
 
         return True
@@ -364,7 +366,7 @@ class GoogleOAuthenticator(OAuthenticator, GoogleOAuth2Mixin):
 
         return credentials
 
-    def _setup_credentials(self, user_email_domain):
+    def _setup_service_credentials(self, user_email_domain):
         """
         Set up the oauth credentials for Google API.
         """
@@ -399,7 +401,7 @@ class GoogleOAuthenticator(OAuthenticator, GoogleOAuth2Mixin):
         Return a set with the google groups a given user/group is a member of, including nested groups if allowed.
         """
 
-        credentials = credentials or self._get_credentials(user_email_domain)
+        credentials = credentials or self._get_service_credentials(user_email_domain)
         checked_groups = checked_groups or set()
         processed_groups = processed_groups or set()
 

--- a/oauthenticator/google.py
+++ b/oauthenticator/google.py
@@ -314,7 +314,7 @@ class GoogleOAuthenticator(OAuthenticator, GoogleOAuth2Mixin):
         # users should be explicitly allowed via config, otherwise they aren't
         return False
 
-    async def _service_client_credentials(self, scopes, user_email_domain):
+    def _service_client_credentials(self, scopes, user_email_domain):
         """
         Return a configured service client credentials for the API.
         """
@@ -338,11 +338,11 @@ class GoogleOAuthenticator(OAuthenticator, GoogleOAuth2Mixin):
 
         return credentials
 
-    async def _setup_credentials(self, user_email_domain):
+    def _setup_credentials(self, user_email_domain):
         """
         Set up the oauth credentials for Google API.
         """
-        credentials = await self._service_client_credentials(
+        credentials = self._service_client_credentials(
             scopes=[f"{self.google_api_url}/auth/admin.directory.group.readonly"],
             user_email_domain=user_email_domain,
         )
@@ -372,7 +372,7 @@ class GoogleOAuthenticator(OAuthenticator, GoogleOAuth2Mixin):
         Return a set with the google groups a given user/group is a member of, including nested groups if allowed.
         """
 
-        credentials = credentials or await self._setup_credentials(user_email_domain)
+        credentials = credentials or self._setup_credentials(user_email_domain)
         checked_groups = checked_groups or set()
         processed_groups = processed_groups or set()
 

--- a/oauthenticator/google.py
+++ b/oauthenticator/google.py
@@ -403,8 +403,8 @@ class GoogleOAuthenticator(OAuthenticator, GoogleOAuth2Mixin):
         """
         Return a set with the google groups a given user/group is a member of, including nested groups if allowed.
         """
-# WARNING: There's a race condition here if multiple users login at the same time.
-# This is currently ignored.
+        # WARNING: There's a race condition here if multiple users login at the same time.
+        # This is currently ignored.
         credentials = credentials or self._get_service_credentials(user_email_domain)
         token = credentials[user_email_domain].token
         checked_groups = checked_groups or set()

--- a/oauthenticator/google.py
+++ b/oauthenticator/google.py
@@ -403,7 +403,8 @@ class GoogleOAuthenticator(OAuthenticator, GoogleOAuth2Mixin):
         """
         Return a set with the google groups a given user/group is a member of, including nested groups if allowed.
         """
-
+# WARNING: There's a race condition here if multiple users login at the same time.
+# This is currently ignored.
         credentials = credentials or self._get_service_credentials(user_email_domain)
         token = credentials[user_email_domain].token
         checked_groups = checked_groups or set()

--- a/oauthenticator/google.py
+++ b/oauthenticator/google.py
@@ -340,7 +340,7 @@ class GoogleOAuthenticator(OAuthenticator, GoogleOAuth2Mixin):
 
     async def _setup_credentials(self, user_email_domain):
         """
-        Set up the service client for Google API.
+        Set up the oauth credentials for Google API.
         """
         credentials = await self._service_client_credentials(
             scopes=[f"{self.google_api_url}/auth/admin.directory.group.readonly"],

--- a/oauthenticator/tests/test_google.py
+++ b/oauthenticator/tests/test_google.py
@@ -3,6 +3,7 @@ import json
 import logging
 import re
 from unittest import mock
+from unittest.mock import AsyncMock
 
 from pytest import fixture, mark, raises
 from traitlets.config import Config
@@ -211,7 +212,7 @@ async def test_google(
     handled_user_model = user_model("user1@example.com", "user1")
     handler = google_client.handler_for_user(handled_user_model)
     with mock.patch.object(
-        authenticator, "_fetch_member_groups", lambda *args: {"group1"}
+        authenticator, "_fetch_member_groups", AsyncMock(return_value={"group1"})
     ):
         auth_model = await authenticator.get_authenticated_user(handler, None)
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
+aiohttp
 # jsonschema is used for validating authenticator configurations
 jsonschema
 jupyterhub>=2.2

--- a/setup.py
+++ b/setup.py
@@ -91,7 +91,6 @@ setup_args['extras_require'] = {
     # googlegroups is required for use of GoogleOAuthenticator configured with
     # either admin_google_groups and/or allowed_google_groups.
     'googlegroups': [
-        'google-api-python-client',
         'google-auth-oauthlib',
     ],
     # mediawiki is required for use of MWOAuthenticator
@@ -105,7 +104,6 @@ setup_args['extras_require'] = {
         'pytest-cov',
         'requests-mock',
         # dependencies from googlegroups:
-        'google-api-python-client',
         'google-auth-oauthlib',
         # dependencies from mediawiki:
         'mwoauth>=0.3.8',


### PR DESCRIPTION
Closes #607 and should only be merged after #763 as it is stacked. There might be some conflicts that I will resolve.

The main change was removing the creation of the `service` and instead retrieving an oauth token and using an asynchronous `aiohttp` session to get the groups. If Google ever releases an asynchronous client that uses the `service` then we should switch to that because it's more readable.