### PR TITLE
add refresh_user_hook

### DIFF
--- a/oauthenticator/tests/test_generic.py
+++ b/oauthenticator/tests/test_generic.py
@@ -547,6 +547,22 @@ async def test_refresh_user(get_authenticator, generic_client, enable_refresh_to
     # from here on, enable auth state required for refresh to do anything
     authenticator.enable_auth_state = True
 
+    # case: custom refresh hook
+    async def async_hook(authenticator, user, auth_state):
+        return True
+
+    authenticator.refresh_user_hook = async_hook
+    refreshed = await authenticator.refresh_user(user, handler)
+    assert refreshed is True
+
+    def sync_hook(authenticator, user, auth_state):
+        return False
+
+    authenticator.refresh_user_hook = sync_hook
+    refreshed = await authenticator.refresh_user(user, handler)
+    assert refreshed is False
+    authenticator.refresh_user_hook = None
+
     # case: no auth state, but auth state enabled needs refresh
     auth_without_state = auth_model.copy()
     auth_without_state["auth_state"] = None


### PR DESCRIPTION
allows customizing/overriding refresh_user behavior when the default isn't desirable.

testing `refresh_user` on 2i2c revealed a use case I had not considered, which is reliance on 'fake' users that don't actually exist in the oauth provider, and `refresh_user` means those users cannot actually do things, because their auth state is never valid. I added what should be the solution for 2i2c's health check accounts as an example in the docs. This makes enabling refresh_user by default a more disruptive change than I realized, if we want to switch the default to a more explicit opt-in. I still think it is the right thing to do in most cases, so in that way makes sense as a default (eventually, if not immediately).

I also hadn't realized that `refresh_pre_spawn` is overridden to True by default in OAuthenticator, which was surprising since it's been that way for _years_, despite `refresh_user` never having been implemented before now.

Maybe I should have done a beta of 17.2. We can yank 17.2, if folks feel that would take some pressure off, and then take a more careful beta process pushing this out again as 17.3.