### PR TITLE
[CILogon] support callable username_claim

### DIFF
--- a/oauthenticator/cilogon.py
+++ b/oauthenticator/cilogon.py
@@ -216,6 +216,13 @@ class CILogonOAuthenticator(OAuthenticator):
         .. versionchanged:: 15.0
 
            Changed format from a list to a dictionary.
+
+        .. versionchanged:: 17.5
+
+           `username_claim` can be a callable,
+           and top-level `CILogonOAuthenticator.username_claim` can be a callable,
+           restoring feature parity with base OAuthenticator.
+           The top-level `username_claim` callable will only be used when `username_derivation.username_claim` is not defined for a given identity provider.
         """,
     )
 
@@ -272,7 +279,6 @@ class CILogonOAuthenticator(OAuthenticator):
         "strip_idp_domain": ("idps", "15.0.0", False),
         "shown_idps": ("idps", "16.0.0", False),
         "additional_username_claims": ("idps", "16.0.0", False),
-        "username_claim": ("idps", "16.0.0", False),
         "allowed_idps": ("idps", "17.4.0", True),
         **OAuthenticator._deprecated_oauth_aliases,
     }
@@ -309,14 +315,6 @@ class CILogonOAuthenticator(OAuthenticator):
         """,
     )
     additional_username_claims = List(
-        config=True,
-        help="""
-        .. versionremoved:: 16.0
-
-           Use :attr:`idps`.
-        """,
-    )
-    username_claim = Unicode(
         config=True,
         help="""
         .. versionremoved:: 16.0
@@ -369,12 +367,26 @@ class CILogonOAuthenticator(OAuthenticator):
         """
         user_idp = user_info["idp"]
         username_derivation = self.idps[user_idp]["username_derivation"]
-        username_claim = username_derivation["username_claim"]
 
-        username = user_info.get(username_claim)
+        if "username_claim" in username_derivation:
+            username_claim = username_derivation["username_claim"]
+        else:
+            # only allow callable top-level username_claim
+            # can be shared across IdPs
+            if callable(self.username_claim):
+                username_claim = self.username_claim
+                return self.username_claim(user_info)
+            else:
+                msg = f"username_claim not configured for {user_idp}"
+                self.log.error(msg)
+                raise web.HTTPError(500, f"Configuration error in idp: {user_idp}")
+
+        if callable(username_claim):
+            username = username_claim(user_info)
+        else:
+            username = user_info.get(username_claim, None)
         if not username:
             message = f"Configured username_claim {username_claim} for {user_idp} was not found in the response {user_info.keys()}"
-            self.log.error(message)
             raise web.HTTPError(500, message)
 
         return username

--- a/oauthenticator/schemas/cilogon-schema.yaml
+++ b/oauthenticator/schemas/cilogon-schema.yaml
@@ -20,8 +20,6 @@ properties:
   username_derivation:
     type: object
     additionalProperties: false
-    required:
-      - username_claim
     properties:
       username_claim:
         type: string

--- a/oauthenticator/tests/test_cilogon.py
+++ b/oauthenticator/tests/test_cilogon.py
@@ -541,13 +541,6 @@ async def test_cilogon_idps(
             "CILogonOAuthenticator.shown_idps is deprecated in CILogonOAuthenticator 16.0.0, use CILogonOAuthenticator.idps instead",
         ),
         (
-            "username_claim",
-            {"username_claim": "dummy"},
-            {},
-            logging.ERROR,
-            "CILogonOAuthenticator.username_claim is deprecated in CILogonOAuthenticator 16.0.0, use CILogonOAuthenticator.idps instead",
-        ),
-        (
             "additional_username_claims",
             {"additional_username_claims": ["dummy"]},
             {},

--- a/oauthenticator/tests/test_cilogon.py
+++ b/oauthenticator/tests/test_cilogon.py
@@ -434,6 +434,35 @@ async def test_cilogon(
             False,
             None,
         ),
+        (
+            "callable username_claim",
+            {
+                "username_derivation": {
+                    "action": "prefix",
+                    "prefix": "some-prefix",
+                },
+            },
+            {
+                "allowed_users": ["some-prefix:xyz-user1@domain.org"],
+                "username_claim": lambda user_info: "xyz-" + user_info["email"],
+            },
+            "user1@domain.org",
+            True,
+            None,
+        ),
+        (
+            "callable username_claim, no derivation",
+            {
+                "username_derivation": {},
+            },
+            {
+                "allowed_users": ["xyz-user1@domain.org"],
+                "username_claim": lambda user_info: "xyz-" + user_info["email"],
+            },
+            "user1@domain.org",
+            True,
+            None,
+        ),
     ],
 )
 async def test_cilogon_idps(
@@ -454,7 +483,11 @@ async def test_cilogon_idps(
     }
     authenticator = CILogonOAuthenticator(config=c)
 
-    username_claim = idp_config["username_derivation"]["username_claim"]
+    if "username_claim" in idp_config["username_derivation"]:
+        username_claim = idp_config["username_derivation"]["username_claim"]
+    else:
+        assert "username_claim" in class_config
+        username_claim = "email"
     handled_user_model = user_model(test_user_name, username_claim, idp=test_idp)
     handler = cilogon_client.handler_for_user(handled_user_model)
     auth_model = await authenticator.get_authenticated_user(handler, None)


### PR DESCRIPTION
restores compatibility with base class by allowing a callable, both on the class level OAuthenticator.username_claim, and on the per-idp level.

idp-level username_claim has priority, so class-level username_claim is only used when idp.username_derivation.username_claim is _not_ defined.

closes #712 with by allowing callable `username_claim` but if we wanted a simple _declarative_ solution to orcid (e.g. strip url prefix analogous to strip idp domain), we could also do that separately if it's likely to be common enough.

Example orcid config:

```python
def orcid_username(user_info):
    assert user_info["idp"] == 'http://orcid.org/oauth/authorize'
    # Only modify usernames if orcid is used
    # oidc is of the form https://orcid.org/<orcid-id>
    return user_info['oidc'].split('/')[-1]

c.CILogonOAuthenticator.username_claim = orcid_username
c.CILogonOAuthenticator.idps = {
    'http://orcid.org/oauth/authorize': {
        'username_derivation': {
            # could set username_claim: callable here, too
            'action': 'prefix',
            'prefix': 'orcid',
    },
    'other': {
        'username_derivation': {
            'username_claim': 'sub', # username_claim callable not used
    },
}
```        
