### PR TITLE
add OIDCOAuthenticator

### DIFF
--- a/docs/source/tutorials/provider-specific-setup/index.md
+++ b/docs/source/tutorials/provider-specific-setup/index.md
@@ -24,5 +24,6 @@ providers/globus.md
 providers/google.md
 providers/mediawiki.md
 providers/openshift.md
+providers/oidc.md
 providers/generic.md
 ```

--- a/docs/source/tutorials/provider-specific-setup/providers/generic.md
+++ b/docs/source/tutorials/provider-specific-setup/providers/generic.md
@@ -2,47 +2,12 @@
 
 # Generic OAuthenticator setups for various identity providers
 
-(tutorials:provider-specific:generic:oidc)=
-
 ## Setup for an OpenID Connect (OIDC) based identity provider
 
-The GenericOAuthenticator can be configured to be used against an OpenID Connect
-(OIDC) based identity provider, and this is an example demonstrating that.
-
-```python
-c.JupyterHub.authenticator_class = "generic-oauth"
-
-# OAuth2 application info
-# -----------------------
-c.GenericOAuthenticator.client_id = "some-client-id"
-c.GenericOAuthenticator.client_secret = "some-often-long-client-secret"
-
-# Identity provider info
-# ----------------------
-c.GenericOAuthenticator.authorize_url =
-c.GenericOAuthenticator.token_url = "https://accounts.example.com/auth/realms/example/protocol/openid-connect/token"
-c.GenericOAuthenticator.userdata_url = "https://accounts.example.com/auth/realms/example/protocol/openid-connect/userinfo"
-
-# What we request about the user
-# ------------------------------
-# scope represents requested information about the user, and since we configure
-# this against an OIDC based identity provider, we should request "openid" at
-# least.
-#
-# In this example we include "email" and "groups" as well, and then declare that
-# we should set the username based on the "email" key in the response, and read
-# group membership from the "groups" key in the response.
-#
-c.GenericOAuthenticator.scope = ["openid", "email", "groups"]
-c.GenericOAuthenticator.username_claim = "email"
-c.GenericOAuthenticator.auth_state_groups_key = "oauth_user.groups"
-
-# Authorization
-# -------------
-c.GenericOAuthenticator.allowed_users = {"user1@example.com"}
-c.GenericOAuthenticator.allowed_groups = {"staff"}
-c.GenericOAuthenticator.admin_users = {"user2@example.com"}
-c.GenericOAuthenticator.admin_groups = {"administrator"}
+```{note}
+OIDC Configuration has been simplified by adding [OIDCOAuthenticator](./oidc),
+which is equivalent to GenericOAuthenticator but requires less configuration options
+by following the OIDC Discovery standard.
 ```
 
 (tutorials:provider-specific:generic:moodle)=
@@ -121,68 +86,3 @@ c.GenericOAuthenticator.authorize_url = "https://oauth.yandex.ru/authorize"
 c.GenericOAuthenticator.token_url = "https://oauth.yandex.ru/token"
 c.GenericOAuthenticator.userdata_url = "https://login.yandex.ru/info"
 ```
-
-(tutorials:provider-specific:generic:awscognito)=
-
-## Setup for AWS Cognito
-
-First visit AWS official documentation on [Getting started with user pools] for
-info on how to register and configure a cognito user pool and an associated
-OAuth2 application.
-
-[Getting started with user pools]: https://docs.aws.amazon.com/cognito/latest/developerguide/getting-started-user-pools.html
-
-Set the above settings in your `jupyterhub_config.py`:
-
-```python
-c.JupyterHub.authenticator_class = "generic-oauth"
-c.OAuthenticator.oauth_callback_url = "https://[your-host]/hub/oauth_callback"
-c.OAuthenticator.client_id = "[your oauth2 application id]"
-c.OAuthenticator.client_secret = "[your oauth2 application secret]"
-
-c.GenericOAuthenticator.login_service = "AWS Cognito"
-c.GenericOAuthenticator.username_claim = "login"
-
-c.GenericOAuthenticator.authorize_url = "https://your-AWSCognito-domain/oauth2/authorize"
-c.GenericOAuthenticator.token_url = "https://your-AWSCognito-domain/oauth2/token"
-c.GenericOAuthenticator.userdata_url = "https://your-AWSCognito-domain/oauth2/userInfo"
-```
-
-## Setup for ORCID iD
-
-```{note}
-The `GenericOAuthenticator` will by default lowercase your username. For example, an ORCID iD of `0000-0002-9079-593X` will produce a JupyterHub username of `0000-0002-9079-593x`.
-```
-
-Follow the ORCID [API Tutorial](https://info.orcid.org/documentation/api-tutorials/api-tutorial-get-and-authenticated-orcid-id/) to create an application via the Developer Tools submenu after clicking on your name in the top right of the page.
-
-Edit your `jupyterhub_config.py` with the following:
-
-```python
-c.JupyterHub.authenticator_class = "generic-oauth"
-
-# Fill these in with your values
-c.GenericOAuthenticator.oauth_callback_url = "YOUR CALLBACK URL"
-c.GenericOAuthenticator.client_id = "YOUR CLIENT ID"
-c.GenericOAuthenticator.client_secret = "YOUR CLIENT SECRET"
-
-c.GenericOAuthenticator.login_service = "ORCID iD" # Text of login button
-c.GenericOAuthenticator.authorize_url = "https://orcid.org/oauth/authorize"
-c.GenericOAuthenticator.token_url = "https://orcid.org/oauth/token"
-c.GenericOAuthenticator.scope = ["/authenticate", "openid"]
-c.GenericOAuthenticator.userdata_url = "https://orcid.org/oauth/userinfo"
-c.GenericOAuthenticator.username_claim = "sub"
-```
-
-The above `username_claim` value selects the ORCID iD from the JSON response as the individual's JupyterHub username. An example response is below:
-
-```json
-{
-  "sub": "0000-0002-2601-8132",
-  "name": "Credit Name",
-  "family_name": "Jones",
-  "given_name": "Tom"
-}
-```
-
-Please refer to the [Authorization Code Flow](https://github.com/ORCID/ORCID-Source/blob/main/orcid-web/ORCID_AUTH_WITH_OPENID_CONNECT.md#authorization-code-flow) section of the ORCID documentation for more information.

--- a/docs/source/tutorials/provider-specific-setup/providers/oidc.md
+++ b/docs/source/tutorials/provider-specific-setup/providers/oidc.md
@@ -1,0 +1,130 @@
+(tutorials:provider-specific:oidc)=
+(tutorials:provider-specific:generic:oidc)=
+
+# OpenID Connect (OIDC) Setup
+
+{class}`.OIDCOAuthenticator` is an extension of GenericOAuthenticator,
+but which loads some standard configuration from `.well-known/openid-configuration`.
+This means you'll have fewer options that you need to configure for most
+OIDC providers.
+
+## JupyterHub configuration
+
+Your `jupyterhub_config.py` file should look something like this:
+
+```python
+c.JupyterHub.authenticator_class = "oidc"
+c.OAuthenticator.oauth_callback_url = "https://[your-domain]/hub/oauth_callback"
+c.OAuthenticator.client_id = "[your oauth2 application id]"
+c.OAuthenticator.client_secret = "[your oauth2 application secret]"
+c.JupyterHub.openid_provider_url = "https://yourprovider.example.org"
+```
+
+`openid_provider_url` should be the base URL of your provider.
+OIDCOAuthenticator will fetch `{openid_provider_url}/.well-known/openid-configuration`
+to set up the following configuration:
+
+| OAuthenticator option | openid-configuration key | notes                   |
+| --------------------- | ------------------------ | ----------------------- |
+| `authorize_url`       | `authorization_endpoint` |                         |
+| `token_url`           | `token_endpoint`         |                         |
+| `jwks_uri`            | `jwks_uri`               | for verifying id tokens |
+| `jwt_issuer`          | `issuer`                 | for verifying id tokens |
+| `userdata_url`        | `userinfo_endpoint`      | if defined (not always) |
+
+You can get the exact same behavior as `OIDCOAuthenticator` with the base `OAuthenticator`, if you set all of these parameters by hand.
+
+```{note}
+not all providers define `userinfo_endpoint`.
+You can _either_ set `c.OAuthenticator.userdata_url`,
+or set `c.OAuthenticator.userdata_from_id_token = True` to rely on the claims in the `id_token` of the token response.
+```
+
+Examples of `openid_provider_url` for common providers:
+
+- auth0: `https://$yourdomain.auth0.com`
+- github: `https://github.com/login/oauth`
+- google: `https://accounts.google.com`
+- orcid: `https://orcid.org`
+
+## Additional configuration
+
+Typically, when configuring with OIDC, you'll need to configure the `scope`, which will always include `openid`.
+The remaining scopes may vary.
+
+The default `username_claim` for OIDCOAuthenticator is `sub`,
+but is very likely to vary, depending on your provider.
+Make sure that you use a _verified_ and _unique_ claim from your
+
+```python
+c.OIDCOAuthenticator.scope = ["openid", "email", "groups"]
+c.OIDCOAuthenticator.username_claim = "sub" # the default
+c.OIDCOAuthenticator.auth_state_groups_key = "oauth_user.groups"
+```
+
+You will likely want to set the `user`
+
+And as with all Authenticators, you will need to `allow` specific users or groups.
+
+(tutorials:provider-specific:generic:orcid)=
+(tutorials:provider-specific:oidc:orcid)=
+
+## Setup for ORCID iD
+
+```{note}
+The `OAuthenticator` will by default lowercase your username. For example, an ORCID iD of `0000-0002-9079-593X` will produce a JupyterHub username of `0000-0002-9079-593x`.
+```
+
+Follow the ORCID [API Tutorial](https://info.orcid.org/documentation/api-tutorials/api-tutorial-get-and-authenticated-orcid-id/) to create an application via the Developer Tools submenu after clicking on your name in the top right of the page.
+
+Edit your `jupyterhub_config.py` with the following:
+
+```python
+c.JupyterHub.authenticator_class = "oidc"
+
+# Fill these in with your values
+c.OIDCOAuthenticator.oauth_callback_url = "YOUR CALLBACK URL"
+c.OIDCOAuthenticator.client_id = "YOUR CLIENT ID"
+c.OIDCOAuthenticator.client_secret = "YOUR CLIENT SECRET"
+
+c.OIDCOAuthenticator.login_service = "ORCID iD" # Text of login button
+c.OIDCOAuthenticator.openid_provider_url = "https://orcid.org"
+c.GenericOAuthenticator.scope = ["/authenticate", "openid"]
+```
+
+The default `username_claim` of `sub` selects the ORCID iD from the JSON response as the individual's JupyterHub username. An example response is below:
+
+```json
+{
+  "sub": "0000-0002-2601-8132",
+  "name": "Credit Name",
+  "family_name": "Jones",
+  "given_name": "Tom"
+}
+```
+
+Please refer to the [Authorization Code Flow](https://github.com/ORCID/ORCID-Source/blob/main/orcid-web/ORCID_AUTH_WITH_OPENID_CONNECT.md#authorization-code-flow) section of the ORCID documentation for more information.
+
+(tutorials:provider-specific:generic:awscognito)=
+(tutorials:provider-specific:oidc:awscognito)=
+
+## Setup for AWS Cognito
+
+First visit AWS official documentation on [Getting started with user pools] for
+info on how to register and configure a cognito user pool and an associated
+OAuth2 application.
+
+[Getting started with user pools]: https://docs.aws.amazon.com/cognito/latest/developerguide/getting-started-user-pools.html
+
+Set the above settings in your `jupyterhub_config.py`:
+
+```python
+c.JupyterHub.authenticator_class = "oidc"
+c.OAuthenticator.oauth_callback_url = "https://[your-host]/hub/oauth_callback"
+c.OAuthenticator.client_id = "[your oauth2 application id]"
+c.OAuthenticator.client_secret = "[your oauth2 application secret]"
+
+c.OAuthenticator.login_service = "AWS Cognito"
+c.OAuthenticator.username_claim = "login"
+c.OIDCOAuthenticator.openid_provider_url = "https://your-AWSCognito-domain"
+```

--- a/oauthenticator/oauth2.py
+++ b/oauthenticator/oauth2.py
@@ -28,6 +28,7 @@ from traitlets import (
     Bool,
     Callable,
     Dict,
+    Instance,
     List,
     Set,
     Unicode,
@@ -490,6 +491,21 @@ class OAuthenticator(Authenticator):
         Code Flow
         <https://openid.net/specs/openid-connect-core-1_0.html#CodeFlowAuth>`_
         in the OIDC Core standard document.
+        """,
+    )
+
+    jwt_issuer = Unicode(
+        None,
+        allow_none=True,
+        config=True,
+        help="""
+        Set the issuer for validating JWT id_token issuers.
+
+        If set, issuer will be validated.
+
+        OIDC sets this from openid-configuration, no need to configure.
+
+        .. versionadded:: 17.4
         """,
     )
 
@@ -1107,6 +1123,59 @@ class OAuthenticator(Authenticator):
 
         return token_info
 
+    jwks_uri = Unicode(
+        config=True,
+        help="""
+        URI for JSON Web Keys (JWKs)
+
+        e.g. for OpenID Connect clients.
+
+        Used for verifying signatures of JWTs.
+
+        Default: unset, signatures will not be verified
+        (which is secure, per OIDC spec (core v1.0 § 3.1.3.7.6)).
+
+        OIDCOAuthenticator sets this from openid-configuration, no need to configure.
+
+        .. versionadded:: 17.4
+        """,
+    )
+
+    jwks_client = Instance(jwt.PyJWKClient, allow_none=True, default_value=None)
+
+    @default("jwks_client")
+    def _default_jwks_client(self):
+        if not self.jwks_uri:
+            return None
+        self.log.debug(f"Loading jwks client from {self.jwks_uri}")
+        return jwt.PyJWKClient(self.jwks_uri)
+
+    async def decode_jwt(self, token):
+        """Validate and decode a JSON Web Token (JWT)"""
+
+        # if a jwks client is configured, verify signature
+        if self.jwks_client:
+            signing_key = self.jwks_client.get_signing_key_from_jwt(token)
+        else:
+            signing_key = None
+        # Here we parse the id token. Note that per OIDC spec (core v1.0 sect. 3.1.3.7.6) we can skip
+        # signature validation as the hub has obtained the tokens from the id provider directly (using https).
+        # Google suggests all token validation may be skipped assuming the provider is trusted.
+        # https://openid.net/specs/openid-connect-core-1_0.html#IDTokenValidation
+        # https://developers.google.com/identity/openid-connect/openid-connect#obtainuserinfo
+        return jwt.decode(
+            token,
+            key=signing_key,
+            audience=self.client_id,
+            issuer=self.jwt_issuer,
+            options=dict(
+                verify_signature=signing_key is not None,
+                verify_aud=True,
+                verify_exp=True,
+                verify_iss=self.jwt_issuer is not None,
+            ),
+        )
+
     async def token_to_user(self, token_info):
         """
         Determines who the logged-in user by sending a "GET" request to
@@ -1132,18 +1201,7 @@ class OAuthenticator(Authenticator):
                     f"An id token was not returned: {token_info}\nPlease configure authenticator.userdata_url",
                 )
             try:
-                # Here we parse the id token. Note that per OIDC spec (core v1.0 sect. 3.1.3.7.6) we can skip
-                # signature validation as the hub has obtained the tokens from the id provider directly (using
-                # https). Google suggests all token validation may be skipped assuming the provider is trusted.
-                # https://openid.net/specs/openid-connect-core-1_0.html#IDTokenValidation
-                # https://developers.google.com/identity/openid-connect/openid-connect#obtainuserinfo
-                return jwt.decode(
-                    id_token,
-                    audience=self.client_id,
-                    options=dict(
-                        verify_signature=False, verify_aud=True, verify_exp=True
-                    ),
-                )
+                return await self.decode_jwt(id_token)
             except Exception as err:
                 raise web.HTTPError(
                     500, f"Unable to decode id token: {id_token}\n{err}"

--- a/oauthenticator/oidc.py
+++ b/oauthenticator/oidc.py
@@ -1,7 +1,6 @@
 import inspect
 import os
 import time
-from functools import wraps
 
 from jupyterhub.auth import LocalAuthenticator
 from traitlets import Unicode, default
@@ -102,14 +101,12 @@ class OIDCOAuthenticator(OAuthenticator):
         if not self.logout_redirect_url:
             self.logout_redirect_url = cfg.get("end_session_endpoint", "")
 
-    @wraps(OAuthenticator.authenticate)
     async def authenticate(self, *args, **kwargs):
         if not self.openid_configuration:
             await self._load_openid_configuration()
         return await super().authenticate(*args, **kwargs)
 
     def _token_to_auth_model(self, token_info):
-
         return super()._token_to_auth_model(token_info)
 
 

--- a/oauthenticator/oidc.py
+++ b/oauthenticator/oidc.py
@@ -101,7 +101,9 @@ class OIDCOAuthenticator(OAuthenticator):
         if not self.logout_redirect_url:
             self.logout_redirect_url = cfg.get("end_session_endpoint", "")
 
+    # empty docstring to avoid showing up in api docs
     async def authenticate(self, *args, **kwargs):
+        """"""
         if not self.openid_configuration:
             await self._load_openid_configuration()
         return await super().authenticate(*args, **kwargs)

--- a/oauthenticator/oidc.py
+++ b/oauthenticator/oidc.py
@@ -1,0 +1,110 @@
+import inspect
+import os
+import time
+from functools import wraps
+
+from jupyterhub.auth import LocalAuthenticator
+from traitlets import Unicode, default
+
+from .oauth2 import OAuthenticator, OAuthLoginHandler
+
+
+class OIDCLoginHandler(OAuthLoginHandler):
+    async def get(self):
+        # load oidc configuration before handling login page
+        if not self.authenticator.openid_configuration:
+            await self.authenticator._load_openid_configuration()
+        r = super().get()
+        if inspect.isawaitable(r):
+            await r
+
+
+class OIDCOAuthenticator(OAuthenticator):
+    """
+    Subclass of OAuthenticator that loads configuration from OpenIDConnect
+
+    Must provide OIDC Discovery 1.0
+
+    Typically only requires
+
+    ref: https://openid.net/specs/openid-connect-discovery-1_0.html
+
+    - loads URLs from .well-known/openid-configuration
+    - handles JWKs
+    """
+
+    login_handler = OIDCLoginHandler
+
+    openid_provider_url = Unicode(
+        config=True,
+        help="""
+        The base URL for the OpenID Connect (OIDC) provider.
+
+        ${PROVIDER_URL}/.well-known/openid-configuration MUST exist.
+
+        Examples:
+        - https://some-keycloak.domain/realms/realmname
+        - https://accounts.google.com
+        - https://samples.auth0.com
+
+        Required.
+    """,
+    )
+
+    @default("openid_provider_url")
+    def _openid_provider_url_default(self):
+        return os.environ.get("OPENID_PROVIDER_URL", "")
+
+    # loaded from Discovery, not configurable
+    openid_configuration = None
+    _last_openid_configuration_fetch_time = None
+
+    @default("scope")
+    def _scope_default(self):
+        return ["openid"]
+
+    async def _load_openid_configuration(self):
+        # for required/optional fields, see
+        # https://openid.net/specs/openid-connect-discovery-1_0.html#ProviderMetadata
+        if not self.openid_provider_url:
+            raise ValueError(
+                f"{self.__class__}.openid_provider_url unset. Please set it."
+            )
+        openid_configuration_url = (
+            self.openid_provider_url.rstrip("/") + "/.well-known/openid-configuration"
+        )
+        self.log.info(f"Loading OIDC Configuration from {openid_configuration_url}")
+        self.openid_configuration = cfg = await self.httpfetch(openid_configuration_url)
+        self._last_openid_configuration_fetch_time = time.monotonic()
+        # required fields
+        self.jwt_issuer = cfg["issuer"]
+        self.token_url = cfg["token_endpoint"]
+        self.authorize_url = cfg["authorization_endpoint"]
+        self.jwks_uri = cfg["jwks_uri"]
+
+        # optional fields for OIDC, maybe optional for us
+        if "userinfo_endpoint" in cfg:
+            if not self.userdata_from_id_token:
+                self.userdata_url = cfg["userinfo_endpoint"]
+        elif not self.userdata_from_id_token:
+            raise ValueError(
+                f"userinfo_endpoint not found in {openid_configuration_url}, but userdata_from_id_token not set."
+            )
+
+        # optional fields
+        if not self.logout_redirect_url:
+            self.logout_redirect_url = cfg.get("end_session_endpoint", "")
+
+    @wraps(OAuthenticator.authenticate)
+    async def authenticate(self, *args, **kwargs):
+        if not self.openid_configuration:
+            await self._load_openid_configuration()
+        return await super().authenticate(*args, **kwargs)
+
+    def _token_to_auth_model(self, token_info):
+
+        return super()._token_to_auth_model(token_info)
+
+
+class LocalOIDCOAuthenticator(LocalAuthenticator, OIDCOAuthenticator):
+    """A version that mixes in local system user creation"""

--- a/oauthenticator/oidc.py
+++ b/oauthenticator/oidc.py
@@ -23,14 +23,16 @@ class OIDCOAuthenticator(OAuthenticator):
     """
     Subclass of OAuthenticator that loads configuration from OpenIDConnect
 
-    Must provide OIDC Discovery 1.0
+    Provider must provide OIDC Discovery 1.0.
 
-    Typically only requires
+    Typically only requires `OIDCOAuthenticator.openid_provider_url` to be set.
 
     ref: https://openid.net/specs/openid-connect-discovery-1_0.html
 
-    - loads URLs from .well-known/openid-configuration
-    - handles JWKs
+    - loads URLs from `${openid_provider_url}/.well-known/openid-configuration`
+    - handles JWKs for token signing
+
+    .. versionadded:: 17.5
     """
 
     login_handler = OIDCLoginHandler

--- a/oauthenticator/oidc.py
+++ b/oauthenticator/oidc.py
@@ -43,9 +43,9 @@ class OIDCOAuthenticator(OAuthenticator):
         ${PROVIDER_URL}/.well-known/openid-configuration MUST exist.
 
         Examples:
-        - https://some-keycloak.domain/realms/realmname
-        - https://accounts.google.com
-        - https://samples.auth0.com
+        - `https://some-keycloak.domain/realms/realmname`
+        - `https://accounts.google.com`
+        - `https://samples.auth0.com`
 
         Required.
     """,

--- a/oauthenticator/oidc.py
+++ b/oauthenticator/oidc.py
@@ -55,6 +55,11 @@ class OIDCOAuthenticator(OAuthenticator):
     def _openid_provider_url_default(self):
         return os.environ.get("OPENID_PROVIDER_URL", "")
 
+    @default("username_claim")
+    def _default_username_claim(self):
+        # change default username claim to oidc-standard 'sub'
+        return os.environ.get('OAUTH2_USERNAME_KEY', 'sub')
+
     # loaded from Discovery, not configurable
     openid_configuration = None
     _last_openid_configuration_fetch_time = None

--- a/oauthenticator/tests/mocks.py
+++ b/oauthenticator/tests/mocks.py
@@ -10,7 +10,6 @@ from urllib.parse import parse_qs, urlparse
 
 import jwt
 import pytest
-from cryptography.hazmat.primitives import serialization
 from cryptography.hazmat.primitives.asymmetric import rsa
 from jwt.algorithms import RSAAlgorithm
 from tornado import web
@@ -150,12 +149,6 @@ def setup_oauth_mock(
     jwk["use"] = "sig"
     jwk["alg"] = "RS256"
     jwk["kid"] = str(uuid.uuid4())
-    client.private_key_bytes = client.private_key.private_bytes(
-        encoding=serialization.Encoding.PEM,
-        format=serialization.PrivateFormat.PKCS8,
-        encryption_algorithm=serialization.NoEncryption(),
-    )
-
     client.private_jwk = jwt.PyJWK(
         RSAAlgorithm.to_jwk(client.private_key, as_dict=True)
     )
@@ -230,10 +223,7 @@ def setup_oauth_mock(
             )
             jwt_user.update(user)
             model['id_token'] = jwt.encode(
-                jwt_user,
-                key=client.private_key_bytes,
-                headers={"kid": jwk["kid"]},
-                algorithm="RS256",
+                jwt_user, key=client.private_jwk, headers={"kid": jwk["kid"]}
             )
 
         return model

--- a/oauthenticator/tests/mocks.py
+++ b/oauthenticator/tests/mocks.py
@@ -10,6 +10,7 @@ from urllib.parse import parse_qs, urlparse
 
 import jwt
 import pytest
+from cryptography.hazmat.primitives import serialization
 from cryptography.hazmat.primitives.asymmetric import rsa
 from jwt.algorithms import RSAAlgorithm
 from tornado import web
@@ -149,6 +150,12 @@ def setup_oauth_mock(
     jwk["use"] = "sig"
     jwk["alg"] = "RS256"
     jwk["kid"] = str(uuid.uuid4())
+    client.private_key_bytes = client.private_key.private_bytes(
+        encoding=serialization.Encoding.PEM,
+        format=serialization.PrivateFormat.PKCS8,
+        encryption_algorithm=serialization.NoEncryption(),
+    )
+
     client.private_jwk = jwt.PyJWK(
         RSAAlgorithm.to_jwk(client.private_key, as_dict=True)
     )
@@ -224,7 +231,7 @@ def setup_oauth_mock(
             jwt_user.update(user)
             model['id_token'] = jwt.encode(
                 jwt_user,
-                key=client.private_jwk.private_bytes(),
+                key=client.private_key_bytes,
                 headers={"kid": jwk["kid"]},
                 algorithm="RS256",
             )

--- a/oauthenticator/tests/mocks.py
+++ b/oauthenticator/tests/mocks.py
@@ -223,7 +223,10 @@ def setup_oauth_mock(
             )
             jwt_user.update(user)
             model['id_token'] = jwt.encode(
-                jwt_user, key=client.private_jwk, headers={"kid": jwk["kid"]}
+                jwt_user,
+                key=client.private_jwk.private_bytes(),
+                headers={"kid": jwk["kid"]},
+                algorithm="RS256",
             )
 
         return model

--- a/oauthenticator/tests/mocks.py
+++ b/oauthenticator/tests/mocks.py
@@ -8,7 +8,10 @@ from io import BytesIO
 from unittest.mock import Mock
 from urllib.parse import parse_qs, urlparse
 
+import jwt
 import pytest
+from cryptography.hazmat.primitives.asymmetric import rsa
+from jwt.algorithms import RSAAlgorithm
 from tornado import web
 from tornado.httpclient import HTTPResponse
 from tornado.httputil import HTTPServerRequest
@@ -109,6 +112,7 @@ def setup_oauth_mock(
     token_request_style='post',
     enable_refresh_tokens=False,
     scope="",
+    client_id="oauthenticator-tests",
 ):
     """setup the mock client for OAuth
 
@@ -137,6 +141,18 @@ def setup_oauth_mock(
     client.access_tokens = access_tokens = {}
     client.refresh_tokens = refresh_tokens = {}
     client.enable_refresh_tokens = enable_refresh_tokens
+    client.private_key = rsa.generate_private_key(
+        public_exponent=65537,
+        key_size=2048,
+    )
+    jwk = RSAAlgorithm.to_jwk(client.private_key.public_key(), as_dict=True)
+    jwk["use"] = "sig"
+    jwk["alg"] = "RS256"
+    jwk["kid"] = str(uuid.uuid4())
+    client.private_jwk = jwt.PyJWK(
+        RSAAlgorithm.to_jwk(client.private_key, as_dict=True)
+    )
+    jwks = client.jwks = {"keys": [jwk]}
 
     def access_token(request):
         """Handler for access token endpoint
@@ -200,6 +216,16 @@ def setup_oauth_mock(
             model['scope'] = scope
         if 'id_token' in user:
             model['id_token'] = user['id_token']
+        else:
+            jwt_user = dict(
+                aud=client_id,
+                iss=f"https://{host}",
+            )
+            jwt_user.update(user)
+            model['id_token'] = jwt.encode(
+                jwt_user, key=client.private_jwk, headers={"kid": jwk["kid"]}
+            )
+
         return model
 
     def get_user(request):
@@ -226,6 +252,21 @@ def setup_oauth_mock(
             )
         return access_tokens.get(token)
 
+    def openid_configuration(request):
+        origin = f"https://{host}"
+        well_known = f"{origin}/.well-known"
+        return {
+            "issuer": origin,
+            "authorization_url": f"{well_known}/openid-configuration",
+            "authorization_endpoint": f"{origin}/authorize",
+            "token_endpoint": f"{origin}{access_token_path}",
+            "userinfo_endpoint": f"{origin}{user_path}",
+            "jwks_uri": f"{well_known}/jwks",
+        }
+
+    def openid_jwks():
+        return jwks
+
     if isinstance(host, str):
         hosts = [host]
     else:
@@ -236,6 +277,8 @@ def setup_oauth_mock(
             [
                 (access_token_path, access_token),
                 (user_path, get_user),
+                ("/.well-known/openid-configuration", openid_configuration),
+                ("/.well-known/jwks", openid_jwks),
             ],
         )
 

--- a/oauthenticator/tests/test_oidc.py
+++ b/oauthenticator/tests/test_oidc.py
@@ -122,7 +122,6 @@ async def test_oidc(
     c = Config()
     c.OIDCOAuthenticator = Config(class_config)
     c.OIDCOAuthenticator.openid_provider_url = openid_provider_url
-    c.OIDCOAuthenticator.username_claim = "sub"
     handled_user_model = user_model()
     handler = oidc_client.handler_for_user(handled_user_model)
 

--- a/oauthenticator/tests/test_oidc.py
+++ b/oauthenticator/tests/test_oidc.py
@@ -2,8 +2,8 @@ import json
 
 import jwt
 import pytest
+from cryptography.hazmat.primitives import serialization
 from cryptography.hazmat.primitives.asymmetric import rsa
-from jwt.algorithms import RSAAlgorithm
 from pytest import fixture, mark, param
 from tornado import web
 from traitlets.config import Config
@@ -187,7 +187,7 @@ async def test_oidc_id_token(
         "iss": openid_provider_url,
     }
     id_token_content.update(handled_user_model)
-    private_jwk = oidc_client.private_jwk
+    private_key_bytes = oidc_client.private_key_bytes
     kid = oidc_client.jwks["keys"][0]["kid"]
     if id_token_fields:
         id_token_content.update(id_token_fields)
@@ -197,10 +197,14 @@ async def test_oidc_id_token(
                 public_exponent=65537,
                 key_size=2048,
             )
-            private_jwk = jwt.PyJWK(RSAAlgorithm.to_jwk(private_key, as_dict=True))
+            private_key_bytes = private_key.private_bytes(
+                encoding=serialization.Encoding.PEM,
+                format=serialization.PrivateFormat.PKCS8,
+                encryption_algorithm=serialization.NoEncryption(),
+            )
 
     handled_user_model["id_token"] = jwt.encode(
-        id_token_content, key=private_jwk, algorithm="RS256", headers={"kid": kid}
+        id_token_content, key=private_key_bytes, algorithm="RS256", headers={"kid": kid}
     )
     handler = oidc_client.handler_for_user(handled_user_model)
 

--- a/oauthenticator/tests/test_oidc.py
+++ b/oauthenticator/tests/test_oidc.py
@@ -1,0 +1,227 @@
+import json
+
+import jwt
+import pytest
+from cryptography.hazmat.primitives.asymmetric import rsa
+from jwt.algorithms import RSAAlgorithm
+from pytest import fixture, mark, param
+from tornado import web
+from traitlets.config import Config
+
+from ..oidc import OIDCOAuthenticator
+from .mocks import setup_oauth_mock
+
+openid_provider_host = "oidc.example.com"
+openid_provider_url = f"https://{openid_provider_host}"
+client_id = "oidc-tests"
+
+
+@fixture
+def oidc_client(client):
+    setup_oauth_mock(
+        client,
+        host=openid_provider_host,
+        access_token_path='/oauth/token',
+        user_path='/userinfo',
+        client_id=client_id,
+    )
+    return client
+
+
+def user_model():
+    """Return a user model"""
+    return {
+        "email": "user1@example.com",
+        "sub": "user1",
+        "groups": ["group1"],
+    }
+
+
+@mark.parametrize(
+    "class_config,expect_allowed,expect_admin",
+    [
+        # no allow config tested
+        param({}, False, None, id="not_allowed"),
+        # allow config, individually tested
+        param({"allow_all": True}, True, None, id="allow_all"),
+        param({"allowed_users": {"user1"}}, True, None, id="allowed_user"),
+        param({"allowed_users": {"not-test-user"}}, False, None, id="not_allowed_user"),
+        param({"admin_users": {"user1"}}, True, True, id="admin_users"),
+        param({"admin_users": {"not-test-user"}}, False, None, id="not_admin_users"),
+        # allow config, some combinations of two tested
+        param(
+            {
+                "allow_all": False,
+                "allowed_users": {"not-test-user"},
+            },
+            False,
+            None,
+            id="not_allow_all,not_allowed_user",
+        ),
+        param(
+            # "11",
+            {
+                "admin_users": {"user1"},
+                "allowed_users": {"not-test-user"},
+            },
+            True,
+            True,
+            id="admin_user_not_allowed_users",
+        ),
+        # common tests with allowed_groups and manage_groups
+        param(
+            # "20",
+            {
+                "allowed_groups": {"group1"},
+                "auth_state_groups_key": "oauth_user.groups",
+                "manage_groups": True,
+            },
+            True,
+            None,
+            id="allowed_groups",
+        ),
+        param(
+            # "21",
+            {
+                "allowed_groups": {"test-user-not-in-group"},
+                "auth_state_groups_key": "oauth_user.groups",
+                "manage_groups": True,
+            },
+            False,
+            None,
+            id="not_allowed_groups",
+        ),
+        param(
+            {
+                "admin_groups": {"group1"},
+                "auth_state_groups_key": "oauth_user.groups",
+                "manage_groups": True,
+            },
+            True,
+            True,
+            id="admin_groups",
+        ),
+        param(
+            {
+                "admin_groups": {"test-user-not-in-group"},
+                "auth_state_groups_key": "oauth_user.groups",
+                "manage_groups": True,
+            },
+            False,
+            False,
+            id="not_admin_groups",
+        ),
+    ],
+)
+async def test_oidc(
+    oidc_client,
+    class_config,
+    expect_allowed,
+    expect_admin,
+):
+    c = Config()
+    c.OIDCOAuthenticator = Config(class_config)
+    c.OIDCOAuthenticator.openid_provider_url = openid_provider_url
+    c.OIDCOAuthenticator.username_claim = "sub"
+    handled_user_model = user_model()
+    handler = oidc_client.handler_for_user(handled_user_model)
+
+    authenticator = OIDCOAuthenticator(config=c)
+    auth_model = await authenticator.get_authenticated_user(handler, None)
+
+    if expect_allowed:
+        assert auth_model
+        if authenticator.manage_groups:
+            assert set(auth_model) == {"name", "admin", "auth_state", "groups"}
+        else:
+            assert set(auth_model) == {"name", "admin", "auth_state"}
+        assert auth_model["admin"] == expect_admin
+        auth_state = auth_model["auth_state"]
+        assert json.dumps(auth_state)
+        assert "access_token" in auth_state
+        user_info = auth_state[authenticator.user_auth_state_key]
+        assert user_info == handled_user_model
+        assert auth_model["name"] == user_info[authenticator.username_claim]
+    else:
+        assert auth_model is None
+
+
+@mark.parametrize(
+    "id_token_fields, expect_success",
+    [
+        param(
+            {"aud": "wrong"},
+            "error",
+            id="wrong audience",
+        ),
+        param(
+            {"iss": "wrong"},
+            "error",
+            id="wrong issuer",
+        ),
+        param(
+            {"kid": "wrong"},
+            "error",
+            id="wrong key",
+        ),
+        param(
+            {"sub": "user1"},
+            True,
+            id="ok",
+        ),
+    ],
+)
+async def test_oidc_id_token(
+    oidc_client,
+    id_token_fields,
+    expect_success,
+):
+    c = Config()
+    c.OIDCOAuthenticator.allowed_users = {"user1"}
+    c.OIDCOAuthenticator.userdata_from_id_token = True
+    c.OIDCOAuthenticator.openid_provider_url = openid_provider_url
+    c.OIDCOAuthenticator.username_claim = "sub"
+    c.OIDCOAuthenticator.client_id = client_id
+    handled_user_model = user_model()
+    id_token_content = {
+        "aud": client_id,
+        "iss": openid_provider_url,
+    }
+    id_token_content.update(handled_user_model)
+    private_jwk = oidc_client.private_jwk
+    kid = oidc_client.jwks["keys"][0]["kid"]
+    if id_token_fields:
+        id_token_content.update(id_token_fields)
+        if "kid" in id_token_content:
+            # use a mismatched key
+            private_key = rsa.generate_private_key(
+                public_exponent=65537,
+                key_size=2048,
+            )
+            private_jwk = jwt.PyJWK(RSAAlgorithm.to_jwk(private_key, as_dict=True))
+
+    handled_user_model["id_token"] = jwt.encode(
+        id_token_content, key=private_jwk, algorithm="RS256", headers={"kid": kid}
+    )
+    handler = oidc_client.handler_for_user(handled_user_model)
+
+    authenticator = OIDCOAuthenticator(config=c)
+
+    def fetch_data():
+        return oidc_client.jwks
+
+    await authenticator._load_openid_configuration()
+    authenticator.jwks_client.fetch_data = fetch_data
+    if expect_success is True:
+        auth_model = await authenticator.get_authenticated_user(handler, None)
+        assert auth_model
+        assert "oauth_user" in auth_model["auth_state"]
+        assert auth_model["auth_state"]["oauth_user"] == id_token_content
+    elif expect_success == 'error':
+        with pytest.raises(web.HTTPError):
+            auth_model = await authenticator.get_authenticated_user(handler, None)
+    elif expect_success is False:
+        auth_model = await authenticator.get_authenticated_user(handler, None)
+        assert auth_model is None
+    else:
+        raise ValueError(f"{expect_success=}")

--- a/oauthenticator/tests/test_oidc.py
+++ b/oauthenticator/tests/test_oidc.py
@@ -2,8 +2,8 @@ import json
 
 import jwt
 import pytest
-from cryptography.hazmat.primitives import serialization
 from cryptography.hazmat.primitives.asymmetric import rsa
+from jwt.algorithms import RSAAlgorithm
 from pytest import fixture, mark, param
 from tornado import web
 from traitlets.config import Config
@@ -187,7 +187,7 @@ async def test_oidc_id_token(
         "iss": openid_provider_url,
     }
     id_token_content.update(handled_user_model)
-    private_key_bytes = oidc_client.private_key_bytes
+    private_jwk = oidc_client.private_jwk
     kid = oidc_client.jwks["keys"][0]["kid"]
     if id_token_fields:
         id_token_content.update(id_token_fields)
@@ -197,14 +197,10 @@ async def test_oidc_id_token(
                 public_exponent=65537,
                 key_size=2048,
             )
-            private_key_bytes = private_key.private_bytes(
-                encoding=serialization.Encoding.PEM,
-                format=serialization.PrivateFormat.PKCS8,
-                encryption_algorithm=serialization.NoEncryption(),
-            )
+            private_jwk = jwt.PyJWK(RSAAlgorithm.to_jwk(private_key, as_dict=True))
 
     handled_user_model["id_token"] = jwt.encode(
-        id_token_content, key=private_key_bytes, algorithm="RS256", headers={"kid": kid}
+        id_token_content, key=private_jwk, algorithm="RS256", headers={"kid": kid}
     )
     handler = oidc_client.handler_for_user(handled_user_model)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -71,6 +71,8 @@ local-google = "oauthenticator.google:LocalGoogleOAuthenticator"
 mediawiki = "oauthenticator.mediawiki:MWOAuthenticator"
 openshift = "oauthenticator.openshift:OpenShiftOAuthenticator"
 local-openshift = "oauthenticator.openshift:LocalOpenShiftOAuthenticator"
+oidc = "oauthenticator.oidc:OIDCOAuthenticator"
+local-oidc = "oauthenticator.oidc:LocalOIDCOAuthenticator"
 
 [project.urls]
 Homepage = "https://jupyter.org"

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@ jsonschema
 jupyterhub>=2.2
 # PyJWT is used for parsing id tokens
 # and azuread
-pyjwt>=2
+pyjwt>=2.7
 # requests is already required by JupyterHub, but explicitly ask for it since we use it
 requests
 # ruamel.yaml is used to read and write .yaml files.

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,8 +2,7 @@
 jsonschema
 jupyterhub>=2.2
 # PyJWT is used for parsing id tokens
-# and azuread
-pyjwt>=2.7
+pyjwt>=2.9
 # requests is already required by JupyterHub, but explicitly ask for it since we use it
 requests
 # ruamel.yaml is used to read and write .yaml files.

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@
 jsonschema
 jupyterhub>=2.2
 # PyJWT is used for parsing id tokens
-pyjwt>=2.9
+pyjwt>=2.10
 # requests is already required by JupyterHub, but explicitly ask for it since we use it
 requests
 # ruamel.yaml is used to read and write .yaml files.


### PR DESCRIPTION
generally only needs one configuration value: openid_provider_url

OIDCOAuthenticator is basically the same as base/generic OAuthenticator, but loads authorization/token/userinfo/jwks from openid configuration instead of requiring user config.

This adds jwks config options and jwt signature verification to the base class, but which remain disabled (unchanged) if unset.

closes #254

TODO:

- [x] more testing
- [x] docs
- [ ] consider basing several of our actually-OIDC Authenticator classes on this instead of the base (auth0, github, google, AzureAD))