### PR TITLE
GoogleOAuthenthicator now allows admin_users and allowed_users access.

### DIFF
--- a/oauthenticator/google.py
+++ b/oauthenticator/google.py
@@ -269,23 +269,25 @@ class GoogleOAuthenticator(OAuthenticator, GoogleOAuth2Mixin):
 
     def check_blocked_users(self, username, auth_model):
         """
-        Overrides `Authenticator.check_blocked_users` to not only block users in
-        `Authenticator.blocked_users`, but to also enforce
-        `GoogleOAuthenticator.hosted_domain` if its configured.
+        Overrides `Authenticator.check_blocked_users` to also enforce
+        `GoogleOAuthenticator.hosted_domain` if configured, except for users
+        individually named in `allowed_users` or `admin_users`.
 
-        When hosted_domain is configured, users are required to be part of
-        listed Google organizations/workspaces.
+        This has to live here rather than in `check_allowed` because the GoogleOAuthenticator
+        `allow_all` attribute bypasses `check_allowed` entirely, so
+        `check_blocked_users` is the only place that can
+        restrict `hosted_domain` membership when `allow_all` is True.
 
-        Returns False if the user is blocked, otherwise True.
+        Returns False if the user is blocked or the hd is not in the hosted_domain list or the username is 
+        not in `allowed_users` or `admin_users`, otherwise returns True
         """
-        user_info = auth_model["auth_state"][self.user_auth_state_key]
-
-        # hd ref: https://developers.google.com/identity/openid-connect/openid-connect#id_token-hd
-        hd = user_info.get("hd", "")
-
-        if self.hosted_domain and hd not in self.hosted_domain:
-            self.log.warning(f"Blocked {username} with 'hd={hd}' not in hosted_domain")
-            return False
+        if self.hosted_domain and not (username in self.allowed_users or username in self.admin_users):
+            user_info = auth_model["auth_state"][self.user_auth_state_key]
+            # hd ref: https://developers.google.com/identity/openid-connect/openid-connect#id_token-hd
+            hd = user_info.get("hd", "")
+            if hd not in self.hosted_domain:
+                self.log.warning(f"Blocked {username} with 'hd={hd}' not in hosted_domain")
+                return False
 
         return super().check_blocked_users(username, auth_model)
 

--- a/oauthenticator/google.py
+++ b/oauthenticator/google.py
@@ -278,15 +278,19 @@ class GoogleOAuthenticator(OAuthenticator, GoogleOAuth2Mixin):
         `check_blocked_users` is the only place that can
         restrict `hosted_domain` membership when `allow_all` is True.
 
-        Returns False if the user is blocked or the hd is not in the hosted_domain list or the username is 
+        Returns False if the user is blocked or the hd is not in the hosted_domain list or the username is
         not in `allowed_users` or `admin_users`, otherwise returns True
         """
-        if self.hosted_domain and not (username in self.allowed_users or username in self.admin_users):
+        if self.hosted_domain and not (
+            username in self.allowed_users or username in self.admin_users
+        ):
             user_info = auth_model["auth_state"][self.user_auth_state_key]
             # hd ref: https://developers.google.com/identity/openid-connect/openid-connect#id_token-hd
             hd = user_info.get("hd", "")
             if hd not in self.hosted_domain:
-                self.log.warning(f"Blocked {username} with 'hd={hd}' not in hosted_domain")
+                self.log.warning(
+                    f"Blocked {username} with 'hd={hd}' not in hosted_domain"
+                )
                 return False
 
         return super().check_blocked_users(username, auth_model)

--- a/oauthenticator/tests/test_google.py
+++ b/oauthenticator/tests/test_google.py
@@ -240,11 +240,16 @@ async def test_google(
         ("01", "user1@ok-hd.orG", "ok-hd.org", "user1", True, True),
         ("02", "user2@ok-hd.orG", "ok-hd.org", "user2", True, None),
         ("03", "blocked@ok-hd.org", "ok-hd.org", None, False, None),
-        ("04", "user2@ok-hd.org", "", None, False, None),
+        # user2 is explicitly in allowed_users, so they're exempted from the
+        # hosted_domain restriction even without a matching (or any) hd
+        ("04", "user2@ok-hd.org", "", "user2", True, None),
         ("05", "user1@not-ok.org", "", None, False, None),
         # Test variation 06 below isn't believed to be possible, but since we
         # aren't sure this test clarifies what we expect to happen.
         ("06", "user1@other.org", "ok-hd.org", "user1@other.org", True, None),
+        # user1 is explicitly in admin_users, so they're exempted from the
+        # hosted_domain restriction even without a matching (or any) hd
+        ("07", "user1@ok-hd.org", "", "user1", True, True),
     ],
 )
 async def test_hosted_domain_single_entry(


### PR DESCRIPTION
Prior to this change, GoogleOAuthenticator did not allow admin_users and allowed_users to log in if they weren't part of hosted_domain list, even though they could otherwise successfully authenticate with Google.

The problem is two-fold.

First, we are forced to check the hosted_domain list in the funciton check_blocked_users but that function returns False as soon as it finds that the user is not in the hosted_domain list.

This means that if a user is not in the hosted_domain list, they will be blocked even if they are in the admin_users or allowed_users list.

Second, we can not check for the hosted_domain by overriding check_allowed becuase if the allow_all attribute is set on the authenticator the parent class will not call check_allowed!

You can see it [here] (https://github.com/jupyterhub/jupyterhub/blob/main/jupyterhub/auth.py#L727)

This change fixes the problem by checking for admin_users and allowed_users in the overriden check_blocked_users function of google.py before checking for hosted_domain.