### PR TITLE
[All] fix parsing of scope, often required for github email address

### DIFF
--- a/oauthenticator/oauth2.py
+++ b/oauthenticator/oauth2.py
@@ -1200,8 +1200,16 @@ class OAuthenticator(Authenticator):
         id_token = token_info.get("id_token", None)
         scope = token_info.get("scope", "")
 
+        # scope is a nonstandard field
+        # sometimes list, sometimes space-delimited str like the request,
+        # sometimes comma-delimited str (github)
         if isinstance(scope, str):
-            scope = scope.split(" ")
+            if " " in scope:
+                scope = scope.split(" ")
+            elif "," in scope:
+                scope = scope.split(",")
+            else:
+                scope = [scope]
 
         return {
             "access_token": access_token,

--- a/oauthenticator/tests/test_github.py
+++ b/oauthenticator/tests/test_github.py
@@ -33,6 +33,7 @@ def github_client(client):
         access_token_path='/login/oauth/access_token',
         user_path='/user',
         token_type='token',
+        scope="user:email,read:org",
     )
     return client
 
@@ -135,6 +136,7 @@ async def test_github(
             assert set(auth_model) == {"name", "admin", "auth_state"}
         assert auth_model["admin"] == expect_admin
         auth_state = auth_model["auth_state"]
+        assert auth_state["scope"] == ["user:email", "read:org"]
         assert json.dumps(auth_state)
         assert "access_token" in auth_state
         user_info = auth_state[authenticator.user_auth_state_key]


### PR DESCRIPTION
github returns scope as comma-separated string, not space-separated

this is required to get our handling of the `user:email` scope to populate the email address when 2 or more scopes are requested, because currently if you have `scope=["user:email","read:org"]`.

`scope` is not a defined part of the oauth standard token reply (it is space-separated everywhere it _is_ defined), but I've only seen space and comma-separated strings.