### PR TITLE
Added allowed_hosted_domains to GoogleOAuthenticator

### DIFF
--- a/oauthenticator/google.py
+++ b/oauthenticator/google.py
@@ -161,7 +161,7 @@ class GoogleOAuthenticator(OAuthenticator, GoogleOAuth2Mixin):
            stripped to exclude the `@domain` part.
 
         Users not restricted by this configuration must still be explicitly
-        allowed by a configuration intended to allow users, like `allow_all`
+        allowed by a configuration intended to allow users, like `allow_all`,
         `allowed_users`, `allowed_hosted_domains`, or `allowed_google_groups`.
 
         .. warning::

--- a/oauthenticator/google.py
+++ b/oauthenticator/google.py
@@ -245,7 +245,7 @@ class GoogleOAuthenticator(OAuthenticator, GoogleOAuth2Mixin):
                 "as allow_all already grants access to everyone."
             )
         return proposal.value
-  
+
     # _deprecated_oauth_aliases is used by deprecation logic in OAuthenticator
     _deprecated_oauth_aliases = {
         "google_group_whitelist": ("allowed_google_groups", "0.12.0"),

--- a/oauthenticator/google.py
+++ b/oauthenticator/google.py
@@ -7,7 +7,7 @@ import os
 from jupyterhub.auth import LocalAuthenticator
 from tornado.auth import GoogleOAuth2Mixin
 from tornado.web import HTTPError
-from traitlets import Bool, Dict, List, Set, Unicode, default, validate
+from traitlets import Bool, Dict, List, Set, TraitError, Unicode, default, validate
 
 from .oauth2 import OAuthenticator
 
@@ -161,8 +161,11 @@ class GoogleOAuthenticator(OAuthenticator, GoogleOAuth2Mixin):
            stripped to exclude the `@domain` part.
 
         Users not restricted by this configuration must still be explicitly
-        allowed by a configuration intended to allow users, like `allow_all`,
-        `allowed_users`, or `allowed_google_groups`.
+        allowed by a configuration intended to allow users, like
+        `allowed_users`, `allowed_hosted_domains`, or `allowed_google_groups`.
+
+        Cannot be combined with `allow_all`, since `allow_all` already grants
+        access to everyone, making this restriction unenforceable.
 
         .. warning::
 
@@ -195,10 +198,54 @@ class GoogleOAuthenticator(OAuthenticator, GoogleOAuth2Mixin):
             # set it to a single item list
             # (or if it's empty, an empty list)
             if proposal.value == '':
-                return []
-            return [proposal.value.lower()]
+                domains = []
+            else:
+                domains = [proposal.value.lower()]
+        else:
+            domains = [hd.lower() for hd in proposal.value]
+
+        if domains and self.allow_all:
+            raise TraitError(
+                "GoogleOAuthenticator.hosted_domain can't be used together with "
+                "GoogleOAuthenticator.allow_all, as allow_all already grants access to everyone."
+            )
+        return domains
+
+    allowed_hosted_domains = List(
+        Unicode(),
+        config=True,
+        help="""
+        Grant access to any user whose Google `hd` claim matches the one of the
+        domains listed.
+
+        Unlike `hosted_domain`, this does not restrict or block anyone on its
+        own. It's purely an additional way to grant access, checked
+        alongside `allowed_users`, `admin_users`, and `allowed_google_groups`.
+
+        Cannot be combined with `allow_all`, since `allow_all` already grants
+        access to everyone, making this configuration meaningless.
+        """,
+    )
+
+    @validate('allowed_hosted_domains')
+    def _check_allowed_hosted_domains(self, proposal):
+        if proposal.value and self.allow_all:
+            raise TraitError(
+                "GoogleOAuthenticator.allowed_hosted_domains can't be used together with "
+                "GoogleOAuthenticator.allow_all, as allow_all already grants access to everyone."
+            )
         return [hd.lower() for hd in proposal.value]
 
+    @validate('allow_all')
+    def _check_allow_all(self, proposal):
+        if proposal.value and (self.allowed_hosted_domains or self.hosted_domain):
+            raise TraitError(
+                "GoogleOAuthenticator.allow_all can't be used together with "
+                "GoogleOAuthenticator.allowed_hosted_domains or GoogleOAuthenticator.hosted_domain, "
+                "as allow_all already grants access to everyone."
+            )
+        return proposal.value
+  
     # _deprecated_oauth_aliases is used by deprecation logic in OAuthenticator
     _deprecated_oauth_aliases = {
         "google_group_whitelist": ("allowed_google_groups", "0.12.0"),
@@ -269,14 +316,10 @@ class GoogleOAuthenticator(OAuthenticator, GoogleOAuth2Mixin):
 
     def check_blocked_users(self, username, auth_model):
         """
-        Overrides `Authenticator.check_blocked_users` to not only block users in
-        `Authenticator.blocked_users`, but to also enforce
-        `GoogleOAuthenticator.hosted_domain` if its configured.
+        Overrides `Authenticator.check_blocked_users` to also enforce
+        `GoogleOAuthenticator.hosted_domain` if configured
 
-        When hosted_domain is configured, users are required to be part of
-        listed Google organizations/workspaces.
-
-        Returns False if the user is blocked, otherwise True.
+        Returns False if the user is blocked or the hd is not in the hosted_domain list, otherwise returns True
         """
         user_info = auth_model["auth_state"][self.user_auth_state_key]
 
@@ -292,7 +335,7 @@ class GoogleOAuthenticator(OAuthenticator, GoogleOAuth2Mixin):
     async def check_allowed(self, username, auth_model):
         """
         Overrides the OAuthenticator.check_allowed to also allow users part of
-        `allowed_google_groups`.
+        `allowed_hosted_domains` or `allowed_google_groups`.
         """
         # A workaround for JupyterHub < 5.0 described in
         # https://github.com/jupyterhub/oauthenticator/issues/621
@@ -313,6 +356,13 @@ class GoogleOAuthenticator(OAuthenticator, GoogleOAuth2Mixin):
 
         if await super().check_allowed(username, auth_model):
             return True
+
+        # allow users whose hd is in allowed_hosted_domains
+        # hd ref: https://developers.google.com/identity/openid-connect/openid-connect#id_token-hd
+        if self.allowed_hosted_domains:
+            hd = user_info.get("hd", "")
+            if hd in self.allowed_hosted_domains:
+                return True
 
         if self.allowed_google_groups:
             user_groups = set(user_info["google_groups"])

--- a/oauthenticator/google.py
+++ b/oauthenticator/google.py
@@ -288,8 +288,12 @@ class GoogleOAuthenticator(OAuthenticator, GoogleOAuth2Mixin):
 
     def check_blocked_users(self, username, auth_model):
         """
-        Overrides `Authenticator.check_blocked_users` to also enforce
-        `GoogleOAuthenticator.hosted_domain` if configured
+        Overrides `Authenticator.check_blocked_users` to not only block users in
+        `Authenticator.blocked_users`, but to also enforce
+        `GoogleOAuthenticator.hosted_domain` if its configured.
+
+        When hosted_domain is configured, users are required to be part of
+        listed Google organizations/workspaces.
 
         Returns False if the user is blocked or the hd is not in the hosted_domain list, otherwise returns True
         """

--- a/oauthenticator/google.py
+++ b/oauthenticator/google.py
@@ -164,9 +164,6 @@ class GoogleOAuthenticator(OAuthenticator, GoogleOAuth2Mixin):
         allowed by a configuration intended to allow users, like
         `allowed_users`, `allowed_hosted_domains`, or `allowed_google_groups`.
 
-        Cannot be combined with `allow_all`, since `allow_all` already grants
-        access to everyone, making this restriction unenforceable.
-
         .. warning::
 
            Changing this config either to or from having a single entry is a
@@ -198,18 +195,9 @@ class GoogleOAuthenticator(OAuthenticator, GoogleOAuth2Mixin):
             # set it to a single item list
             # (or if it's empty, an empty list)
             if proposal.value == '':
-                domains = []
-            else:
-                domains = [proposal.value.lower()]
-        else:
-            domains = [hd.lower() for hd in proposal.value]
-
-        if domains and self.allow_all:
-            raise TraitError(
-                "GoogleOAuthenticator.hosted_domain can't be used together with "
-                "GoogleOAuthenticator.allow_all, as allow_all already grants access to everyone."
-            )
-        return domains
+                return []
+            return [proposal.value.lower()]
+        return [hd.lower() for hd in proposal.value]
 
     allowed_hosted_domains = List(
         Unicode(),
@@ -238,10 +226,10 @@ class GoogleOAuthenticator(OAuthenticator, GoogleOAuth2Mixin):
 
     @validate('allow_all')
     def _check_allow_all(self, proposal):
-        if proposal.value and (self.allowed_hosted_domains or self.hosted_domain):
+        if proposal.value and self.allowed_hosted_domains:
             raise TraitError(
                 "GoogleOAuthenticator.allow_all can't be used together with "
-                "GoogleOAuthenticator.allowed_hosted_domains or GoogleOAuthenticator.hosted_domain, "
+                "GoogleOAuthenticator.allowed_hosted_domains, "
                 "as allow_all already grants access to everyone."
             )
         return proposal.value

--- a/oauthenticator/google.py
+++ b/oauthenticator/google.py
@@ -7,7 +7,7 @@ import os
 from jupyterhub.auth import LocalAuthenticator
 from tornado.auth import GoogleOAuth2Mixin
 from tornado.web import HTTPError
-from traitlets import Bool, Dict, List, Set, TraitError, Unicode, default, validate
+from traitlets import Bool, Dict, List, Set, Unicode, default, validate
 
 from .oauth2 import OAuthenticator
 
@@ -210,29 +210,13 @@ class GoogleOAuthenticator(OAuthenticator, GoogleOAuth2Mixin):
         own. It's purely an additional way to grant access, checked
         alongside `allowed_users`, `admin_users`, and `allowed_google_groups`.
 
-        Cannot be combined with `allow_all`, since `allow_all` already grants
-        access to everyone, making this configuration meaningless.
+        .. versionadded:: 17.5
         """,
     )
 
     @validate('allowed_hosted_domains')
-    def _check_allowed_hosted_domains(self, proposal):
-        if proposal.value and self.allow_all:
-            raise TraitError(
-                "GoogleOAuthenticator.allowed_hosted_domains can't be used together with "
-                "GoogleOAuthenticator.allow_all, as allow_all already grants access to everyone."
-            )
+    def _cast_allowed_hosted_domains(self, proposal):
         return [hd.lower() for hd in proposal.value]
-
-    @validate('allow_all')
-    def _check_allow_all(self, proposal):
-        if proposal.value and self.allowed_hosted_domains:
-            raise TraitError(
-                "GoogleOAuthenticator.allow_all can't be used together with "
-                "GoogleOAuthenticator.allowed_hosted_domains, "
-                "as allow_all already grants access to everyone."
-            )
-        return proposal.value
 
     # _deprecated_oauth_aliases is used by deprecation logic in OAuthenticator
     _deprecated_oauth_aliases = {

--- a/oauthenticator/google.py
+++ b/oauthenticator/google.py
@@ -161,7 +161,7 @@ class GoogleOAuthenticator(OAuthenticator, GoogleOAuth2Mixin):
            stripped to exclude the `@domain` part.
 
         Users not restricted by this configuration must still be explicitly
-        allowed by a configuration intended to allow users, like
+        allowed by a configuration intended to allow users, like `allow_all`
         `allowed_users`, `allowed_hosted_domains`, or `allowed_google_groups`.
 
         .. warning::

--- a/oauthenticator/tests/test_google.py
+++ b/oauthenticator/tests/test_google.py
@@ -6,7 +6,6 @@ from unittest import mock
 from unittest.mock import AsyncMock
 
 from pytest import fixture, mark, raises
-from traitlets import TraitError
 from traitlets.config import Config
 
 from ..google import GoogleOAuthenticator
@@ -377,20 +376,6 @@ async def test_allowed_hosted_domains(
         assert auth_model
     else:
         assert auth_model is None
-
-
-def test_allowed_hosted_domains_conflicts_with_allow_all():
-    """
-    `allowed_hosted_domains` can't be combined with `allow_all`, regardless
-    of which one is set second.
-    """
-    authenticator = GoogleOAuthenticator(allow_all=True)
-    with raises(TraitError):
-        authenticator.allowed_hosted_domains = ["ok.org"]
-
-    authenticator = GoogleOAuthenticator(allowed_hosted_domains=["ok.org"])
-    with raises(TraitError):
-        authenticator.allow_all = True
 
 
 @mark.parametrize(

--- a/oauthenticator/tests/test_google.py
+++ b/oauthenticator/tests/test_google.py
@@ -332,6 +332,7 @@ async def test_hosted_domain_multiple_entries(
     ]
 
     c.GoogleOAuthenticator.blocked_users = ["blocked@ok-hd1.org"]
+    c.GoogleOAuthenticator.allow_all = True
     authenticator = GoogleOAuthenticator(config=c)
 
     handled_user_model = user_model(user_email, hd=user_hd)

--- a/oauthenticator/tests/test_google.py
+++ b/oauthenticator/tests/test_google.py
@@ -379,17 +379,16 @@ async def test_allowed_hosted_domains(
         assert auth_model is None
 
 
-@mark.parametrize("trait_name", ["hosted_domain", "allowed_hosted_domains"])
-def test_hosted_domain_traits_conflict_with_allow_all(trait_name):
+def test_allowed_hosted_domains_conflicts_with_allow_all():
     """
-    `hosted_domain` and `allowed_hosted_domains` can't be combined with
-    `allow_all`, regardless of which one is set second.
+    `allowed_hosted_domains` can't be combined with `allow_all`, regardless
+    of which one is set second.
     """
     authenticator = GoogleOAuthenticator(allow_all=True)
     with raises(TraitError):
-        setattr(authenticator, trait_name, ["ok.org"])
+        authenticator.allowed_hosted_domains = ["ok.org"]
 
-    authenticator = GoogleOAuthenticator(**{trait_name: ["ok.org"]})
+    authenticator = GoogleOAuthenticator(allowed_hosted_domains=["ok.org"])
     with raises(TraitError):
         authenticator.allow_all = True
 

--- a/oauthenticator/tests/test_google.py
+++ b/oauthenticator/tests/test_google.py
@@ -6,6 +6,7 @@ from unittest import mock
 from unittest.mock import AsyncMock
 
 from pytest import fixture, mark, raises
+from traitlets import TraitError
 from traitlets.config import Config
 
 from ..google import GoogleOAuthenticator
@@ -325,8 +326,13 @@ async def test_hosted_domain_multiple_entries(
         "ok-hd1.org",
         "ok-hd2.ORG",
     ]
+
+    c.GoogleOAuthenticator.allowed_hosted_domains = [
+        "ok-hd1.org",
+        "ok-hd2.ORG",
+    ]
+
     c.GoogleOAuthenticator.blocked_users = ["blocked@ok-hd1.org"]
-    c.GoogleOAuthenticator.allow_all = True
     authenticator = GoogleOAuthenticator(config=c)
 
     handled_user_model = user_model(user_email, hd=user_hd)
@@ -337,6 +343,55 @@ async def test_hosted_domain_multiple_entries(
         assert auth_model["name"] == expect_username
     else:
         assert auth_model == None
+
+
+@mark.parametrize(
+    "test_variation_id,user_hd,class_config,expect_allowed",
+    [
+        ("01", "ok.org", {}, True),
+        ("02", "not-ok.org", {}, False),
+        ("03", None, {}, False),
+        # admin_users/allowed_users still grant access on their own, even
+        # when allowed_hosted_domains is configured and the hd doesn't match
+        ("04", "not-ok.org", {"admin_users": {"user1@example.com"}}, True),
+        ("05", "not-ok.org", {"allowed_users": {"user1@example.com"}}, True),
+    ],
+)
+async def test_allowed_hosted_domains(
+    google_client, test_variation_id, user_hd, class_config, expect_allowed
+):
+    """
+    Tests that `allowed_hosted_domains` grants access based on a matching
+    `hd`, without restricting/blocking anyone by itself: admin_users and
+    allowed_users still work normally even when the hd doesn't match.
+    """
+    c = Config()
+    c.GoogleOAuthenticator = Config(class_config)
+    c.GoogleOAuthenticator.allowed_hosted_domains = ["ok.org"]
+    authenticator = GoogleOAuthenticator(config=c)
+
+    handled_user_model = user_model("user1@example.com", "user1", hd=user_hd)
+    handler = google_client.handler_for_user(handled_user_model)
+    auth_model = await authenticator.get_authenticated_user(handler, None)
+    if expect_allowed:
+        assert auth_model
+    else:
+        assert auth_model is None
+
+
+@mark.parametrize("trait_name", ["hosted_domain", "allowed_hosted_domains"])
+def test_hosted_domain_traits_conflict_with_allow_all(trait_name):
+    """
+    `hosted_domain` and `allowed_hosted_domains` can't be combined with
+    `allow_all`, regardless of which one is set second.
+    """
+    authenticator = GoogleOAuthenticator(allow_all=True)
+    with raises(TraitError):
+        setattr(authenticator, trait_name, ["ok.org"])
+
+    authenticator = GoogleOAuthenticator(**{trait_name: ["ok.org"]})
+    with raises(TraitError):
+        authenticator.allow_all = True
 
 
 @mark.parametrize(


### PR DESCRIPTION
Adds `allowed_hosted_domains` config to allow a list of Google-hosted domains to authenticate to the hub while also honoring `allowed_users`, `admin_users` and `allowed_google_groups`. Note: The domains in `allowed_users` and `admin_users` are not required to be in the `allowed_hosted_domains` list, but of course, must be valid Google accounts.