### PR TITLE
[Google] Remove redundant service credential checks

### DIFF
--- a/oauthenticator/google.py
+++ b/oauthenticator/google.py
@@ -344,14 +344,7 @@ class GoogleOAuthenticator(OAuthenticator, GoogleOAuth2Mixin):
         """
         Checks if the stored token is valid.
         """
-        if not self._service_credentials[user_email_domain]:
-            return False
-        if not self._service_credentials[user_email_domain].token:
-            return False
-        if self._service_credentials[user_email_domain].expired:
-            return False
-
-        return True
+        return self._service_credentials[user_email_domain].valid
 
     def _service_client_credentials(self, scopes, user_email_domain):
         """


### PR DESCRIPTION
This removes some redundancy in the service credential checks for Google.

According to their [docs](https://google-auth.readthedocs.io/en/master/reference/google.oauth2.service_account.html), the `valid` attribute returns `True` if `token` exists and isn't `expired`, so we can switch out those two checks for one. 

Further, the `_get_service_credentials()` method already checks whether `user_email_domain` is in `self._service_credentials` so this check isn't also needed in `_is_token_valid()`.